### PR TITLE
Correct file version no. in VC110 sln files 

### DIFF
--- a/contrib/extractor/VC110_AD.sln
+++ b/contrib/extractor/VC110_AD.sln
@@ -1,5 +1,5 @@
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ad", "VC110_ad.vcxproj", "{D7552D4F-408F-4F8E-859B-366659150CF4}"
 EndProject
 Global

--- a/contrib/mmap/win/MoveMapGen_VC110.sln
+++ b/contrib/mmap/win/MoveMapGen_VC110.sln
@@ -1,6 +1,5 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MoveMapGen", "VC110\MoveMapGen_VC110.vcxproj", "{8028C1F8-4C3E-44D4-96D7-1D6F51B7AB47}"
 	ProjectSection(ProjectDependencies) = postProject
 		{8F1DEA42-6A5B-4B62-839D-C141A7BFACF2} = {8F1DEA42-6A5B-4B62-839D-C141A7BFACF2}

--- a/contrib/vmap_assembler/vmap_assemblerVC110.sln
+++ b/contrib/vmap_assembler/vmap_assemblerVC110.sln
@@ -1,5 +1,5 @@
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "vmap_assembler", "VC110\vmap_assembler.vcxproj", "{572FFF74-480C-4472-8ABF-81733BB4049D}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zlib", "..\..\win\VC110\zlib.vcxproj", "{8F1DEA42-6A5B-4B62-839D-C141A7BFACF2}"

--- a/contrib/vmap_extractor/win/vmapExtractor_VC110.sln
+++ b/contrib/vmap_extractor/win/vmapExtractor_VC110.sln
@@ -1,5 +1,5 @@
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "vmapExtractor", "VC110\vmapExtractor.vcxproj", "{D4624B20-AC1E-4EE9-8C9C-0FB65EEE3393}"
 	ProjectSection(ProjectDependencies) = postProject
 		{B96F612A-C91D-43B3-A4C3-D4294817EC6C} = {B96F612A-C91D-43B3-A4C3-D4294817EC6C}

--- a/dep/libmpq/win/libmpq_VC110.sln
+++ b/dep/libmpq/win/libmpq_VC110.sln
@@ -1,5 +1,5 @@
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libmpq", "VC110\libmpq.vcxproj", "{03AB0F44-628E-4855-99A0-C98A1EB52C50}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zlib", "..\..\..\win\VC110\zlib.vcxproj", "{8F1DEA42-6A5B-4B62-839D-C141A7BFACF2}"

--- a/dep/recastnavigation/Detour/win/Detour_VC110.sln
+++ b/dep/recastnavigation/Detour/win/Detour_VC110.sln
@@ -1,6 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Detour", "VC110\Detour.vcxproj", "{72BDF975-4D4A-42C7-B2C4-F9ED90A2ABB6}"
 EndProject
 Global

--- a/dep/recastnavigation/Recast/win/Recast_VC110.sln
+++ b/dep/recastnavigation/Recast/win/Recast_VC110.sln
@@ -1,6 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Recast", "VC110\Recast.vcxproj", "{00B9DC66-96A6-465D-A6C1-5DFF94E48A64}"
 EndProject
 Global

--- a/win/mangosdVC110.sln
+++ b/win/mangosdVC110.sln
@@ -1,5 +1,5 @@
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "game", "VC110\game.vcxproj", "{1DC6C4DA-A028-41F3-877D-D5400C594F88}"
 	ProjectSection(ProjectDependencies) = postProject
 		{90297C34-F231-4DF4-848E-A74BCC0E40ED} = {90297C34-F231-4DF4-848E-A74BCC0E40ED}


### PR DESCRIPTION
Correct the File Version numbers in VC110 solution files so that VS2012
opens correctly on systems that have both VS2010 and VS2012 installed.
