### PR TITLE
Store cast item GUID in Spell to prevent crash when item is deleted

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -3723,6 +3723,7 @@ void Spell::TakeReagents()
                 }
 
                 m_CastItem = NULL;
+                m_CastItemGUID.Clear();
             }
         }
 
@@ -6261,6 +6262,7 @@ void Spell::ClearCastItem()
         m_targets.setItemTarget(NULL);
 
     m_CastItem = NULL;
+    m_CastItemGUID.Clear();
 }
 
 bool Spell::HasGlobalCooldown()

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -2477,6 +2477,9 @@ void Spell::prepare(SpellCastTargets const* targets, Aura* triggeredByAura)
 {
     m_targets = *targets;
 
+    if (m_CastItem)
+        m_CastItemGUID = m_CastItem->GetObjectGuid();
+
     m_spellState = SPELL_STATE_PREPARING;
 
     m_castPositionX = m_caster->GetPositionX();
@@ -2903,6 +2906,12 @@ void Spell::update(uint32 difftime)
     UpdatePointers();
 
     if (m_targets.getUnitTargetGuid() && !m_targets.getUnitTarget())
+    {
+        cancel();
+        return;
+    }
+
+    if (m_CastItemGUID && !m_CastItem)
     {
         cancel();
         return;
@@ -5819,6 +5828,11 @@ void Spell::UpdatePointers()
     UpdateOriginalCasterPointer();
 
     m_targets.Update(m_caster);
+
+    if (m_caster->GetTypeId() == TYPEID_PLAYER)
+        m_CastItem = ((Player *)m_caster)->GetItemByGuid(m_CastItemGUID);
+    else
+        m_CastItem = NULL;
 }
 
 bool Spell::CheckTargetCreatureType(Unit* target) const

--- a/src/game/Spell.h
+++ b/src/game/Spell.h
@@ -372,7 +372,10 @@ class Spell
         SpellEntry const* m_spellInfo;
         SpellEntry const* m_triggeredBySpellInfo;
         int32 m_currentBasePoints[MAX_EFFECT_INDEX];        // cache SpellEntry::CalculateSimpleValue and use for set custom base points
+
+        ObjectGuid m_CastItemGUID;
         Item* m_CastItem;
+
         SpellCastTargets m_targets;
 
         int32 GetCastTime() const { return m_casttime; }


### PR DESCRIPTION
If cast item is somehow deleted during a spell cast, a crash may occur when the spell is fired. The easiest way to reproduce it is to use the hearthstone and then throw it away until the cast finishes.