### PR TITLE
5/8 set bonus is broken for hunter/warlock in T1 and T2 

### DIFF
--- a/src/game/Pet.cpp
+++ b/src/game/Pet.cpp
@@ -1030,6 +1030,8 @@ bool Pet::CreateBaseAtCreature(Creature* creature)
         SetUInt32Value(UNIT_MOD_CAST_SPEED, creature->GetUInt32Value(UNIT_MOD_CAST_SPEED));
         SetLoyaltyLevel(REBELLIOUS);
     }
+
+    SetCanModifyStats(true);
     return true;
 }
 

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -1088,14 +1088,14 @@ void Aura::TriggerSpell()
             case 21741: // Demonic Ally (warlock's T1 5/8 bonus)
             case 21922: // Demonic Ally (warlock's T2 5/8 bonus)
             {
-				if (Pet* pet = triggerTarget->GetPet())
-					if (SpellAuraHolder* holder = pet->GetSpellAuraHolder(trigger_spell_id))
-					{
-						holder->SetAuraDuration(4000);
-						return;
-					}
+                if (Pet* pet = triggerTarget->GetPet())
+                    if (SpellAuraHolder* holder = pet->GetSpellAuraHolder(trigger_spell_id))
+                    {
+                        holder->SetAuraDuration(4000);
+                        return;
+                    }
 
-				break;
+                break;
             }
         }
     }

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -3231,29 +3231,9 @@ void Aura::HandleModResistancePercent(bool apply, bool /*Real*/)
 
 void Aura::HandleModBaseResistance(bool apply, bool /*Real*/)
 {
-    // only players have base stats
-    if (GetTarget()->GetTypeId() != TYPEID_PLAYER)
-    {
-        // only pets have base stats
-        if (((Creature*)GetTarget())->IsPet())
-        {
-            if (m_modifier.m_miscvalue & SPELL_SCHOOL_MASK_NORMAL) {
-                GetTarget()->HandleStatModifier(UNIT_MOD_ARMOR, TOTAL_VALUE, float(m_modifier.m_amount), apply);
-            } 
-            else if (m_modifier.m_miscvalue & SPELL_SCHOOL_MASK_MAGIC)
-            {
-                for (int i = SPELL_SCHOOL_NORMAL; i < MAX_SPELL_SCHOOL; ++i)
-                    if (m_modifier.m_miscvalue & (1 << i))
-                        GetTarget()->HandleStatModifier(UnitMods(UNIT_MOD_RESISTANCE_START + i), TOTAL_VALUE, float(m_modifier.m_amount), apply);
-            }
-        }
-    }
-    else
-    {
-        for (int i = SPELL_SCHOOL_NORMAL; i < MAX_SPELL_SCHOOL; ++i)
-            if (m_modifier.m_miscvalue & (1 << i))
-                GetTarget()->HandleStatModifier(UnitMods(UNIT_MOD_RESISTANCE_START + i), TOTAL_VALUE, float(m_modifier.m_amount), apply);
-    }
+    for (int i = SPELL_SCHOOL_NORMAL; i < MAX_SPELL_SCHOOL; ++i)
+        if (m_modifier.m_miscvalue & (1 << i))
+            GetTarget()->HandleStatModifier(UnitMods(UNIT_MOD_RESISTANCE_START + i), TOTAL_VALUE, float(m_modifier.m_amount), apply);
 }
 
 /********************************/

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -1083,6 +1083,25 @@ void Aura::TriggerSpell()
                 triggerTarget->CastCustomSpell(triggerTarget, 19698, &damageForTick[GetAuraTicks() - 1], nullptr, nullptr, true, nullptr);
                 return;
             }
