### PR TITLE
Fix HP change in bear forms

### DIFF
--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -3441,6 +3441,15 @@ void Aura::HandleAuraModIncreaseHealth(bool apply, bool Real)
     {
         case 1178:                                          // Bear Form (Passive)
         case 9635:                                          // Dire Bear Form (Passive)
+        {
+            if(Real)
+            {
+                float pct = target->GetHealthPercent();
+                target->HandleStatModifier(UNIT_MOD_HEALTH, TOTAL_VALUE, float(m_modifier.m_amount), apply);
+                target->SetHealthPercent(pct);
+            }
+            return;
+        }
         case 12976:                                         // Warrior Last Stand triggered spell
         {
             if (Real)


### PR DESCRIPTION
Allow druids to keep the same currentHP/maxHP ratio when switching forms between humanoid and bear

This commit [e0a0426](http://github.com/mangos-zero/server-old/commit/e0a0426) is one of those pending backports from old mangos-zero concatenated in: https://github.com/cmangos/issues/wiki/classic_backporting-todo-zero-commits

I tested it and this is my:

> Shapeshifting into bear form, druids do not keep the same percentage of HP with current core revision. This commit fixes it by keeping constant currentHP/maxHP ratio.
