### PR TITLE
Fix Beastslayer Damage Bonus

### DIFF
--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -5461,7 +5461,7 @@ uint32 Unit::SpellDamageBonusDone(Unit* pVictim, SpellEntry const* spellProto, u
     for (AuraList::const_iterator i = mDamageDoneCreature.begin(); i != mDamageDoneCreature.end(); ++i)
     {
         if (creatureTypeMask & uint32((*i)->GetModifier()->m_miscvalue))
-            DoneTotalMod += ((*i)->GetModifier()->m_amount + 100.0f) / 100.0f;
+            DoneTotal += ((*i)->GetModifier()->m_amount);
     }
 
     // done scripted mod (take it from owner)


### PR DESCRIPTION
Original patch by Zataron from old mangos community forums

This commit [e45f908](http://github.com/mangos-zero/server-old/commit/e45f908) is one of those pending backports from old mangos-zero concatenated in: https://github.com/cmangos/issues/wiki/classic_backporting-todo-zero-commits

I tested it and this is my:

> Tested: without this commit damages on beasts with a weapon are the same with or without the beastslayer enchantment. This commit fixes it by adding the right amount of bonus damage.
