### PR TITLE
fix CHAT_TAG_GM

### DIFF
--- a/src/game/Player.h
+++ b/src/game/Player.h
@@ -633,7 +633,7 @@ enum PlayerChatTag
     CHAT_TAG_NONE               = 0x00,
     CHAT_TAG_AFK                = 0x01,
     CHAT_TAG_DND                = 0x02,
-    CHAT_TAG_GM                 = 0x04,
+    CHAT_TAG_GM                 = 0x03,
 };
 
 enum PlayedTimeIndex


### PR DESCRIPTION
In version 1.12.1 the GM chat badge has a value of 0x03 not 0x04.
