### PR TITLE
Implement Inferno Spell for Baron Geddon

### DIFF
--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -1068,6 +1068,12 @@ void Aura::TriggerSpell()
                 triggerTarget->CastCustomSpell(triggerTarget, trigger_spell_id, &m_modifier.m_amount, NULL, NULL, true, NULL, this);
                 return;
             }
+            case 19695:                                     // Inferno
+            {
+                int32 damageForTick[8] = { 500, 500, 1000, 1000, 2000, 2000, 3000, 5000 };
+                triggerTarget->CastCustomSpell(triggerTarget, 19698, &damageForTick[GetAuraTicks() - 1], NULL, NULL, true, NULL);
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
damage values from official server http://i.imgur.com/WxKXkui.png
note: this patch is for classic, as the trigger spell was removed in bc. post bc version: https://github.com/krullgor/mangos-wotlk/commit/e622101b0b6d416beff5580ca392601595ea05a3