### PR TITLE
Fixing channel issue with built-in channels

### DIFF
--- a/src/game/Channel.cpp
+++ b/src/game/Channel.cpp
@@ -26,7 +26,7 @@ Channel::Channel(const std::string& name, uint32 channel_id)
     : m_announce(true), m_moderate(false), m_name(name), m_flags(0), m_channelId(channel_id)
 {
     // set special flags if built-in channel
-    ChatChannelsEntry const* ch = GetChannelEntryFor(channel_id);
+	ChatChannelsEntry const* ch = GetChannelEntryFor(name);
     if (ch)                                                 // it's built-in channel
     {
         channel_id = ch->ChannelID;                         // built-in channel

--- a/src/game/DBCStores.cpp
+++ b/src/game/DBCStores.cpp
@@ -632,6 +632,29 @@ ChatChannelsEntry const* GetChannelEntryFor(uint32 channel_id)
     }
     return NULL;
 }
+
+ChatChannelsEntry const* GetChannelEntryFor(const std::string& name)
+{
+	// not sorted, numbering index from 0
+	for (uint32 i = 0; i < sChatChannelsStore.GetNumRows(); ++i)
+	{
+		ChatChannelsEntry const* ch = sChatChannelsStore.LookupEntry(i);
+		if (ch)
+		{
+			// need to remove %s from entryName if it exists before we match
+			std::string entryName (ch->pattern[0]);
+			std::size_t removeString = entryName.find("%s");
+
+			if (removeString != std::string::npos)
+				entryName.replace(removeString, 2, "");
+
+			if (name.find(entryName) != std::string::npos)
+				return ch;
+		}
+	}
+	return NULL;
+}
+
 /*[-ZERO]
 bool IsTotemCategoryCompatiableWith(uint32 itemTotemCategoryId, uint32 requiredTotemCategoryId)
 {

--- a/src/game/DBCStores.h
+++ b/src/game/DBCStores.h
@@ -48,6 +48,8 @@ uint32 GetVirtualMapForMapAndZone(uint32 mapid, uint32 zoneId);
 
 ChatChannelsEntry const* GetChannelEntryFor(uint32 channel_id);
 
+ChatChannelsEntry const* GetChannelEntryFor(const std::string& channel_id);
+
 // [-ZERO] bool IsTotemCategoryCompatiableWith(uint32 itemTotemCategoryId, uint32 requiredTotemCategoryId);
 
 bool Zone2MapCoordinates(float& x, float& y, uint32 zone);


### PR DESCRIPTION
Built-in channels weren't being found in the dbc's because the channel_id is always 0 (it is never sent in the join channel packet in classic). Using the channel name to match instead.

See issue:
https://github.com/cmangos/issues/issues/430
