### PR TITLE
Classic Mistletoe Spell Fix

### DIFF
--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -3489,9 +3489,9 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
                     if (!unitTarget || unitTarget->GetTypeId() != TYPEID_PLAYER)
                         return;
 
-                    uint32 spells[3] = {26206, 26207, 45036};
+                    uint32 spells[2] = {26206, 26207};
 
-                    m_caster->CastSpell(unitTarget, spells[urand(0, 2)], true);
+                    m_caster->CastSpell(unitTarget, spells[urand(0, 1)], true);
                     return;
                 }
                 case 26275:                                 // PX-238 Winter Wondervolt TRAP


### PR DESCRIPTION
This spell included the handful of snowflakes spell (45036) which was not present in Classic (introduced with 2.3.0).  As a result sometimes nothing happens when players use this event functionality.  This fix ensures players will either get mistletoe or fresh holly everytime not withstanding the usual cooldowns.