### PR TITLE
Fix fast corpse decay

### DIFF
--- a/src/game/Creature.cpp
+++ b/src/game/Creature.cpp
@@ -948,24 +948,6 @@ void Creature::PrepareBodyLootState()
 
     if (killer)
         loot = new Loot(killer, this, LOOT_CORPSE);
-
-    uint32 corpseLootedDelay;
-    if (sWorld.getConfig(CONFIG_FLOAT_RATE_CORPSE_DECAY_LOOTED) > 0.0f)
-        corpseLootedDelay = (uint32)((m_corpseDelay * IN_MILLISECONDS) * sWorld.getConfig(CONFIG_FLOAT_RATE_CORPSE_DECAY_LOOTED));
-    else
-        corpseLootedDelay = (m_respawnDelay * IN_MILLISECONDS) / 3;
-
-    // if m_respawnDelay is larger than default corpse delay always use corpseLootedDelay
-    if (m_respawnDelay > m_corpseDelay)
-    {
-        m_corpseDecayTimer = corpseLootedDelay;
-    }
-    else
-    {
-        // if m_respawnDelay is relatively short and corpseDecayTimer is larger than corpseLootedDelay
-        if (m_corpseDecayTimer > corpseLootedDelay)
-            m_corpseDecayTimer = corpseLootedDelay;
-    }
 }
 
 /**
@@ -2676,7 +2658,27 @@ void Creature::SetLootStatus(CreatureLootStatus status)
             if (m_creatureInfo->SkinningLootId)
                 SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SKINNABLE);
             else
+            {
+                uint32 corpseLootedDelay;
+                if (sWorld.getConfig(CONFIG_FLOAT_RATE_CORPSE_DECAY_LOOTED) > 0.0f)
+                    corpseLootedDelay = (uint32)((m_corpseDelay * IN_MILLISECONDS) * sWorld.getConfig(CONFIG_FLOAT_RATE_CORPSE_DECAY_LOOTED));
+                else
+                    corpseLootedDelay = (m_respawnDelay * IN_MILLISECONDS) / 3;
+
+                // if m_respawnDelay is larger than default corpse delay always use corpseLootedDelay
+                if (m_respawnDelay > m_corpseDelay)
+                {
+                    m_corpseDecayTimer = corpseLootedDelay;
+                }
+                else
+                {
+                    // if m_respawnDelay is relatively short and corpseDecayTimer is larger than corpseLootedDelay
+                    if (m_corpseDecayTimer > corpseLootedDelay)
+                        m_corpseDecayTimer = corpseLootedDelay;
+                }
+
                 RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
+            }
             break;
         case CREATURE_LOOT_STATUS_SKINNED:
             m_corpseDecayTimer = 0; // remove corpse at next update


### PR DESCRIPTION
Before update once creature has died we prepared his fast decay.
Now once creature has been fully looted it will decay fast.