### PR TITLE
Fix glancing blows formula for classic

### DIFF
--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -2216,7 +2216,7 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(const Unit* pVictim, WeaponAttackT
         int32 maxskill = attackerMaxSkillValueForLevel;
         skill = (skill > maxskill) ? maxskill : skill;
 
-        tmp = (10 + (victimDefenseSkill - skill)) * 100;
+        tmp = (10 + 2 * (victimDefenseSkill - skill)) * 100;
         tmp = tmp > 4000 ? 4000 : tmp;
         if (roll < (sum += tmp))
         {


### PR DESCRIPTION
In classic a difference in skill points should reward an extra 2% chance of getting a glancing blow.

source: http://www.wowwiki.com/Glancing_blow#Glancing_Blow_chance

This commit [c041d59](http://github.com/mangos-zero/server-old/commit/c041d59) is one of those pending backports from old mangos-zero concatenated in: https://github.com/cmangos/issues/wiki/classic_backporting-todo-zero-commits

I tested it and this is my report:

> See source: http://www.wowwiki.com/Glancing_blow#Glancing_Blow_chance
