### PR TITLE
Implement elemental subdamage support

### DIFF
--- a/src/game/ItemPrototype.h
+++ b/src/game/ItemPrototype.h
@@ -525,6 +525,8 @@ struct ItemPrototype
 
     bool IsPotion() const { return Class == ITEM_CLASS_CONSUMABLE && SubClass == ITEM_SUBCLASS_POTION; }
     bool IsConjuredConsumable() const { return Class == ITEM_CLASS_CONSUMABLE && (Flags & ITEM_FLAG_CONJURED); }
+    bool IsWeapon() const { return Class == ITEM_CLASS_WEAPON; }
+    bool IsRangedWeapon() const { return IsWeapon() && (InventoryType == INVTYPE_RANGED || InventoryType == INVTYPE_THROWN || InventoryType == INVTYPE_RANGEDRIGHT); }
 };
 
 // GCC have alternative #pragma pack() syntax and old gcc version not support pack(pop), also any gcc version not support it at some platform

--- a/src/game/Player.h
+++ b/src/game/Player.h
@@ -1529,7 +1529,7 @@ class MANGOS_DLL_SPEC Player : public Unit
         void UpdateDamagePhysical(WeaponAttackType attType) override;
         void UpdateSpellDamageAndHealingBonus();
 
-        void CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, float& min_damage, float& max_damage);
+        void CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, float& min_damage, float& max_damage, uint8 index = 0);
 
         void UpdateDefenseBonusesMod();
         float GetMeleeCritFromAgility();

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -272,15 +272,11 @@ Spell::Spell(Unit* caster, SpellEntry const* info, bool triggered, ObjectGuid or
 
     m_spellSchoolMask = GetSpellSchoolMask(info);           // Can be override for some spell (wand shoot for example)
 
+    // wand case
     if (m_attackType == RANGED_ATTACK)
-    {
-        // wand case
-        if ((m_caster->getClassMask() & CLASSMASK_WAND_USERS) != 0 && m_caster->GetTypeId() == TYPEID_PLAYER)
-        {
-            if (Item* pItem = ((Player*)m_caster)->GetWeaponForAttack(RANGED_ATTACK))
-                m_spellSchoolMask = GetSchoolMask(pItem->GetProto()->Damage[0].DamageType);
-        }
-    }
+        if (!!(m_caster->getClassMask() & CLASSMASK_WAND_USERS) && m_caster->GetTypeId() == TYPEID_PLAYER)
+            m_spellSchoolMask = GetSchoolMask(m_caster->GetWeaponDamageSchool(RANGED_ATTACK));
+
     // Set health leech amount to zero
     m_healthLeech = 0;
 

--- a/src/game/StatSystem.cpp
+++ b/src/game/StatSystem.cpp
@@ -306,7 +306,7 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
     }
 }
 
