### PR TITLE
Removing column from gameobject_template (mangos.sql)

### DIFF
--- a/sql/mangos.sql
+++ b/sql/mangos.sql
@@ -1875,7 +1875,6 @@ CREATE TABLE `gameobject_template` (
   `type` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `displayId` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `name` varchar(100) NOT NULL DEFAULT '',
-  `castBarCaption` varchar(100) NOT NULL DEFAULT '',
   `faction` smallint(5) unsigned NOT NULL DEFAULT '0',
   `flags` int(10) unsigned NOT NULL DEFAULT '0',
   `size` float NOT NULL DEFAULT '1',


### PR DESCRIPTION
The gameobject_template.castBarCaption column is no longer in classicDB, it still being in the mangos.sql creates an error message on server startup when following Installation-Instructions, saying there are 34 columns expected. Removing the castBarCaption column fixed this.

Compare to:
https://github.com/classicdb/database/blob/classic/Full_DB/ClassicDB_1_4_1_z2525.sql
Lines 514330 - 514366
