### PR TITLE
fix extractors build errors on linux

### DIFF
--- a/contrib/mmap/src/MapBuilder.cpp
+++ b/contrib/mmap/src/MapBuilder.cpp
@@ -16,6 +16,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#include <limits.h>
+
 #include "MMapCommon.h"
 #include "MapBuilder.h"
 

--- a/src/game/MoveMapSharedDefines.h
+++ b/src/game/MoveMapSharedDefines.h
@@ -20,7 +20,7 @@
 #define _MOVE_MAP_SHARED_DEFINES_H
 
 #include "Platform/Define.h"
-#include "../recastnavigation/Detour/Include/DetourNavMesh.h"
+#include "../../dep/recastnavigation/Detour/Include/DetourNavMesh.h"
 
 #define MMAP_MAGIC 0x4d4d4150   // 'MMAP'
 #define MMAP_VERSION 4


### PR DESCRIPTION
`[ 98%] Building CXX object CMakeFiles/MoveMapGen.dir/src/MapBuilder.cpp.o
mangos-classic/contrib/mmap/src/MapBuilder.cpp: In member function 'void MMAP::MapBuilder::getGridBounds(uint32, uint32&, uint32&, uint32&, uint32&)':
mangos-classic/contrib/mmap/src/MapBuilder.cpp:156:16: error: 'INT_MAX' was not declared in this scope
         maxX = INT_MAX;
                ^
mangos-classic/contrib/mmap/src/MapBuilder.cpp:158:16: error: 'INT_MIN' was not declared in this scope
         minX = INT_MIN;
                ^
CMakeFiles/MoveMapGen.dir/build.make:110: recipe for target 'CMakeFiles/MoveMapGen.dir/src/MapBuilder.cpp.o' failed
make[2]: *** [CMakeFiles/MoveMapGen.dir/src/MapBuilder.cpp.o] Error 1
CMakeFiles/Makefile2:108: recipe for target 'CMakeFiles/MoveMapGen.dir/all' failed
make[1]: *** [CMakeFiles/MoveMapGen.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2`

`[ 96%] Building CXX object CMakeFiles/MoveMapGen.dir/src/IntermediateValues.cpp.o
In file included from mangos-classic/contrib/mmap/src/TerrainBuilder.h:24:0,
                 from mangos-classic/contrib/mmap/src/IntermediateValues.h:23,
                 from mangos-classic/contrib/mmap/src/IntermediateValues.cpp:19:
mangos-classic/contrib/mmap/../../src/shared/../../src/game/MoveMapSharedDefines.h:23:62: fatal error: ../recastnavigation/Detour/Include/DetourNavMesh.h: No such file or directory
 #include "../recastnavigation/Detour/Include/DetourNavMesh.h"
                                                              ^
compilation terminated.
CMakeFiles/MoveMapGen.dir/build.make:62: recipe for target 'CMakeFiles/MoveMapGen.dir/src/IntermediateValues.cpp.o' failed
make[2]: *** [CMakeFiles/MoveMapGen.dir/src/IntermediateValues.cpp.o] Error 1
CMakeFiles/Makefile2:108: recipe for target 'CMakeFiles/MoveMapGen.dir/all' failed
make[1]: *** [CMakeFiles/MoveMapGen.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2`

`mangos-classic/src/game/vmap/BIH.cpp: In member function 'void BIH::subdivide(int, int, std::vector<unsigned int>&, BIH::buildData&, AABound&, AABound&, int, int, BIH::BuildStats&)':
mangos-classic/src/game/vmap/BIH.cpp:60:19: error: 'logic_error' is not a member of 'std'
             throw std::logic_error("negative node extents");
                   ^
mangos-classic/src/game/vmap/BIH.cpp:66:23: error: 'logic_error' is not a member of 'std'
                 throw std::logic_error("invalid node overlap");
                       ^
CMakeFiles/vmap.dir/build.make:65: recipe for target 'CMakeFiles/vmap.dir/mangos-classic/src/game/vmap/BIH.cpp.o' failed
make[2]: *** [CMakeFiles/vmap.dir/mangos-classic/src/game/vmap/BIH.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory 'mangos-classic/contrib/vmap_assembler'
CMakeFiles/Makefile2:139: recipe for target 'CMakeFiles/vmap.dir/all' failed
make[1]: *** [CMakeFiles/vmap.dir/all] Error 2
make[1]: Leaving directory 'mangos-classic/contrib/vmap_assembler'
Makefile:86: recipe for target 'all' failed
make: *** [all] Error 2`