### PR TITLE
Hide known recipes when the Usable box is checked in the AH.

### DIFF
--- a/src/game/AuctionHouseMgr.cpp
+++ b/src/game/AuctionHouseMgr.cpp
@@ -616,6 +616,11 @@ void AuctionHouseObject::BuildListAuctionItems(WorldPacket& data, Player* player
             if (usable != 0x00 && player->CanUseItem(item) != EQUIP_ERR_OK)
                 continue;
 
+            if (usable != 0x00 && proto->Class == ITEM_CLASS_RECIPE)
+                if (SpellEntry const* spell = sSpellStore.LookupEntry(proto->Spells[0].SpellId))
+                    if (player->HasSpell(spell->EffectTriggerSpell[EFFECT_INDEX_0]))
+                        continue;
+
             std::string name = proto->Name1;
             sObjectMgr.GetItemLocaleStrings(proto->ItemId, loc_idx, &name);
 


### PR DESCRIPTION
Fixes cmangos/issues#394.

Patch by http://github.com/y1x2
