### PR TITLE
Fix spirit based mana regen

### DIFF
--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -4719,6 +4719,8 @@ float Player::OCTRegenMPPerSpirit()
         case CLASS_WARLOCK: addvalue = (Spirit / 5 + 15);   break;
     }
 
+    addvalue /= 2.0f;   // the above addvalue are given per tick which occurs every 2 seconds, hence this divide by 2
+
     return addvalue;
 }
 


### PR DESCRIPTION
Fix spirit based mana regen because mana regen was too fast, especially with spells like innervate or evocate or when players have a high ratio spirit/mana points.
Unlike TBC and later expansions, spirit mana regen values per class were not stored in DBC in Classic but used formulas as described below (and written in `Player::OCTRegenMPPerSpirit()`)
http://www.wowwiki.com/Mana_regeneration?direction=prev&oldid=103895
However, those formulas give regen values per tick, a tick occuring every 2 sec, the returned value must be cut by half in order to have the correct mana regen rate when `OCTRegenMPPerSpirit()` is called.
source: http://www.wowwiki.com/Talk:Mana_regeneration#Untitled
