### PR TITLE
Protecting the Shipment quest fix

### DIFF
--- a/src/scriptdev2/scripts/eastern_kingdoms/loch_modan.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/loch_modan.cpp
@@ -133,11 +133,11 @@ struct npc_miranAI: public npc_escortAI
                 m_creature->SummonCreature(NPC_DARK_IRON_DWARF, m_afAmbushSpawn[1].m_fX, m_afAmbushSpawn[1].m_fY, m_afAmbushSpawn[1].m_fZ, m_afAmbushSpawn[1].m_fO, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 25000);
                 break;
             case 23:
-				if (Player* pPlayer = GetPlayerForEscort())
-				{
-					DoScriptText(SAY_MIRAN_3, m_creature);
-					pPlayer->GroupEventHappens(QUEST_PROTECTING_THE_SHIPMENT, m_creature);
-				}
+                if (Player* pPlayer = GetPlayerForEscort())
+                {
+                    DoScriptText(SAY_MIRAN_3, m_creature);
+                    pPlayer->GroupEventHappens(QUEST_PROTECTING_THE_SHIPMENT, m_creature);
+                }
                 break;
         }
     }

--- a/src/scriptdev2/scripts/eastern_kingdoms/loch_modan.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/loch_modan.cpp
@@ -133,9 +133,11 @@ struct npc_miranAI: public npc_escortAI
                 m_creature->SummonCreature(NPC_DARK_IRON_DWARF, m_afAmbushSpawn[1].m_fX, m_afAmbushSpawn[1].m_fY, m_afAmbushSpawn[1].m_fZ, m_afAmbushSpawn[1].m_fO, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 25000);
                 break;
             case 23:
-                DoScriptText(SAY_MIRAN_3, m_creature);
-                if (Player* pPlayer = GetPlayerForEscort())
-                    pPlayer->GroupEventHappens(QUEST_PROTECTING_THE_SHIPMENT, m_creature);
+				if (Player* pPlayer = GetPlayerForEscort())
+				{
+					DoScriptText(SAY_MIRAN_3, m_creature);
+					pPlayer->GroupEventHappens(QUEST_PROTECTING_THE_SHIPMENT, m_creature);
+				}
                 break;
         }
     }


### PR DESCRIPTION
Fixes quest 309 Protecting the Shipment by some magic of C++ which I have no knowledge of.
It was just common sense looking at the code that something wasn't right when I compared it to other code and hey presto now it works.
Used in conjunction with https://github.com/classicdb/database/pull/844