### PR TITLE
Fix rogue talent Improved Sprint

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -2064,6 +2064,9 @@ bool SpellMgr::IsNoStackSpellDueToSpell(uint32 spellId_1, uint32 spellId_2) cons
             // Garrote -> Garrote-Silence (multi-family check)
             if (spellInfo_1->SpellIconID == 498 && spellInfo_2->SpellIconID == 498 && spellInfo_2->SpellVisual == 0)
                 return false;
+            // Improved Sprint && Sprint
+            if (spellInfo_1->SpellIconID == 516 && spellInfo_2->SpellIconID == 516)
+                return false;
             break;
         case SPELLFAMILY_HUNTER:
             if (spellInfo_2->SpellFamilyName == SPELLFAMILY_HUNTER)


### PR DESCRIPTION
Fix rogue sprint no longer working when talent Improved Sprint was active


This commit [482ca12](http://github.com/mangos-zero/server-old/commit/482ca12) is one of those pending backports from old mangos-zero concatenated in: https://github.com/cmangos/issues/wiki/classic_backporting-todo-zero-commits

I tested it and this is my report:
> Improved sprint is indeed broken as it prevent sprint from working. This commit fixes it.