-void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, float& min_damage, float& max_damage)
+void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, float& min_damage, float& max_damage, uint8 index)
 {
     UnitMods unitMod;
 
@@ -331,8 +331,8 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
     float total_value = GetModifierValue(unitMod, TOTAL_VALUE);
     float total_pct   = GetModifierValue(unitMod, TOTAL_PCT);
 
-    float weapon_mindamage = GetWeaponDamageRange(attType, MINDAMAGE);
-    float weapon_maxdamage = GetWeaponDamageRange(attType, MAXDAMAGE);
+    float weapon_mindamage = GetWeaponDamageRange(attType, MINDAMAGE, index);
+    float weapon_maxdamage = GetWeaponDamageRange(attType, MAXDAMAGE, index);
 
     if (IsInFeralForm())                                    // check if player is druid and in cat or bear forms, non main hand attacks not allowed for this mode so not check attack type
     {
@@ -352,6 +352,12 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
     {
         weapon_mindamage += GetAmmoDPS() * att_speed;
         weapon_maxdamage += GetAmmoDPS() * att_speed;
+    }
+
+    if (index != 0)
+    {
+        base_value = 0.0f;
+        total_value = 0.0f;
     }
 
     min_damage = ((base_value + weapon_mindamage) * base_pct + total_value) * total_pct;

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -218,9 +218,16 @@ Unit::Unit() :
 
     for (int i = 0; i < MAX_ATTACK; ++i)
     {
-        m_weaponDamage[i][MINDAMAGE] = BASE_MINDAMAGE;
-        m_weaponDamage[i][MAXDAMAGE] = BASE_MAXDAMAGE;
+        for (int j = 0; j < MAX_ITEM_PROTO_DAMAGES; j++)
+        {
+            m_weaponDamage[i][j].damage[MINDAMAGE] = (j == 0) ? BASE_MINDAMAGE : 0;
+            m_weaponDamage[i][j].damage[MAXDAMAGE] = (j == 0) ? BASE_MAXDAMAGE : 0;
+            m_weaponDamage[i][j].school = SPELL_SCHOOL_NORMAL;
+        }
+
+        m_weaponDamageCount[i] = 1;
     }
+
     for (int i = 0; i < MAX_STATS; ++i)
         m_createStats[i] = 0.0f;
 
@@ -1334,12 +1341,9 @@ void Unit::CalculateMeleeDamage(Unit* pVictim, CalcDamageInfo* damageInfo, Weapo
 {
     damageInfo->attacker         = this;
     damageInfo->target           = pVictim;
-    damageInfo->damageSchoolMask = GetMeleeDamageSchoolMask();
     damageInfo->attackType       = attackType;
-    damageInfo->damage           = 0;
+    damageInfo->totalDamage      = 0;
     damageInfo->cleanDamage      = 0;
-    damageInfo->absorb           = 0;
-    damageInfo->resist           = 0;
     damageInfo->blocked_amount   = 0;
 
     damageInfo->TargetState      = VICTIMSTATE_UNAFFECTED;
@@ -1376,25 +1380,49 @@ void Unit::CalculateMeleeDamage(Unit* pVictim, CalcDamageInfo* damageInfo, Weapo
             break;
     }
 
-    // Physical Immune check
-    if (damageInfo->target->IsImmuneToDamage(damageInfo->damageSchoolMask))
+    bool immune = true;
+
+    for (uint8 i = 0; i < m_weaponDamageCount[damageInfo->attackType]; i++)
     {
-        damageInfo->HitInfo       |= HITINFO_NORMALSWING;
-        damageInfo->TargetState    = VICTIMSTATE_IS_IMMUNE;
+        SubDamageInfo *subDamage = &damageInfo->subDamage[i];
+
+        subDamage->damageSchoolMask = GetSchoolMask(GetWeaponDamageSchool(damageInfo->attackType, i));
+
+        if (damageInfo->target->IsImmuneToDamage(subDamage->damageSchoolMask))
+        {
+            subDamage->damage = 0;
+            continue;
+        }
+        else
+            immune = false;
+
+        subDamage->damage = CalculateDamage(damageInfo->attackType, false, i);
+        // Add melee damage bonus
+        subDamage->damage = MeleeDamageBonusDone(damageInfo->target, subDamage->damage, damageInfo->attackType, nullptr, DIRECT_DAMAGE, 1, i == 0);
+        subDamage->damage = damageInfo->target->MeleeDamageBonusTaken(this, subDamage->damage, damageInfo->attackType, nullptr, DIRECT_DAMAGE, 1, i == 0);
+
+        // Calculate armor reduction
+        if(subDamage->damageSchoolMask == SPELL_SCHOOL_MASK_NORMAL)
+        {
+            damageInfo->cleanDamage += subDamage->damage;
+            subDamage->damage = CalcArmorReducedDamage(damageInfo->target, subDamage->damage);
+            damageInfo->cleanDamage -= subDamage->damage;
+        }
+
+        damageInfo->totalDamage += subDamage->damage;
+    }
+
+    // Physical Immune check
+    if (immune)
+    {
+        damageInfo->HitInfo |= HITINFO_NORMALSWING;
+        damageInfo->TargetState = VICTIMSTATE_IS_IMMUNE;
 
         damageInfo->procEx |= PROC_EX_IMMUNE;
-        damageInfo->damage         = 0;
-        damageInfo->cleanDamage    = 0;
+        damageInfo->totalDamage = 0;
+        damageInfo->cleanDamage = 0;
         return;
     }
-    uint32 damage = CalculateDamage(damageInfo->attackType, false);
-    // Add melee damage bonus
-    damage = MeleeDamageBonusDone(damageInfo->target, damage, damageInfo->attackType);
-    damage = damageInfo->target->MeleeDamageBonusTaken(this, damage, damageInfo->attackType);
-
-    // Calculate armor reduction
-    damageInfo->damage = CalcArmorReducedDamage(damageInfo->target, damage);
-    damageInfo->cleanDamage += damage - damageInfo->damage;
 
     damageInfo->hitOutCome = RollMeleeOutcomeAgainst(damageInfo->target, damageInfo->attackType);
 
@@ -1409,73 +1437,96 @@ void Unit::CalculateMeleeDamage(Unit* pVictim, CalcDamageInfo* damageInfo, Weapo
     {
         case MELEE_HIT_EVADE:
         {
-            damageInfo->HitInfo    |= HITINFO_MISS | HITINFO_SWINGNOHITSOUND;
+            damageInfo->HitInfo |= HITINFO_MISS | HITINFO_SWINGNOHITSOUND;
             damageInfo->TargetState = VICTIMSTATE_EVADES;
 
             damageInfo->procEx |= PROC_EX_EVADE;
-            damageInfo->damage = 0;
+            damageInfo->totalDamage = 0;
             damageInfo->cleanDamage = 0;
+
+            for (uint8 i = 0; i < m_weaponDamageCount[damageInfo->attackType]; i++)
+                damageInfo->subDamage[i].damage = 0;
+
             return;
         }
         case MELEE_HIT_MISS:
         {
-            damageInfo->HitInfo    |= HITINFO_MISS;
+            damageInfo->HitInfo |= HITINFO_MISS;
             damageInfo->TargetState = VICTIMSTATE_UNAFFECTED;
 
             damageInfo->procEx |= PROC_EX_MISS;
-            damageInfo->damage = 0;
+            damageInfo->totalDamage = 0;
             damageInfo->cleanDamage = 0;
+
+            for (uint8 i = 0; i < m_weaponDamageCount[damageInfo->attackType]; i++)
+                damageInfo->subDamage[i].damage = 0;
+
             break;
         }
         case MELEE_HIT_NORMAL:
+        {
             damageInfo->TargetState = VICTIMSTATE_NORMAL;
             damageInfo->procEx |= PROC_EX_NORMAL_HIT;
             break;
+        }
         case MELEE_HIT_CRIT:
         {
-            damageInfo->HitInfo     |= HITINFO_CRITICALHIT;
-            damageInfo->TargetState  = VICTIMSTATE_NORMAL;
+            damageInfo->HitInfo |= HITINFO_CRITICALHIT;
+            damageInfo->TargetState = VICTIMSTATE_NORMAL;
 
             damageInfo->procEx |= PROC_EX_CRITICAL_HIT;
-            // Crit bonus calc
-            damageInfo->damage += damageInfo->damage;
-            int32 mod = 0;
 
-            uint32 crTypeMask = damageInfo->target->GetCreatureTypeMask();
+            uint32 creatureTypeMask = damageInfo->target->GetCreatureTypeMask();
 
-            // Increase crit damage from SPELL_AURA_MOD_CRIT_PERCENT_VERSUS
-            mod += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_CRIT_PERCENT_VERSUS, crTypeMask);
-            if (mod != 0)
-                damageInfo->damage = int32((damageInfo->damage) * float((100.0f + mod) / 100.0f));
+            int32 mod = GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_CRIT_PERCENT_VERSUS, creatureTypeMask);
+
+            damageInfo->totalDamage = uint32((damageInfo->totalDamage) * float((200.0f + mod) / 100.0f));
+
+            for (uint8 i = 0; i < m_weaponDamageCount[damageInfo->attackType]; i++)
+                damageInfo->subDamage[i].damage = uint32((damageInfo->subDamage[i].damage) * float((200.0f + mod) / 100.0f));
+
             break;
         }
         case MELEE_HIT_PARRY:
-            damageInfo->TargetState  = VICTIMSTATE_PARRY;
-            damageInfo->procEx      |= PROC_EX_PARRY;
-            damageInfo->cleanDamage += damageInfo->damage;
-            damageInfo->damage = 0;
-            break;
+        {
+            damageInfo->TargetState = VICTIMSTATE_PARRY;
+            damageInfo->procEx |= PROC_EX_PARRY;
+            damageInfo->cleanDamage += damageInfo->totalDamage;
+            damageInfo->totalDamage = 0;
 
-        case MELEE_HIT_DODGE:
-            damageInfo->TargetState  = VICTIMSTATE_DODGE;
-            damageInfo->procEx      |= PROC_EX_DODGE;
-            damageInfo->cleanDamage += damageInfo->damage;
-            damageInfo->damage = 0;
+            for (uint8 i = 0; i < m_weaponDamageCount[damageInfo->attackType]; i++)
+                damageInfo->subDamage[i].damage = 0;
+
             break;
+        }
+        case MELEE_HIT_DODGE:
+        {
+            damageInfo->TargetState = VICTIMSTATE_DODGE;
+            damageInfo->procEx |= PROC_EX_DODGE;
+            damageInfo->cleanDamage += damageInfo->totalDamage;
+            damageInfo->totalDamage = 0;
+
+            for (uint8 i = 0; i < m_weaponDamageCount[damageInfo->attackType]; i++)
+                damageInfo->subDamage[i].damage = 0;
+
+            break;
+        }
         case MELEE_HIT_BLOCK:
         {
             damageInfo->TargetState = VICTIMSTATE_NORMAL;
-            damageInfo->procEx     |= PROC_EX_BLOCK;
+            damageInfo->procEx |= PROC_EX_BLOCK;
             damageInfo->blocked_amount = damageInfo->target->GetShieldBlockValue();
-            if (damageInfo->blocked_amount >= damageInfo->damage)
+
+            if (damageInfo->blocked_amount >= damageInfo->subDamage[0].damage)
             {
                 damageInfo->TargetState = VICTIMSTATE_BLOCKS;
-                damageInfo->blocked_amount = damageInfo->damage;
+                damageInfo->blocked_amount = damageInfo->subDamage[0].damage;
             }
             else
                 damageInfo->procEx |= PROC_EX_NORMAL_HIT;   // Partial blocks can still cause attacker procs
 
-            damageInfo->damage      -= damageInfo->blocked_amount;
+            damageInfo->totalDamage -= damageInfo->blocked_amount;
+            damageInfo->subDamage[0].damage -= damageInfo->blocked_amount;
             damageInfo->cleanDamage += damageInfo->blocked_amount;
             break;
         }
@@ -1528,42 +1579,58 @@ void Unit::CalculateMeleeDamage(Unit* pVictim, CalcDamageInfo* damageInfo, Weapo
 
             float reducePercent = lowEnd + rand_norm_f() * (highEnd - lowEnd);
 
-            damageInfo->cleanDamage += damageInfo->damage - uint32(reducePercent *  damageInfo->damage);
-            damageInfo->damage   = uint32(reducePercent *  damageInfo->damage);
+            damageInfo->cleanDamage += uint32((1.0f - reducePercent) * damageInfo->totalDamage);
+            damageInfo->totalDamage = uint32(reducePercent * damageInfo->totalDamage);
+
+            for (uint8 i = 0; i < m_weaponDamageCount[damageInfo->attackType]; i++)
+                damageInfo->subDamage[i].damage = uint32(reducePercent * damageInfo->subDamage[i].damage);
+
             break;
         }
         case MELEE_HIT_CRUSHING:
         {
-            damageInfo->HitInfo     |= HITINFO_CRUSHING;
-            damageInfo->TargetState  = VICTIMSTATE_NORMAL;
+            damageInfo->HitInfo |= HITINFO_CRUSHING;
+            damageInfo->TargetState = VICTIMSTATE_NORMAL;
             damageInfo->procEx |= PROC_EX_NORMAL_HIT;
-            // 150% normal damage
-            damageInfo->damage += (damageInfo->damage / 2);
+
+            // 150% of normal damage
+            damageInfo->totalDamage += damageInfo->totalDamage / 2;
+
+            for (uint8 i = 0; i < m_weaponDamageCount[damageInfo->attackType]; i++)
+                damageInfo->subDamage[i].damage += damageInfo->subDamage[i].damage / 2;
+
             break;
         }
         default:
-
             break;
     }
 
     // Calculate absorb resist
-    if (int32(damageInfo->damage) > 0)
+    if (int32(damageInfo->totalDamage) > 0)
     {
         damageInfo->procVictim |= PROC_FLAG_TAKEN_ANY_DAMAGE;
 
         // Calculate absorb & resists
-        damageInfo->target->CalculateDamageAbsorbAndResist(this, damageInfo->damageSchoolMask, DIRECT_DAMAGE, damageInfo->damage, &damageInfo->absorb, &damageInfo->resist, true);
-        damageInfo->damage -= damageInfo->absorb + damageInfo->resist;
-        if (damageInfo->absorb)
+        for (uint8 i = 0; i < m_weaponDamageCount[damageInfo->attackType]; i++)
         {
-            damageInfo->HitInfo |= HITINFO_ABSORB;
-            damageInfo->procEx |= PROC_EX_ABSORB;
+            SubDamageInfo *subDamage = &damageInfo->subDamage[i];
+
+            damageInfo->target->CalculateDamageAbsorbAndResist(this, subDamage->damageSchoolMask, DIRECT_DAMAGE, subDamage->damage, &subDamage->absorb, &subDamage->resist, true);
+            damageInfo->totalDamage -= subDamage->absorb + subDamage->resist;
+            subDamage->damage -= subDamage->absorb + subDamage->resist;
+
+            if (subDamage->absorb)
+            {
+                damageInfo->HitInfo |= HITINFO_ABSORB;
+                damageInfo->procEx |= PROC_EX_ABSORB;
+            }
+
+            if (subDamage->resist)
+                damageInfo->HitInfo |= HITINFO_RESIST;
         }
-        if (damageInfo->resist)
-            damageInfo->HitInfo |= HITINFO_RESIST;
     }
-    else // Umpossible get negative result but....
-        damageInfo->damage = 0;
+    else
+        damageInfo->totalDamage = 0;
 }
 
 void Unit::DealMeleeDamage(CalcDamageInfo* damageInfo, bool durabilityLoss)
@@ -1627,11 +1694,11 @@ void Unit::DealMeleeDamage(CalcDamageInfo* damageInfo, bool durabilityLoss)
 
     // Call default DealDamage
     CleanDamage cleanDamage(damageInfo->cleanDamage, damageInfo->attackType, damageInfo->hitOutCome);
-    DealDamage(pVictim, damageInfo->damage, &cleanDamage, DIRECT_DAMAGE, SpellSchoolMask(damageInfo->damageSchoolMask), nullptr, durabilityLoss);
+    DealDamage(pVictim, damageInfo->totalDamage, &cleanDamage, DIRECT_DAMAGE, SpellSchoolMask(damageInfo->subDamage[0].damageSchoolMask), nullptr, durabilityLoss);
 
     // If this is a creature and it attacks from behind it has a probability to daze it's victim
     if ((damageInfo->hitOutCome == MELEE_HIT_CRIT || damageInfo->hitOutCome == MELEE_HIT_CRUSHING || damageInfo->hitOutCome == MELEE_HIT_NORMAL || damageInfo->hitOutCome == MELEE_HIT_GLANCING) &&
-            GetTypeId() != TYPEID_PLAYER && !((Creature*)this)->GetCharmerOrOwnerGuid() && !pVictim->HasInArc(M_PI_F, this))
+            GetTypeId() != TYPEID_PLAYER && !((Creature*)this)->GetCharmerOrOwnerGuid() && !pVictim->HasInArc(M_PI_F, this) && damageInfo->totalDamage)
     {
         // -probability is between 0% and 40%
         // 20% base chance
@@ -1654,7 +1721,7 @@ void Unit::DealMeleeDamage(CalcDamageInfo* damageInfo, bool durabilityLoss)
     }
 
     // update at damage Judgement aura duration that applied by attacker at victim
-    if (damageInfo->damage)
+    if (damageInfo->totalDamage)
     {
         SpellAuraHolderMap const& vAuras = pVictim->GetSpellAuraHolderMap();
         for (SpellAuraHolderMap::const_iterator itr = vAuras.begin(); itr != vAuras.end(); ++itr)
@@ -2037,18 +2104,34 @@ void Unit::AttackerStateUpdate(Unit* pVictim, WeaponAttackType attType, bool ext
 
     CalcDamageInfo damageInfo;
     CalculateMeleeDamage(pVictim, &damageInfo, attType);
+
     // Send log damage message to client
-    DealDamageMods(pVictim, damageInfo.damage, &damageInfo.absorb);
+    for (uint8 i = 0; i < m_weaponDamageCount[attType]; i++)
+    {
+        damageInfo.totalDamage -= damageInfo.subDamage[i].damage;
+        DealDamageMods(pVictim, damageInfo.subDamage[i].damage, &damageInfo.subDamage[i].absorb);
+        damageInfo.totalDamage += damageInfo.subDamage[i].damage;
+    }
+
     SendAttackStateUpdate(&damageInfo);
-    ProcDamageAndSpell(damageInfo.target, damageInfo.procAttacker, damageInfo.procVictim, damageInfo.procEx, damageInfo.damage, damageInfo.attackType);
+    ProcDamageAndSpell(damageInfo.target, damageInfo.procAttacker, damageInfo.procVictim, damageInfo.procEx, damageInfo.totalDamage, damageInfo.attackType);
     DealMeleeDamage(&damageInfo, true);
+
+    uint32 totalAbsorb = 0;
+    uint32 totalResist = 0;
+
+    for (uint8 i = 0; i < m_weaponDamageCount[attType]; i++)
+    {
+        totalAbsorb += damageInfo.subDamage[i].absorb;
+        totalResist += damageInfo.subDamage[i].resist;
+    }
 
     if (GetTypeId() == TYPEID_PLAYER)
         DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "AttackerStateUpdate: (Player) %u attacked %u (TypeId: %u) for %u dmg, absorbed %u, blocked %u, resisted %u.",
-                         GetGUIDLow(), pVictim->GetGUIDLow(), pVictim->GetTypeId(), damageInfo.damage, damageInfo.absorb, damageInfo.blocked_amount, damageInfo.resist);
+                         GetGUIDLow(), pVictim->GetGUIDLow(), pVictim->GetTypeId(), damageInfo.totalDamage, totalAbsorb, damageInfo.blocked_amount, totalResist);
     else
         DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "AttackerStateUpdate: (NPC)    %u attacked %u (TypeId: %u) for %u dmg, absorbed %u, blocked %u, resisted %u.",
-                         GetGUIDLow(), pVictim->GetGUIDLow(), pVictim->GetTypeId(), damageInfo.damage, damageInfo.absorb, damageInfo.blocked_amount, damageInfo.resist);
+                         GetGUIDLow(), pVictim->GetGUIDLow(), pVictim->GetTypeId(), damageInfo.totalDamage, totalAbsorb, damageInfo.blocked_amount, totalResist);
 
     // if damage pVictim call AI reaction
     pVictim->AttackedBy(this);
