### PR TITLE
Bodge fix for disarm trap spell having unlimited range

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4674,7 +4674,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                             !((Player*)m_caster)->CanUseBattleGroundObject())
                         return SPELL_FAILED_TRY_AGAIN;
 
-					if (((Player*)m_caster)->GetDistance(go->GetPositionX(), go->GetPositionY(), go->GetPositionZ()) > 5)
+					if (m_spellInfo->Id == 1842 && ((Player*)m_caster)->GetDistance(go) > 5)
 						return SPELL_FAILED_OUT_OF_RANGE;
 
                     lockId = go->GetGOInfo()->GetLockId();

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4674,6 +4674,9 @@ SpellCastResult Spell::CheckCast(bool strict)
                             !((Player*)m_caster)->CanUseBattleGroundObject())
                         return SPELL_FAILED_TRY_AGAIN;
 
+					if (((Player*)m_caster)->GetDistance(go->GetPositionX(), go->GetPositionY(), go->GetPositionZ()) > 5)
+						return SPELL_FAILED_OUT_OF_RANGE;
+
                     lockId = go->GetGOInfo()->GetLockId();
                     if (!lockId)
                         return SPELL_FAILED_ALREADY_OPEN;


### PR DESCRIPTION
This probably wants to be a lot cleaner, but it now correct returns "Out of range" on hunter traps