### PR TITLE
Fix MeleeDamageBonusTaken coeff calculation

### DIFF
--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -6106,7 +6106,7 @@ uint32 Unit::MeleeDamageBonusTaken(Unit* pCaster, uint32 pdamage, WeaponAttackTy
     if (!isWeaponDamageBasedSpell)
     {
         // apply benefit affected by spell power implicit coeffs and spell level penalties
-        TakenFlat = SpellBonusWithCoeffs(spellProto, 0, TakenFlat, 0, damagetype, false);
+        TakenFlat = pCaster->SpellBonusWithCoeffs(spellProto, 0, TakenFlat, 0, damagetype, false);
     }
 
     float tmpDamage = float(int32(pdamage) + TakenFlat * int32(stack)) * TakenPercent;


### PR DESCRIPTION
This change fixes cases when pVictim->MeleeDamageBonusTaken is called to
get Victims (In this case creatures) AURA_MOD_DAMAGE_TAKEN spell coeff
calculation.

Previously or as it is now when we enter MeleeDamageBonusTaken we will
never calculate coeff based on caster and this will return in bad
behaviour when fighting against Creatures in PVE Environment.

This applies to all cores.