### PR TITLE
Fix chat tag on classic

### DIFF
--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -1473,16 +1473,15 @@ void Player::ToggleDND()
 
 uint8 Player::GetChatTag() const
 {
-    uint8 tag = CHAT_TAG_NONE;
+    if (isGMChat())
+        return CHAT_TAG_GM;
 
     if (isAFK())
-        tag |= CHAT_TAG_AFK;
+        return CHAT_TAG_AFK;
     if (isDND())
-        tag |= CHAT_TAG_DND;
-    if (isGMChat())
-        tag |= CHAT_TAG_GM;
+        return CHAT_TAG_DND;
 
-    return tag;
+    return CHAT_TAG_NONE;
 }
 
 bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientation, uint32 options /*=0*/, AreaTrigger const* at /*=NULL*/)

--- a/src/game/Player.h
+++ b/src/game/Player.h
@@ -630,10 +630,10 @@ enum EnvironmentalDamageType
 
 enum PlayerChatTag
 {
-    CHAT_TAG_NONE               = 0x00,
-    CHAT_TAG_AFK                = 0x01,
-    CHAT_TAG_DND                = 0x02,
-    CHAT_TAG_GM                 = 0x04,
+    CHAT_TAG_NONE               = 0,
+    CHAT_TAG_AFK                = 1,
+    CHAT_TAG_DND                = 2,
+    CHAT_TAG_GM                 = 3,
 };
 
 enum PlayedTimeIndex


### PR DESCRIPTION
Bitmask for chat tag was implemented in TBC.

Seems like GMs could not be afk in pre-tbc times hehe

This kind of reverts 2174cee
