### PR TITLE
Don't do periodic heal ticks if the target is already at max health.

### DIFF
--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -4394,6 +4394,10 @@ void Aura::PeriodicTick()
             if (!target->isAlive())
                 return;
 
+            // Don't heal target if it is already at max health.
+            if (target->GetHealth() == target->GetMaxHealth())
+                return;
+
             Unit* pCaster = GetCaster();
             if (!pCaster)
                 return;


### PR DESCRIPTION
If a target is at maximum health already periodic healing spells should
not tick.

From the healer's point of view this means far less overhealing, improving
their healing performance information.

Fixes cmangos/issues#385.
