### PR TITLE
Fix Paladin Bonus Healing not scaling with gear with Flash of light and Holy Light

### DIFF
--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -3644,13 +3644,20 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
         }
         case SPELLFAMILY_PALADIN:
         {
+            Unit* caster = GetAffectiveCaster();
+            
             // Holy Light
             if (m_spellInfo->SpellIconID == 70)
             {
+
                 if (!unitTarget || !unitTarget->isAlive())
                     return;
                 int32 heal = damage;
                 int32 spellid = m_spellInfo->Id;            // send main spell id as basepoints for not used effect
+
+                heal = caster->SpellHealingBonusDone(unitTarget, m_spellInfo, heal, HEAL); //Potential bug fix, added bonus healing from
+                heal = unitTarget->SpellHealingBonusTaken(caster, m_spellInfo, heal, HEAL); //caster and source as in spelleffect HEAL 10
+
                 m_caster->CastCustomSpell(unitTarget, 19968, &heal, &spellid, NULL, true);
             }
             // Flash of Light
@@ -3660,6 +3667,10 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
                     return;
                 int32 heal = damage;
                 int32 spellid = m_spellInfo->Id;            // send main spell id as basepoints for not used effect
+
+                heal = caster->SpellHealingBonusDone(unitTarget, m_spellInfo, heal, HEAL); //Potential bug fix, added bonus healing from
+                heal = unitTarget->SpellHealingBonusTaken(caster, m_spellInfo, heal, HEAL); //caster and source as in spelleffect HEAL 10
+                
                 m_caster->CastCustomSpell(unitTarget, 19993, &heal, &spellid, NULL, true);
             }
             else if (m_spellInfo->SpellFamilyFlags & UI64LIT(0x0000000000800000))


### PR DESCRIPTION
Since Holy Light and Flash of Light are handled in their own, they need to have bonus healing added just like other healing does in SPELL_EFFECT_HEAL.
