### PR TITLE
Fix NPCs having the wrong orientation while fleeing.

### DIFF
--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -7173,7 +7173,7 @@ bool Unit::SelectHostileTarget()
 
     if (target)
     {
-        if (!hasUnitState(UNIT_STAT_STUNNED | UNIT_STAT_DIED))
+        if (!hasUnitState(UNIT_STAT_CAN_NOT_REACT_OR_LOST_CONTROL))
         {
             SetInFront(target);
             if (oldTarget != target)


### PR DESCRIPTION
SelectHostileTarget was not taking into account loss-of-control and was
mistakenly making the creature face the player even while it was running
away.

Fixes cmangos/issues#375.
