### PR TITLE
Fix rewarding honor for outdoor pvp objectives

### DIFF
--- a/src/game/OutdoorPvP/OutdoorPvPEP.cpp
+++ b/src/game/OutdoorPvP/OutdoorPvPEP.cpp
@@ -171,15 +171,14 @@ void OutdoorPvPEP::HandleObjectiveComplete(uint32 eventId, std::list<Player*> pl
             return;
     }
 
-    // ToDo: fix this! Maybe uses spells 31885 or 31929
-    /*for (std::list<Player*>::iterator itr = players.begin(); itr != players.end(); ++itr)
+    for (std::list<Player*>::iterator itr = players.begin(); itr != players.end(); ++itr)
     {
         if ((*itr) && (*itr)->GetTeam() == team)
         {
             (*itr)->KilledMonsterCredit(credit);
-            (*itr)->RewardHonor(NULL, 1, HONOR_REWARD_PLAGUELANDS);
+            (*itr)->AddHonorCP(HONOR_REWARD_PLAGUELANDS, HONORABLE, 0, 0);
         }
-    }*/
+    }
 }
 
 // process the capture events

--- a/src/game/OutdoorPvP/OutdoorPvPEP.h
+++ b/src/game/OutdoorPvP/OutdoorPvPEP.h
@@ -47,7 +47,7 @@ enum
     GRAVEYARD_ID_EASTERN_PLAGUE                     = 927,
 
     // misc
-    HONOR_REWARD_PLAGUELANDS                        = 18,
+    HONOR_REWARD_PLAGUELANDS                        = 189, // guessed, same factor as silithus
 
     // npcs
     NPC_SPECTRAL_FLIGHT_MASTER                      = 17209,

--- a/src/game/OutdoorPvP/OutdoorPvPSI.cpp
+++ b/src/game/OutdoorPvP/OutdoorPvPSI.cpp
@@ -139,8 +139,7 @@ bool OutdoorPvPSI::HandleAreaTrigger(Player* player, uint32 triggerId)
 
     // reward the player
     player->CastSpell(player, SPELL_TRACES_OF_SILITHYST, true);
-    // ToDo: fix this!
-    // player->RewardHonor(NULL, 1, HONOR_REWARD_SILITHYST);
+    player->AddHonorCP(HONOR_REWARD_SILITHYST, HONORABLE, 0, 0);
     player->GetReputationMgr().ModifyReputation(sFactionStore.LookupEntry(FACTION_CENARION_CIRCLE), REPUTATION_REWARD_SILITHYST);
 
     return true;

--- a/src/game/OutdoorPvP/OutdoorPvPSI.h
+++ b/src/game/OutdoorPvP/OutdoorPvPSI.h
@@ -50,7 +50,7 @@ enum
 
     // misc
     FACTION_CENARION_CIRCLE             = 609,
-    HONOR_REWARD_SILITHYST              = 19,
+    HONOR_REWARD_SILITHYST              = 199,
     REPUTATION_REWARD_SILITHYST         = 20,
     MAX_SILITHYST                       = 200,
 


### PR DESCRIPTION
Proof for Silithus: http://www.wowwiki.com/The_Silithyst_Must_Flow?oldid=346171#Rewards

Eastern Plaguelands honor is guessed. I used the same factor as silithus honor. Also in classic battlegrounds there are bonus honor rewards with value `189`
