### PR TITLE
AURA_STATE_HEALTHLESS_20_PERCENT apply only on alive targets

### DIFF
--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -328,7 +328,9 @@ void Unit::Update(uint32 update_diff, uint32 p_time)
     // update abilities available only for fraction of time
     UpdateReactives(update_diff);
 
-    ModifyAuraState(AURA_STATE_HEALTHLESS_20_PERCENT, GetHealth() < GetMaxHealth() * 0.20f);
+    if (isAlive())
+        ModifyAuraState(AURA_STATE_HEALTHLESS_20_PERCENT, GetHealth() < GetMaxHealth() * 0.20f);
+
     UpdateSplineMovement(p_time);
     i_motionMaster.UpdateMotion(p_time);
 }


### PR DESCRIPTION
Fixed problem when spell events by AURA_STATE_HEALTHLESS_20_PERCENT procs on died target
It also can be applied to **mangos-tbc** and **mangos-wotlk**