@@ -2241,12 +2324,15 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(const Unit* pVictim, WeaponAttackT
     return MELEE_HIT_NORMAL;
 }
 
-uint32 Unit::CalculateDamage(WeaponAttackType attType, bool normalized)
+uint32 Unit::CalculateDamage(WeaponAttackType attType, bool normalized, uint8 index)
 {
     float min_damage, max_damage;
 
-    if (normalized && GetTypeId() == TYPEID_PLAYER)
-        ((Player*)this)->CalculateMinMaxDamage(attType, normalized, min_damage, max_damage);
+    if (GetTypeId() != TYPEID_PLAYER && index != 0)
+        return 0;
+
+    if ((normalized || index != 0) && GetTypeId() == TYPEID_PLAYER)
+        ((Player*)this)->CalculateMinMaxDamage(attType, normalized, min_damage, max_damage, index);
     else
     {
         switch (attType)
@@ -4519,29 +4605,32 @@ void Unit::SendAttackStateUpdate(CalcDamageInfo* damageInfo)
     DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "WORLD: Sending SMSG_ATTACKERSTATEUPDATE");
 
     WorldPacket data(SMSG_ATTACKERSTATEUPDATE, (16 + 45));  // we guess size
-    data << (uint32)damageInfo->HitInfo;
+
+    data << uint32(damageInfo->HitInfo);
     data << GetPackGUID();
     data << damageInfo->target->GetPackGUID();
-    data << (uint32)(damageInfo->damage);     // Full damage
+    data << uint32(damageInfo->totalDamage);    // Total damage
 
-    data << (uint8)1;                         // Sub damage count
-    //===  Sub damage description
-    data << uint32(GetFirstSchoolInMask(damageInfo->damageSchoolMask));
-    data << float(damageInfo->damage);        // sub damage
-    data << uint32(damageInfo->damage);       // Sub Damage
-    data << uint32(damageInfo->absorb);       // Absorb
-    data << uint32(damageInfo->resist);       // Resist
-    //=================================================
+    data << uint8(m_weaponDamageCount[damageInfo->attackType]);         // Sub damage count
+
+    // Sub damage description
+    for (uint8 i = 0; i < m_weaponDamageCount[damageInfo->attackType]; i++)
+    {
+        SubDamageInfo *subDamage = &damageInfo->subDamage[i];
+
+        data << uint32(GetFirstSchoolInMask(subDamage->damageSchoolMask));
+        data << float(subDamage->damage)/ float(damageInfo->totalDamage);        // Float coefficient of sub damage
+        data << uint32(subDamage->damage);
+        data << uint32(subDamage->absorb);
+        data << uint32(subDamage->resist);
+    }
     data << uint32(damageInfo->TargetState);
-    if (damageInfo->absorb == 0)                            // also 0x3E8 = 0x3E8, check when that happens
-        data << (uint32)0;
-    else
-        data << (uint32) - 1;
-
+    data << uint32(0);
     data << uint32(0);                                      // spell id, seen with heroic strike and disarm as examples.
     // HITINFO_NOACTION normally set if spell
     data << uint32(damageInfo->blocked_amount);
-    SendMessageToSet(&data, true);  /**/
+
+    SendMessageToSet(&data, true);
 }
 
 void Unit::SendAttackStateUpdate(uint32 HitInfo, Unit* target, SpellSchoolMask damageSchoolMask, uint32 Damage, uint32 AbsorbDamage, uint32 Resist, VictimState TargetState, uint32 BlockedAmount)
