### PR TITLE
Fix item 23197 (idol of the moon)

### DIFF
--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -5472,13 +5472,18 @@ uint32 Unit::SpellDamageBonusDone(Unit* pVictim, SpellEntry const* spellProto, u
     {
         if (!(*i)->isAffectedOnSpell(spellProto))
             continue;
+            
         switch ((*i)->GetModifier()->m_miscvalue)
         {
             case 4418: // Increased Shock Damage
             case 4554: // Increased Lightning Damage
-            case 4555: // Improved Moonfire
             {
                 DoneTotal += (*i)->GetModifier()->m_amount;
+                break;
+            }
+            case 4555: // Improved Moonfire
+            {
+                DoneTotalMod *= ((*i)->GetModifier()->m_amount + 100.0f) / 100.0f;
                 break;
             }
         }


### PR DESCRIPTION
Fix bonus provided by druid item 23197 which was insanely high.

This commit [b2d8643](http://github.com/mangos-zero/server-old/commit/b2d8643) is one of those pending backports from old mangos-zero concatenated in: https://github.com/cmangos/issues/wiki/classic_backporting-todo-zero-commits

I tested it and this is my report:

> Without this commit, druids with item 23197 deals to much damage with moonfire spells. This commit fixes this.
