### PR TITLE
Add CREATURE_FLAG_EXTRA_NO_CALL_ASSIST.

### DIFF
--- a/src/game/Creature.cpp
+++ b/src/game/Creature.cpp
@@ -1718,6 +1718,10 @@ void Creature::CallAssistance()
     if (!m_AlreadyCallAssistance && getVictim() && !isCharmed())
     {
         SetNoCallAssistance(true);
+
+        if (GetCreatureInfo()->flags_extra & CREATURE_FLAG_EXTRA_NO_CALL_ASSIST)
+            return;
+
         AI()->SendAIEventAround(AI_EVENT_CALL_ASSISTANCE, getVictim(), sWorld.getConfig(CONFIG_UINT32_CREATURE_FAMILY_ASSISTANCE_DELAY), sWorld.getConfig(CONFIG_FLOAT_CREATURE_FAMILY_ASSISTANCE_RADIUS));
     }
 }

--- a/src/game/Creature.h
+++ b/src/game/Creature.h
@@ -54,6 +54,7 @@ enum CreatureFlagsExtra
     CREATURE_FLAG_EXTRA_NOT_TAUNTABLE   = 0x00000100,       // creature is immune to taunt auras and effect attack me
     CREATURE_FLAG_EXTRA_AGGRO_ZONE      = 0x00000200,       // creature sets itself in combat with zone on aggro
     CREATURE_FLAG_EXTRA_GUARD           = 0x00000400,       // creature is a guard
+    CREATURE_FLAG_EXTRA_NO_CALL_ASSIST  = 0x00000800,       // creature shouldn't call for assistance on aggro
 };
 
 // GCC have alternative #pragma pack(N) syntax and old gcc version not support pack(push,N), also any gcc version not support it at some platform


### PR DESCRIPTION
This is used to prevent creatures from pulling too many nearby monsters,
for example during certain scripted events.

A good example is Mr. Smite in the Deadmines. There are two guards at the
bottom of his bridge which trigger aggro for him, but if he is missing
this flag he will also pull nearby mobs on the ship, which is not expected
behavior.