@@ -4550,10 +4639,12 @@ void Unit::SendAttackStateUpdate(uint32 HitInfo, Unit* target, SpellSchoolMask d
     dmgInfo.HitInfo = HitInfo;
     dmgInfo.attacker = this;
     dmgInfo.target = target;
-    dmgInfo.damage = Damage - AbsorbDamage - Resist - BlockedAmount;
-    dmgInfo.damageSchoolMask = damageSchoolMask;
-    dmgInfo.absorb = AbsorbDamage;
-    dmgInfo.resist = Resist;
+    dmgInfo.attackType = BASE_ATTACK;
+    dmgInfo.totalDamage = Damage - AbsorbDamage - Resist - BlockedAmount;
+    dmgInfo.subDamage[0].damage = dmgInfo.totalDamage;
+    dmgInfo.subDamage[0].damageSchoolMask = damageSchoolMask;
+    dmgInfo.subDamage[0].absorb = AbsorbDamage;
+    dmgInfo.subDamage[0].resist = Resist;
     dmgInfo.TargetState = TargetState;
     dmgInfo.blocked_amount = BlockedAmount;
     SendAttackStateUpdate(&dmgInfo);
@@ -5973,7 +6064,7 @@ bool Unit::IsImmuneToSpellEffect(SpellEntry const* spellInfo, SpellEffectIndex i
  * Calculates caster part of melee damage bonuses,
  * also includes different bonuses dependent from target auras
  */
-uint32 Unit::MeleeDamageBonusDone(Unit* pVictim, uint32 pdamage, WeaponAttackType attType, SpellEntry const* spellProto, DamageEffectType damagetype, uint32 stack)
+uint32 Unit::MeleeDamageBonusDone(Unit* pVictim, uint32 pdamage, WeaponAttackType attType, SpellEntry const* spellProto, DamageEffectType damagetype, uint32 stack, bool flat)
 {
     if (!pVictim || pdamage == 0)
         return pdamage;
@@ -6090,6 +6181,9 @@ uint32 Unit::MeleeDamageBonusDone(Unit* pVictim, uint32 pdamage, WeaponAttackTyp
         DoneTotal *= GetModifierValue(unitMod, TOTAL_PCT);
     }
 
+    if (!flat)
+        DoneTotal = 0.0f;
+
     float tmpDamage = float(int32(pdamage) + DoneTotal * int32(stack)) * DonePercent;
 
     // apply spellmod to Done damage
@@ -6107,7 +6201,7 @@ uint32 Unit::MeleeDamageBonusDone(Unit* pVictim, uint32 pdamage, WeaponAttackTyp
  * Calculates target part of melee damage bonuses,
  * will be called on each tick for periodic damage over time auras
  */
-uint32 Unit::MeleeDamageBonusTaken(Unit* pCaster, uint32 pdamage, WeaponAttackType attType, SpellEntry const* spellProto, DamageEffectType damagetype, uint32 stack)
+uint32 Unit::MeleeDamageBonusTaken(Unit* pCaster, uint32 pdamage, WeaponAttackType attType, SpellEntry const* spellProto, DamageEffectType damagetype, uint32 stack, bool flat)
 {
     if (!pCaster)
         return pdamage;
@@ -6154,6 +6248,9 @@ uint32 Unit::MeleeDamageBonusTaken(Unit* pCaster, uint32 pdamage, WeaponAttackTy
         // apply benefit affected by spell power implicit coeffs and spell level penalties
         TakenFlat = pCaster->SpellBonusWithCoeffs(spellProto, 0, TakenFlat, 0, damagetype, false);
     }
+
+    if (!flat)
+        TakenFlat = 0.0f;
 
     float tmpDamage = float(int32(pdamage) + TakenFlat * int32(stack)) * TakenPercent;
 
@@ -7598,12 +7695,12 @@ float Unit::GetTotalAttackPowerValue(WeaponAttackType attType) const
     }
 }
 
-float Unit::GetWeaponDamageRange(WeaponAttackType attType , WeaponDamageRange type) const
+float Unit::GetWeaponDamageRange(WeaponAttackType attType, WeaponDamageRange damageRange, uint8 index) const
 {
     if (attType == OFF_ATTACK && !haveOffhandWeapon())
         return 0.0f;
 
-    return m_weaponDamage[attType][type];
+    return m_weaponDamage[attType][index].damage[damageRange];
 }
 
 void Unit::SetLevel(uint32 lvl)

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -2649,12 +2649,19 @@ SpellMissInfo Unit::MagicSpellHitResult(Unit* pVictim, SpellEntry const* spell)
 //   Resist
 SpellMissInfo Unit::SpellHitResult(Unit* pVictim, SpellEntry const* spell, bool CanReflect)
 {
+    SpellSchoolMask schoolMask = GetSpellSchoolMask(spell);
+
+    // wand case
+    bool wand = spell->Id == 5019;
+    if (wand && !!(getClassMask() & CLASSMASK_WAND_USERS) && GetTypeId() == TYPEID_PLAYER)
+        schoolMask = GetSchoolMask(GetWeaponDamageSchool(RANGED_ATTACK));
+
     // Return evade for units in evade mode
     if (pVictim->GetTypeId() == TYPEID_UNIT && ((Creature*)pVictim)->IsInEvadeMode())
         return SPELL_MISS_EVADE;
 
     // Check for immune
-    if (pVictim->IsImmuneToSpell(spell, this == pVictim) && !spell->HasAttribute(SPELL_ATTR_UNAFFECTED_BY_INVULNERABILITY))
+    if (!wand && pVictim->IsImmuneToSpell(spell, this == pVictim) && !spell->HasAttribute(SPELL_ATTR_UNAFFECTED_BY_INVULNERABILITY))
         return SPELL_MISS_IMMUNE;
 
     // All positive spells can`t miss
@@ -2663,7 +2670,7 @@ SpellMissInfo Unit::SpellHitResult(Unit* pVictim, SpellEntry const* spell, bool 
         return SPELL_MISS_NONE;
 
     // Check for immune (use charges)
-    if (pVictim->IsImmuneToDamage(GetSpellSchoolMask(spell)) && !spell->HasAttribute(SPELL_ATTR_UNAFFECTED_BY_INVULNERABILITY))
+    if (pVictim->IsImmuneToDamage(schoolMask) && !spell->HasAttribute(SPELL_ATTR_UNAFFECTED_BY_INVULNERABILITY))
         return SPELL_MISS_IMMUNE;
 
     // Try victim reflect spell
@@ -2672,8 +2679,9 @@ SpellMissInfo Unit::SpellHitResult(Unit* pVictim, SpellEntry const* spell, bool 
         int32 reflectchance = pVictim->GetTotalAuraModifier(SPELL_AURA_REFLECT_SPELLS);
         Unit::AuraList const& mReflectSpellsSchool = pVictim->GetAurasByType(SPELL_AURA_REFLECT_SPELLS_SCHOOL);
         for (Unit::AuraList::const_iterator i = mReflectSpellsSchool.begin(); i != mReflectSpellsSchool.end(); ++i)
-            if ((*i)->GetModifier()->m_miscvalue & GetSpellSchoolMask(spell))
+            if ((*i)->GetModifier()->m_miscvalue & schoolMask)
                 reflectchance += (*i)->GetModifier()->m_amount;
+
         if (reflectchance > 0 && roll_chance_i(reflectchance))
         {
             // Start triggers for remove charges if need (trigger only for victim, and mark as active spell)


### PR DESCRIPTION
A few weapons has additional elemental damage, which included in base weapon damage, but calculates as elemental rules.
For example weapon 13982 (Warblade of Caer Darrow) has stats:
> 142 - 214 Damage
> +1 - 22 Frost Damage

It means, that weapon deals base 142-214 damage, which may blocks, armor reducing AND + 1-22 frost damage, which may partical resisted by frost resist or immune.
For detail info comments from old thottbot:
https://web.archive.org/web/20070616083320/http://www.thottbot.com/?i=20133
https://web.archive.org/web/20061231162604/http://www.thottbot.com/?i=3738

in fact, sending information about subdamage in SMSG_ATTACKERSTATEUPDATE carries no meaning to the client...

**Please test it, and point me out inaccuracies if you find any information!**