### PR TITLE
Fixed issue with PCH not working on some versions of GCC

### DIFF
--- a/cmake/FindPCHSupport.cmake
+++ b/cmake/FindPCHSupport.cmake
@@ -17,13 +17,13 @@ IF(CMAKE_COMPILER_IS_GNUCXX)
         ARGS  ${CMAKE_CXX_COMPILER_ARG1} -dumpversion
         OUTPUT_VARIABLE gcc_compiler_version)
     #MESSAGE("GCC Version: ${gcc_compiler_version}")
-    IF(gcc_compiler_version MATCHES "4\\.[0-9]\\.[0-9]")
+    IF(gcc_compiler_version MATCHES "4\\.[0-9](\\.[0-9])?")
         SET(PCHSupport_FOUND TRUE)
-    ELSE(gcc_compiler_version MATCHES "4\\.[0-9]\\.[0-9]")
-        IF(gcc_compiler_version MATCHES "3\\.4\\.[0-9]")
+    ELSE(gcc_compiler_version MATCHES "4\\.[0-9](\\.[0-9])?")
+        IF(gcc_compiler_version MATCHES "3\\.4(\\.[0-9])?")
             SET(PCHSupport_FOUND TRUE)
-        ENDIF(gcc_compiler_version MATCHES "3\\.4\\.[0-9]")
-    ENDIF(gcc_compiler_version MATCHES "4\\.[0-9]\\.[0-9]")
+        ENDIF(gcc_compiler_version MATCHES "3\\.4(\\.[0-9])?")
+    ENDIF(gcc_compiler_version MATCHES "4\\.[0-9](\\.[0-9])?")
 
   SET(_PCH_include_prefix "-I")
 


### PR DESCRIPTION
Since some versions of GCC doesn't output patchlevel on -dumpversion the PCH check can fail.
Bug: https://github.com/cmangos/issues/issues/81
