### PR TITLE
Fix failed assertions while playing with the Mac client.

### DIFF
--- a/src/game/Channel.cpp
+++ b/src/game/Channel.cpp
@@ -895,27 +895,10 @@ void Channel::MakeThrottled(WorldPacket* data)
 
 void Channel::JoinNotify(ObjectGuid guid)
 {
-    WorldPacket data;
-
-    if (IsConstant())
-        data.Initialize(SMSG_USERLIST_ADD, 8 + 1 + 1 + 4 + GetName().size() + 1);
-    else
-        data.Initialize(SMSG_USERLIST_UPDATE, 8 + 1 + 1 + 4 + GetName().size() + 1);
-
-    data << ObjectGuid(guid);
-    data << uint8(GetPlayerFlags(guid));
-    data << uint8(GetFlags());
-    data << uint32(GetNumPlayers());
-    data << GetName();
-    SendToAll(&data);
+    // [-ZERO] Feature doesn't exist in 1.x.
 }
 
 void Channel::LeaveNotify(ObjectGuid guid)
 {
-    WorldPacket data(SMSG_USERLIST_REMOVE, 8 + 1 + 4 + GetName().size() + 1);
-    data << ObjectGuid(guid);
-    data << uint8(GetFlags());
-    data << uint32(GetNumPlayers());
-    data << GetName();
-    SendToAll(&data);
+    // [-ZERO] Feature doesn't exist in 1.x.
 }

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -17394,13 +17394,7 @@ void Player::SendInitialPacketsBeforeAddToMap()
 
     // tutorial stuff
     GetSession()->SendTutorialsData();
-
     SendInitialSpells();
-    //[-ZERO] SMSG_SEND_UNLEARN_SPELLS maybe not for 1.12
-    data.Initialize(SMSG_SEND_UNLEARN_SPELLS, 4);
-    data << uint32(0);                                      // count, for(count) uint32;
-    GetSession()->SendPacket(&data);
-
     SendInitialActionButtons();
     m_reputationMgr.SendInitialReputations();
     UpdateHonor();

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -5486,14 +5486,6 @@ void SpellAuraHolder::UpdateAuraDuration()
         data << uint8(GetAuraSlot());
         data << uint32(GetAuraDuration());
         ((Player*)m_target)->SendDirectMessage(&data);
-
-        data.Initialize(SMSG_SET_EXTRA_AURA_INFO, (8 + 1 + 4 + 4 + 4));
-        data << m_target->GetPackGUID();
-        data << uint8(GetAuraSlot());
-        data << uint32(GetId());
-        data << uint32(GetAuraMaxDuration());
-        data << uint32(GetAuraDuration());
-        ((Player*)m_target)->SendDirectMessage(&data);
     }
 
     // not send in case player loading (will not work anyway until player not added to map), sent in visibility change code
@@ -5508,11 +5500,5 @@ void SpellAuraHolder::UpdateAuraDuration()
 
 void SpellAuraHolder::SendAuraDurationForCaster(Player* caster)
 {
-    WorldPacket data(SMSG_SET_EXTRA_AURA_INFO_NEED_UPDATE, (8 + 1 + 4 + 4 + 4));
-    data << m_target->GetPackGUID();
-    data << uint8(GetAuraSlot());
-    data << uint32(GetId());
-    data << uint32(GetAuraMaxDuration());                   // full
-    data << uint32(GetAuraDuration());                      // remain
-    caster->GetSession()->SendPacket(&data);
+    // [-ZERO] Feature doesn't exist in 1.x.
 }

--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -4039,17 +4039,6 @@ void Spell::EffectSummonTotem(SpellEffectIndex eff_idx)
     if (m_caster->IsPvP())
         pTotem->SetPvP(true);
 
-    // sending SMSG_TOTEM_CREATED before add to map (done in Summon)
-    if (slot < MAX_TOTEM_SLOT && m_caster->GetTypeId() == TYPEID_PLAYER)
-    {
-        WorldPacket data(SMSG_TOTEM_CREATED, 1 + 8 + 4 + 4);
-        data << uint8(slot);
-        data << pTotem->GetObjectGuid();
-        data << uint32(m_duration);
-        data << uint32(m_spellInfo->Id);
-        ((Player*)m_caster)->SendDirectMessage(&data);
-    }
-
     pTotem->Summon(m_caster);
 }
 


### PR DESCRIPTION
Some high opcodes don't exist in 1.x and were causing the Mac client to
display a failed assertion report to the user.
