### PR TITLE
Support 1.12.3 (build 6141)

### DIFF
--- a/src/game/SharedDefines.h
+++ b/src/game/SharedDefines.h
@@ -2476,9 +2476,9 @@ enum TrackedAuraType
 
 // we need to stick to 1 version or half of the stuff will work for someone
 // others will not and opposite
-// will only support 1.12.1 client (build 5875) and 1.12.2 client (build 6005)..
+// will only support 1.12.1 client (build 5875) and 1.12.2 client (build 6005) and 1.12.3 client (build 6141) ..
 
-#define EXPECTED_MANGOSD_CLIENT_BUILD        {5875,6005, 0}
+#define EXPECTED_MANGOSD_CLIENT_BUILD        {5875, 6005, 6141, 0}
 
 // Maxlevel for expansion
 #define MAX_LEVEL_CLASSIC                    60

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -283,6 +283,7 @@ void AuthSocket::SendProof(Sha1Hash sha)
     {
         case 5875:                                          // 1.12.1
         case 6005:                                          // 1.12.2
+        case 6141:                                          // 1.12.3
         {
             sAuthLogonProof_S_BUILD_6005 proof;
             memcpy(proof.M2, sha.GetDigest(), 20);
@@ -894,6 +895,7 @@ void AuthSocket::LoadRealmlist(ByteBuffer& pkt, uint32 acctid)
     {
         case 5875:                                          // 1.12.1
         case 6005:                                          // 1.12.2
+        case 6141:                                          // 1.12.3
         {
             pkt << uint32(0);                               // unused value
             pkt << uint8(sRealmList.size());

--- a/src/realmd/RealmList.cpp
+++ b/src/realmd/RealmList.cpp
@@ -31,7 +31,7 @@ INSTANTIATE_SINGLETON_1(RealmList);
 
 extern DatabaseType LoginDatabase;
 
-// will only support WoW 1.12.1/1.12.2 , WoW:TBC 2.4.3 and official release for WoW:WotLK and later, client builds 10505, 8606, 6005, 5875
+// will only support WoW 1.12.1/1.12.2/1.12.3 , WoW:TBC 2.4.3 and official release for WoW:WotLK and later, client builds 10505, 8606, 6141, 6005, 5875
 // if you need more from old build then add it in cases in realmd sources code
 // list sorted from high to low build and first build used as low bound for accepted by default range (any > it will accepted by realmd at least)
 
@@ -43,6 +43,7 @@ static RealmBuildInfo ExpectedRealmdClientBuilds[] =
     {11159, 3, 3, 0, 'a'},
     {10505, 3, 2, 2, 'a'},
     {8606,  2, 4, 3, ' '},
+    {6141,  1, 12, 3, ' '},
     {6005,  1, 12, 2, ' '},
     {5875,  1, 12, 1, ' '},
     {0,     0, 0, 0, ' '}                                   // terminator


### PR DESCRIPTION
At 2006/11/14 , Blizzard and The9 released 1.12.3.6141 client in China, I already pulled the 1.12.3 (build 6141) support to http://github.com/mangoszero, please view details here: https://github.com/mangoszero/server/pull/13 , would you please merge the change to https://github.com/cmangos/mangos-classic ?

I also uploaded the 1.12.3.6141 version of wow.exe to skydrive: http://sdrv.ms/Wp9IgF , hope it will be useful

Thank you : )
