### PR TITLE
Fix speed modifiers for spells Permafrost, Improved Curse of Exhaustion,...

### DIFF
--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -737,6 +737,35 @@ void Aura::HandleAddModifier(bool apply, bool Real)
                 GetHolder()->SetAuraCharges(1);
                 break;
         }
+        
+        // In pre-TBC wrong spellmods in DBC
+        switch (GetSpellProto()->SpellIconID)
+        {
+            case 143:       // Permafrost Speed Decrease
+                if (GetEffIndex() == EFFECT_INDEX_1)
+                    m_modifier.m_miscvalue = SPELLMOD_EFFECT1;
+                break;
+            case 228:       // Improved Curse of Exhaustion Speed Decrease
+                if (GetEffIndex() == EFFECT_INDEX_0)
+                    m_modifier.m_miscvalue = SPELLMOD_EFFECT1;
+                break;
+            case 250:       // Camouflage Speed Decrease
+                if (GetEffIndex() == EFFECT_INDEX_0)
+                    m_modifier.m_miscvalue = SPELLMOD_EFFECT3;
+                break;
+            case 1181:       // Pathfinding Speed Increase
+                if (GetEffIndex() == EFFECT_INDEX_0)
+                    m_modifier.m_miscvalue = SPELLMOD_EFFECT1;
+                break;
+            case 1494:       // Amplify Curse Speed Decrease
+                if (GetEffIndex() == EFFECT_INDEX_1)
+                    m_modifier.m_miscvalue = SPELLMOD_EFFECT1;
+                break;
+            case 1563:       // Cheetah Sprint
+                if (GetEffIndex() == EFFECT_INDEX_0)
+                    m_modifier.m_miscvalue = SPELLMOD_EFFECT1;
+                break;
+        }
 
         m_spellmod = new SpellModifier(
             SpellModOp(m_modifier.m_miscvalue),


### PR DESCRIPTION
... Camouflage, Pathfinding, Amplify Curse, Cheetah Sprint

This is a hack way, but the other way I can not see because the error is in the DBC. This can be seen when you compare DBC with next patch.

This commit [5a5169b](http://github.com/mangos-zero/server-old/commit/5a5169b) is one of those pending backports from old mangos-zero concatenated in: https://github.com/cmangos/issues/wiki/classic_backporting-todo-zero-commits

I tested it and this is my report:

> I've tested this one and I do see some improvements. However, the original author did not think it was the proper way to fix it. I don't know either. In a nutshell: fix needed and working but maybe not proper.

Maybe this could be discussed with @sidsukana ?