+            case 21926: // Nature's Ally (T1 5/8 bonus)
+            case 21928: // Nature's Ally (T2 5/8 bonus)
+            case 21741: // Demonic Ally (T1 5/8 bonus)
+            case 21922: // Demonic Ally (T2 5/8 bonus)
+            {
+                Pet* pet = triggerTarget->GetPet();
+
+                Pet::AuraList const& auras = pet->GetAurasByType(SPELL_AURA_MOD_STAT);
+
+                if (auras.size() == 0)
+                    break;
+
+                for (Pet::AuraList::const_iterator i = auras.begin(); i != auras.end(); ++i)
+                {
+                    (*i)->GetHolder()->SetAuraDuration(4000);
+                    continue;
+                }
+                return;
+            }
         }
     }
 

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -1083,24 +1083,19 @@ void Aura::TriggerSpell()
                 triggerTarget->CastCustomSpell(triggerTarget, 19698, &damageForTick[GetAuraTicks() - 1], nullptr, nullptr, true, nullptr);
                 return;
             }
-            case 21926: // Nature's Ally (T1 5/8 bonus)
-            case 21928: // Nature's Ally (T2 5/8 bonus)
-            case 21741: // Demonic Ally (T1 5/8 bonus)
-            case 21922: // Demonic Ally (T2 5/8 bonus)
+            case 21926: // Nature's Ally (hunter's T1 5/8 bonus)
+            case 21928: // Nature's Ally (hunter's T2 5/8 bonus)
+            case 21741: // Demonic Ally (warlock's T1 5/8 bonus)
+            case 21922: // Demonic Ally (warlock's T2 5/8 bonus)
             {
-                Pet* pet = triggerTarget->GetPet();
+				if (Pet* pet = triggerTarget->GetPet())
+					if (SpellAuraHolder* holder = pet->GetSpellAuraHolder(trigger_spell_id))
+					{
+						holder->SetAuraDuration(4000);
+						return;
+					}
 
-                Pet::AuraList const& auras = pet->GetAurasByType(SPELL_AURA_MOD_STAT);
-
-                if (auras.size() == 0)
-                    break;
-
-                for (Pet::AuraList::const_iterator i = auras.begin(); i != auras.end(); ++i)
-                {
-                    (*i)->GetHolder()->SetAuraDuration(4000);
-                    continue;
-                }
-                return;
+				break;
             }
         }
     }

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -3235,8 +3235,18 @@ void Aura::HandleModBaseResistance(bool apply, bool /*Real*/)
     if (GetTarget()->GetTypeId() != TYPEID_PLAYER)
     {
         // only pets have base stats
-        if (((Creature*)GetTarget())->IsPet() && (m_modifier.m_miscvalue & SPELL_SCHOOL_MASK_NORMAL))
-            GetTarget()->HandleStatModifier(UNIT_MOD_ARMOR, TOTAL_VALUE, float(m_modifier.m_amount), apply);
+        if (((Creature*)GetTarget())->IsPet())
+        {
+            if (m_modifier.m_miscvalue & SPELL_SCHOOL_MASK_NORMAL) {
+                GetTarget()->HandleStatModifier(UNIT_MOD_ARMOR, TOTAL_VALUE, float(m_modifier.m_amount), apply);
+            } 
+            else if (m_modifier.m_miscvalue & SPELL_SCHOOL_MASK_MAGIC)
+            {
+                for (int i = SPELL_SCHOOL_NORMAL; i < MAX_SPELL_SCHOOL; ++i)
+                    if (m_modifier.m_miscvalue & (1 << i))
+                        GetTarget()->HandleStatModifier(UnitMods(UNIT_MOD_RESISTANCE_START + i), TOTAL_VALUE, float(m_modifier.m_amount), apply);
+            }
+        }
     }
     else
     {

--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -3040,6 +3040,8 @@ void Spell::EffectSummonPet(SpellEffectIndex eff_idx)
         NewSummon->SavePetToDB(PET_SAVE_AS_CURRENT);
         ((Player*)m_caster)->PetSpellInitialize();
     }
+
+    NewSummon->SetCanModifyStats(true);
 }
 
 void Spell::EffectLearnPetSpell(SpellEffectIndex eff_idx)


### PR DESCRIPTION
Current PR includes fixes for resistance, hp aura bonus and small class-related fixes when pet wasn't affected by set bonus aura(when pet was tamed with 5/8 or 5/8 was weared prior to pet summon).

Fixes https://github.com/cmangos/issues/issues/640
