### PR TITLE
Fix possible stacking exploit of combustion

### DIFF
--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -5145,6 +5145,22 @@ void SpellAuraHolder::HandleSpellSpecificBoosts(bool apply)
         {
             switch (GetId())
             {
+                case 11129:                                 // Combustion (remove triggered aura stack)
+                {
+                    if(!apply)
+                        spellId1 = 28682;
+                    else
+                        return;
+                    break;
+                }
+                case 28682:                                 // Combustion (remove main aura)
+                {
+                    if(!apply)
+                        spellId1 = 11129;
+                    else
+                        return;
+                    break;
+                }
                 case 11189:                                 // Frost Warding
                 case 28332:
                 {


### PR DESCRIPTION
Prevent keeping mage talent combustion aura and triggered aura when unlearning talents

This commit [4d68c37](http://github.com/mangos-zero/server-old/commit/4d68c37) is one of those pending backports from old mangos-zero concatenated in: https://github.com/cmangos/issues/wiki/classic_backporting-todo-zero-commits

I tested it and this is my report:

> without this fix it is possible to take advantage of the unlearn mechanics to use combustion aura even after unlearning the talent. This commit fixes it.
