### PR TITLE
Fix player abilities Bloodrage and Enrage.

### DIFF
--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -149,7 +149,7 @@ pAuraHandler AuraHandler[TOTAL_AURAS] =
     &Aura::HandleNoImmediateEffect,                         // 91 SPELL_AURA_MOD_DETECT_RANGE implemented in Creature::GetAttackDistance
     &Aura::HandlePreventFleeing,                            // 92 SPELL_AURA_PREVENTS_FLEEING
     &Aura::HandleModUnattackable,                           // 93 SPELL_AURA_MOD_UNATTACKABLE
-    &Aura::HandleNoImmediateEffect,                         // 94 SPELL_AURA_INTERRUPT_REGEN implemented in Player::RegenerateAll
+    &Aura::HandleInterruptRegen,                            // 94 SPELL_AURA_INTERRUPT_REGEN
     &Aura::HandleAuraGhost,                                 // 95 SPELL_AURA_GHOST
     &Aura::HandleNoImmediateEffect,                         // 96 SPELL_AURA_SPELL_MAGNET implemented in Unit::SelectMagnetTarget
     &Aura::HandleManaShield,                                // 97 SPELL_AURA_MANA_SHIELD implemented in Unit::CalculateAbsorbAndResist
@@ -4788,6 +4788,18 @@ bool Aura::IsLastAuraOnHolder()
         if (i != GetEffIndex() && GetHolder()->m_auras[i])
             return false;
     return true;
+}
+
+void Aura::HandleInterruptRegen(bool apply, bool Real)
+{
+    if (!Real)
+        return;
+
+    if (GetSpellProto()->Id != 5229 && GetSpellProto()->Id != 29131) // Enrage and Bloodrage
+        return;
+
+    if (apply)
+        GetTarget()->SetInCombatState(false);
 }
 
 SpellAuraHolder::SpellAuraHolder(SpellEntry const* spellproto, Unit* target, WorldObject* caster, Item* castItem) :

--- a/src/game/SpellAuras.h
+++ b/src/game/SpellAuras.h
@@ -378,6 +378,7 @@ class MANGOS_DLL_SPEC Aura
         void HandleSchoolAbsorb(bool apply, bool Real);
         void HandlePreventFleeing(bool apply, bool Real);
         void HandleManaShield(bool apply, bool Real);
+        void HandleInterruptRegen(bool apply, bool Real);
 
         virtual ~Aura();
 

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -303,8 +303,8 @@ void Unit::Update(uint32 update_diff, uint32 p_time)
             m_lastManaUseTimer -= update_diff;
     }
 
-    // update combat timer only for players and pets
-    if (isInCombat() && GetCharmerOrOwnerPlayerOrPlayerItself())
+    // update combat timer only for players and pets without Enrage or Bloodrage
+    if (isInCombat() && GetCharmerOrOwnerPlayerOrPlayerItself() && !(HasAura(5229) || HasAura(29131)))
     {
         // Check UNIT_STAT_MELEE_ATTACKING or UNIT_STAT_CHASE (without UNIT_STAT_FOLLOW in this case) so pets can reach far away
         // targets without stopping half way there and running off.


### PR DESCRIPTION
These abilities caused you to enter combat when you used them prior to
patch 2.3.0. Canceling them removes you from combat if you are not
fighting a creature or in PvP/dueling.

Fixes cmangos/issues#374.
