### PR TITLE
Remerge branch, Fix Paladin Bonus Healing not scaling with gear with Flash of light and Holy Light

### DIFF
--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -3644,10 +3644,11 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
         }
         case SPELLFAMILY_PALADIN:
         {
+            Unit* caster = GetAffectiveCaster();
+            
             // Holy Light
             if (m_spellInfo->SpellIconID == 70)
             {
-                Unit* caster = GetAffectiveCaster();
 
                 if (!unitTarget || !unitTarget->isAlive())
                     return;


### PR DESCRIPTION
...Since Holy Light and Flash of Light are handled in their own, they need to have bonus healing added just like other healing does in SPELL_EFFECT_HEAL.
