### PR TITLE
Fix audio repeating due to SMSG_INIT_WORLD_STATES.

### DIFF
--- a/src/game/BattleGround/BattleGround.h
+++ b/src/game/BattleGround/BattleGround.h
@@ -582,15 +582,4 @@ inline void FillInitialWorldState(ByteBuffer& data, uint32& count, WorldStatePai
     }
 }
 
-// [-ZERO] it's just a workaround , packet values in 1.12 aren't known
-inline void FillInitialDefWorldState(ByteBuffer& data, uint32& count, WorldStatePair const* array)
-{
-    for (WorldStatePair const* itr = array; itr->state; ++itr)
-    {
-        data << uint16(itr->state);
-        data << uint16(itr->value);
-        ++count;
-    }
-}
-
 #endif

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -7325,6 +7325,7 @@ void Player::SendUpdateWorldState(uint32 Field, uint32 Value)
     GetSession()->SendPacket(&data);
 }
 
+// TODO: Determine what these values mean, if anything.
 static WorldStatePair def_world_states[] =
 {
     { 0x07AE, 0x01 },
@@ -7435,303 +7436,48 @@ static WorldStatePair def_world_states[] =
     { 0x0518, 0x00 },
     { 0x0517, 0x00 },
     { 0x0703, 0x00 },
-    { 0x0,    0x0 }
-};
-
-static WorldStatePair AV_world_states[] =
-{
-    { 0x7ae, 0x1 },                                         // 1966  7 snowfall n
-    { 0x532, 0x1 },                                         // 1330  8 frostwolfhut hc
-    { 0x531, 0x0 },                                         // 1329  9 frostwolfhut ac
-    { 0x52e, 0x0 },                                         // 1326 10 stormpike firstaid a_a
-    { 0x571, 0x0 },                                         // 1393 11 east frostwolf tower horde assaulted -unused
-    { 0x570, 0x0 },                                         // 1392 12 west frostwolf tower horde assaulted - unused
-    { 0x567, 0x1 },                                         // 1383 13 frostwolfe c
-    { 0x566, 0x1 },                                         // 1382 14 frostwolfw c
-    { 0x550, 0x1 },                                         // 1360 15 irondeep (N) ally
-    { 0x544, 0x0 },                                         // 1348 16 ice grave a_a
-    { 0x536, 0x0 },                                         // 1334 17 stormpike grave h_c
-    { 0x535, 0x1 },                                         // 1333 18 stormpike grave a_c
-    { 0x518, 0x0 },                                         // 1304 19 stoneheart grave a_a
-    { 0x517, 0x0 },                                         // 1303 20 stoneheart grave h_a
-    { 0x574, 0x0 },                                         // 1396 21 unk
-    { 0x573, 0x0 },                                         // 1395 22 iceblood tower horde assaulted -unused
-    { 0x572, 0x0 },                                         // 1394 23 towerpoint horde assaulted - unused
-    { 0x56f, 0x0 },                                         // 1391 24 unk
-    { 0x56e, 0x0 },                                         // 1390 25 iceblood a
-    { 0x56d, 0x0 },                                         // 1389 26 towerp a
-    { 0x56c, 0x0 },                                         // 1388 27 frostwolfe a
-    { 0x56b, 0x0 },                                         // 1387 28 froswolfw a
-    { 0x56a, 0x1 },                                         // 1386 29 unk
-    { 0x569, 0x1 },                                         // 1385 30 iceblood c
-    { 0x568, 0x1 },                                         // 1384 31 towerp c
-    { 0x565, 0x0 },                                         // 1381 32 stoneh tower a
-    { 0x564, 0x0 },                                         // 1380 33 icewing tower a
-    { 0x563, 0x0 },                                         // 1379 34 dunn a
-    { 0x562, 0x0 },                                         // 1378 35 duns a
-    { 0x561, 0x0 },                                         // 1377 36 stoneheart bunker alliance assaulted - unused
-    { 0x560, 0x0 },                                         // 1376 37 icewing bunker alliance assaulted - unused
-    { 0x55f, 0x0 },                                         // 1375 38 dunbaldar south alliance assaulted - unused
-    { 0x55e, 0x0 },                                         // 1374 39 dunbaldar north alliance assaulted - unused
-    { 0x55d, 0x0 },                                         // 1373 40 stone tower d
-    { 0x3c6, 0x0 },                                         //  966 41 unk
-    { 0x3c4, 0x0 },                                         //  964 42 unk
-    { 0x3c2, 0x0 },                                         //  962 43 unk
-    { 0x516, 0x1 },                                         // 1302 44 stoneheart grave a_c
-    { 0x515, 0x0 },                                         // 1301 45 stonheart grave h_c
-    { 0x3b6, 0x0 },                                         //  950 46 unk
-    { 0x55c, 0x0 },                                         // 1372 47 icewing tower d
-    { 0x55b, 0x0 },                                         // 1371 48 dunn d
-    { 0x55a, 0x0 },                                         // 1370 49 duns d
-    { 0x559, 0x0 },                                         // 1369 50 unk
-    { 0x558, 0x0 },                                         // 1368 51 iceblood d
-    { 0x557, 0x0 },                                         // 1367 52 towerp d
-    { 0x556, 0x0 },                                         // 1366 53 frostwolfe d
-    { 0x555, 0x0 },                                         // 1365 54 frostwolfw d
-    { 0x554, 0x1 },                                         // 1364 55 stoneh tower c
-    { 0x553, 0x1 },                                         // 1363 56 icewing tower c
-    { 0x552, 0x1 },                                         // 1362 57 dunn c
-    { 0x551, 0x1 },                                         // 1361 58 duns c
-    { 0x54f, 0x0 },                                         // 1359 59 irondeep (N) horde
-    { 0x54e, 0x0 },                                         // 1358 60 irondeep (N) ally
-    { 0x54d, 0x1 },                                         // 1357 61 mine (S) neutral
-    { 0x54c, 0x0 },                                         // 1356 62 mine (S) horde
-    { 0x54b, 0x0 },                                         // 1355 63 mine (S) ally
-    { 0x545, 0x0 },                                         // 1349 64 iceblood h_a
-    { 0x543, 0x1 },                                         // 1347 65 iceblod h_c
-    { 0x542, 0x0 },                                         // 1346 66 iceblood a_c
-    { 0x540, 0x0 },                                         // 1344 67 snowfall h_a
-    { 0x53f, 0x0 },                                         // 1343 68 snowfall a_a
-    { 0x53e, 0x0 },                                         // 1342 69 snowfall h_c
-    { 0x53d, 0x0 },                                         // 1341 70 snowfall a_c
-    { 0x53c, 0x0 },                                         // 1340 71 frostwolf g h_a
-    { 0x53b, 0x0 },                                         // 1339 72 frostwolf g a_a
-    { 0x53a, 0x1 },                                         // 1338 73 frostwolf g h_c
-    { 0x539, 0x0 },                                         // l33t 74 frostwolf g a_c
-    { 0x538, 0x0 },                                         // 1336 75 stormpike grave h_a
-    { 0x537, 0x0 },                                         // 1335 76 stormpike grave a_a
-    { 0x534, 0x0 },                                         // 1332 77 frostwolf hut h_a
-    { 0x533, 0x0 },                                         // 1331 78 frostwolf hut a_a
-    { 0x530, 0x0 },                                         // 1328 79 stormpike first aid h_a
-    { 0x52f, 0x0 },                                         // 1327 80 stormpike first aid h_c
-    { 0x52d, 0x1 },                                         // 1325 81 stormpike first aid a_c
-    { 0x0,   0x0 }
-};
-
-static WorldStatePair WS_world_states[] =
-{
-    { 0x62d, 0x0 },                                         // 1581  7 alliance flag captures
-    { 0x62e, 0x0 },                                         // 1582  8 horde flag captures
-    { 0x609, 0x0 },                                         // 1545  9 unk, set to 1 on alliance flag pickup...
-    { 0x60a, 0x0 },                                         // 1546 10 unk, set to 1 on horde flag pickup, after drop it's -1
-    { 0x60b, 0x2 },                                         // 1547 11 unk
-    { 0x641, 0x3 },                                         // 1601 12 unk (max flag captures?)
-    { 0x922, 0x1 },                                         // 2338 13 horde (0 - hide, 1 - flag ok, 2 - flag picked up (flashing), 3 - flag picked up (not flashing)
-    { 0x923, 0x1 },                                         // 2339 14 alliance (0 - hide, 1 - flag ok, 2 - flag picked up (flashing), 3 - flag picked up (not flashing)
-    { 0x0,   0x0 }
-};
-
-static WorldStatePair AB_world_states[] =
-{
-    { 0x6e7, 0x0 },                                         // 1767  7 stables alliance
-    { 0x6e8, 0x0 },                                         // 1768  8 stables horde
-    { 0x6e9, 0x0 },                                         // 1769  9 unk, ST?
-    { 0x6ea, 0x0 },                                         // 1770 10 stables (show/hide)
-    { 0x6ec, 0x0 },                                         // 1772 11 farm (0 - horde controlled, 1 - alliance controlled)
-    { 0x6ed, 0x0 },                                         // 1773 12 farm (show/hide)
-    { 0x6ee, 0x0 },                                         // 1774 13 farm color
-    { 0x6ef, 0x0 },                                         // 1775 14 gold mine color, may be FM?
-    { 0x6f0, 0x0 },                                         // 1776 15 alliance resources
-    { 0x6f1, 0x0 },                                         // 1777 16 horde resources
-    { 0x6f2, 0x0 },                                         // 1778 17 horde bases
-    { 0x6f3, 0x0 },                                         // 1779 18 alliance bases
-    { 0x6f4, 0x7d0 },                                       // 1780 19 max resources (2000)
-    { 0x6f6, 0x0 },                                         // 1782 20 blacksmith color
-    { 0x6f7, 0x0 },                                         // 1783 21 blacksmith (show/hide)
-    { 0x6f8, 0x0 },                                         // 1784 22 unk, bs?
-    { 0x6f9, 0x0 },                                         // 1785 23 unk, bs?
-    { 0x6fb, 0x0 },                                         // 1787 24 gold mine (0 - horde contr, 1 - alliance contr)
-    { 0x6fc, 0x0 },                                         // 1788 25 gold mine (0 - conflict, 1 - horde)
-    { 0x6fd, 0x0 },                                         // 1789 26 gold mine (1 - show/0 - hide)
-    { 0x6fe, 0x0 },                                         // 1790 27 gold mine color
-    { 0x700, 0x0 },                                         // 1792 28 gold mine color, wtf?, may be LM?
-    { 0x701, 0x0 },                                         // 1793 29 lumber mill color (0 - conflict, 1 - horde contr)
-    { 0x702, 0x0 },                                         // 1794 30 lumber mill (show/hide)
-    { 0x703, 0x0 },                                         // 1795 31 lumber mill color color
-    { 0x732, 0x1 },                                         // 1842 32 stables (1 - uncontrolled)
-    { 0x733, 0x1 },                                         // 1843 33 gold mine (1 - uncontrolled)
-    { 0x734, 0x1 },                                         // 1844 34 lumber mill (1 - uncontrolled)
-    { 0x735, 0x1 },                                         // 1845 35 farm (1 - uncontrolled)
-    { 0x736, 0x1 },                                         // 1846 36 blacksmith (1 - uncontrolled)
-    { 0x745, 0x2 },                                         // 1861 37 unk
-    { 0x7a3, 0x708 },                                       // 1955 38 warning limit (1800)
-    { 0x0,   0x0 }
-};
-
-static WorldStatePair SI_world_states[] =                   // Silithus
-{
-    { 2313, 0 },                                            // WORLD_STATE_SI_GATHERED_A
-    { 2314, 0 },                                            // WORLD_STATE_SI_GATHERED_H
-    { 2317, 0 }                                             // WORLD_STATE_SI_SILITHYST_MAX
-};
-
-static WorldStatePair EP_world_states[] =                   // Eastern Plaguelands
-{
-    { 2327, 0 },                                            // WORLD_STATE_EP_TOWER_COUNT_ALLIANCE
-    { 2328, 0 },                                            // WORLD_STATE_EP_TOWER_COUNT_HORDE
-    { 2355, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_CROWNGUARD_NEUTRAL
-    { 2374, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_CROWNGUARD_CONTEST_ALLIANCE
-    { 2375, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_CROWNGUARD_CONTEST_HORDE
-    { 2376, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_CROWNGUARD_PROGRESS_ALLIANCE
-    { 2377, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_CROWNGUARD_PROGRESS_HORDE
-    { 2378, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_CROWNGUARD_ALLIANCE
-    { 2379, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_CROWNGUARD_HORDE
-    { 2354, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_EASTWALL_ALLIANCE
-    { 2356, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_EASTWALL_HORDE
-    { 2357, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_EASTWALL_PROGRESS_ALLIANCE
-    { 2358, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_EASTWALL_PROGRESS_HORDE
-    { 2359, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_EASTWALL_CONTEST_ALLIANCE
-    { 2360, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_EASTWALL_CONTEST_HORDE
-    { 2361, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_EASTWALL_NEUTRAL
-    { 2352, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_NORTHPASS_NEUTRAL
-    { 2362, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_NORTHPASS_CONTEST_ALLIANCE
-    { 2363, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_NORTHPASS_CONTEST_HORDE
-    { 2364, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_NORTHPASS_PROGRESS_ALLIANCE
-    { 2365, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_NORTHPASS_PROGRESS_HORDE
-    { 2372, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_NORTHPASS_ALLIANCE
-    { 2373, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_NORTHPASS_HORDE
-    { 2353, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_PLAGUEWOOD_NEUTRAL
-    { 2366, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_PLAGUEWOOD_CONTEST_ALLIANCE
-    { 2367, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_PLAGUEWOOD_CONTEST_HORDE - not in dbc! sent for consistency's sake, and to match field count
-    { 2368, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_PLAGUEWOOD_PROGRESS_ALLIANCE
-    { 2369, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_PLAGUEWOOD_PROGRESS_HORDE
-    { 2370, WORLD_STATE_REMOVE },                           // WORLD_STATE_EP_PLAGUEWOOD_ALLIANCE
-    { 2371, WORLD_STATE_REMOVE }                            // WORLD_STATE_EP_PLAGUEWOOD_HORDE
+    { 0, 0 } // terminator
 };
 
 void Player::SendInitWorldStates(uint32 zoneid)
 {
-    // data depends on zoneid/mapid...
-    BattleGround* bg = GetBattleGround();
     uint32 mapid = GetMapId();
 
     DEBUG_LOG("Sending SMSG_INIT_WORLD_STATES to Map:%u, Zone: %u", mapid, zoneid);
 
-    bool defZone = false;
+    uint32 count = 1; // count of world states in packet, 1 extra for the terminator
 
-    // may be exist better way to do this...
+    WorldPacket data(SMSG_INIT_WORLD_STATES, (4 + 4 + 2 + 6));
+    data << uint32(mapid);                              // mapid
+    data << uint32(zoneid);                             // zone id
+    size_t count_pos = data.wpos();
+    data << uint16(0);                                  // count of uint32 blocks, placeholder
+
+    for (WorldStatePair const* itr = def_world_states; itr->state; ++itr)
+    {
+        data << uint32(itr->state);
+        data << uint32(itr->value);
+        ++count;
+    }
+
     switch (zoneid)
     {
-        case 0:
-        case 1:
-        case 4:
-        case 8:
-        case 10:
-        case 11:
-        case 12:
-        case 36:
-        case 38:
-        case 40:
-        case 41:
-        case 51:
-        case 267:
-        case 1519:
-        case 1537:
-        case 2257:
-        case 2918:
-        case 139:
-        case 1377:
-        case 2597:
-        case 3277:
-        case 3358:
+        case 139:                                       // Eastern Plaguelands
+        case 1377:                                      // Silithus
+            if (OutdoorPvP* outdoorPvP = sOutdoorPvPMgr.GetScript(zoneid))
+                outdoorPvP->FillInitialWorldStates(data, count);
             break;
-        default:
-            defZone = true;
+        case 2597:                                      // AV
+        case 3277:                                      // WS
+        case 3358:                                      // AB
+            if (BattleGround* bg = GetBattleGround())
+                bg->FillInitialWorldStates(data, count);
             break;
     }
 
-    uint32 count = 0;                                       // count of world states in packet
-
-    if (defZone)
-    {
-        WorldPacket data(SMSG_INIT_WORLD_STATES, (4 + 2 + 13));
-        data << uint32(mapid);                              // mapid
-        size_t count_pos = data.wpos();
-        data << uint16(0);                                  // count of uint32 blocks, placeholder
-        FillInitialDefWorldState(data, count, def_world_states);
-
-        data.put<uint16>(count_pos, count);                 // set actual world state amount
-        GetSession()->SendPacket(&data);
-    }
-    else
-    {
-        WorldPacket data(SMSG_INIT_WORLD_STATES, (4 + 4 + 2 + 6));
-        data << uint32(mapid);                              // mapid
-        data << uint32(zoneid);                             // zone id
-        size_t count_pos = data.wpos();
-        data << uint16(0);                                  // count of uint32 blocks, placeholder
-        // common fields
-        FillInitialWorldState(data, count, 0x8d8, 0x0);     // 2264 1
-        FillInitialWorldState(data, count, 0x8d7, 0x0);     // 2263 2
-        FillInitialWorldState(data, count, 0x8d6, 0x0);     // 2262 3
-        FillInitialWorldState(data, count, 0x8d5, 0x0);     // 2261 4
-        FillInitialWorldState(data, count, 0x8d4, 0x0);     // 2260 5
-        FillInitialWorldState(data, count, 0x8d3, 0x0);     // 2259 6
-
-        switch (zoneid)
-        {
-            case 1:                                         // Dun Morogh
-            case 11:                                        // Wetlands
-            case 12:                                        // Elwynn Forest
-            case 38:                                        // Loch Modan
-            case 40:                                        // Westfall
-            case 51:                                        // Searing Gorge
-            case 1519:                                      // Stormwind City
-            case 1537:                                      // Ironforge
-            case 2257:                                      // Deeprun Tram
-                break;
-            case 139:                                       // Eastern Plaguelands
-                if (OutdoorPvP* outdoorPvP = sOutdoorPvPMgr.GetScript(zoneid))
-                    outdoorPvP->FillInitialWorldStates(data, count);
-                else
-                    FillInitialWorldState(data, count, EP_world_states);
-                break;
-            case 1377:                                      // Silithus
-                if (OutdoorPvP* outdoorPvP = sOutdoorPvPMgr.GetScript(zoneid))
-                    outdoorPvP->FillInitialWorldStates(data, count);
-                else
-                    FillInitialWorldState(data, count, SI_world_states);
-                break;
-            case 2597:                                      // AV
-                if (bg && bg->GetTypeID() == BATTLEGROUND_AV)
-                    bg->FillInitialWorldStates(data, count);
-                else
-                    FillInitialWorldState(data, count, AV_world_states);
-                break;
-            case 3277:                                      // WS
-                if (bg && bg->GetTypeID() == BATTLEGROUND_WS)
-                    bg->FillInitialWorldStates(data, count);
-                else
-                    FillInitialWorldState(data, count, WS_world_states);
-                break;
-            case 3358:                                      // AB
-                if (bg && bg->GetTypeID() == BATTLEGROUND_AB)
-                    bg->FillInitialWorldStates(data, count);
-                else
-                    FillInitialWorldState(data, count, AB_world_states);
-                break;
-            default:
-                FillInitialWorldState(data, count, 0x914, 0x0); // 2324 7
-                FillInitialWorldState(data, count, 0x913, 0x0); // 2323 8
-                FillInitialWorldState(data, count, 0x912, 0x0); // 2322 9
-                FillInitialWorldState(data, count, 0x915, 0x0); // 2325 10
-                break;
-        }
-
-        data.put<uint16>(count_pos, count);                 // set actual world state amount
-
-        GetSession()->SendPacket(&data);
-    }
+    data << uint32(0) << uint32(0);     // [-ZERO] Add terminator to prevent repeating audio bug.
+    data.put<uint16>(count_pos, count); // set actual world state amount
+    GetSession()->SendPacket(&data);
 }
 
 uint32 Player::GetXPRestBonus(uint32 xp)


### PR DESCRIPTION
Also simplify Player::SendInitWorldStates significantly.

I remove the sending of the default world states if the script isn't available because the script should be available under all circumstances, and if it isn't we shouldn't pretend that it is.

Fixes cmangos/issues#266.