### PR TITLE
Added missing include for GCC

### DIFF
--- a/src/game/vmap/BIH.h
+++ b/src/game/vmap/BIH.h
@@ -25,6 +25,7 @@
 
 #include <Platform/Define.h>
 
+#include <stdexcept>
 #include <vector>
 #include <algorithm>
 


### PR DESCRIPTION
I mentioned this here:
https://github.com/cmangos/mangos-classic/commit/48a84fbfb6c30d81fb1b7467b071a1512112d50a#commitcomment-17476215

Figured I'll make a PR as well.