### PR TITLE
Lift the check for facing your target out of Spell::CheckRange.

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4327,12 +4327,15 @@ SpellCastResult Spell::CheckCast(bool strict)
 
     if (!m_IsTriggeredSpell)
     {
-        if (!m_triggeredByAuraSpell)
-        {
-            SpellCastResult castResult = CheckRange(strict);
-            if (castResult != SPELL_CAST_OK)
-                return castResult;
-        }
+        SpellCastResult castResult = CheckRange(strict);
+        if (castResult != SPELL_CAST_OK)
+            return castResult;
+
+        if (Unit* target = m_targets.getUnitTarget())
+            if (m_caster->GetTypeId() == TYPEID_PLAYER &&
+                    (sSpellMgr.GetSpellFacingFlag(m_spellInfo->Id) & SPELL_FACING_FLAG_INFRONT) &&
+                    !m_caster->HasInArc(M_PI_F, target))
+                return SPELL_FAILED_UNIT_NOT_INFRONT;
     }
 
     {
@@ -5196,9 +5199,6 @@ SpellCastResult Spell::CheckRange(bool strict)
             return SPELL_FAILED_OUT_OF_RANGE;
         if (min_range && dist < min_range)
             return SPELL_FAILED_TOO_CLOSE;
-        if (m_caster->GetTypeId() == TYPEID_PLAYER &&
-                (sSpellMgr.GetSpellFacingFlag(m_spellInfo->Id) & SPELL_FACING_FLAG_INFRONT) && !m_caster->HasInArc(M_PI_F, target))
-            return SPELL_FAILED_UNIT_NOT_INFRONT;
     }
 
     // TODO verify that such spells really use bounding radius


### PR DESCRIPTION
Whether the caster is facing the target or not has nothing to do with
whether the target is in range. CheckRange returned early for spells with
SPELL_RANGE_IDX_COMBAT, skipping the facing-target check.

Also remove code that allows spells triggered by auras to be cast
regardless of range, reverting part of [z0555].

This fixes cmangos/issues#384.
