### PR TITLE
Fix display of pet mode and reaction after dismount

### DIFF
--- a/src/game/Pet.cpp
+++ b/src/game/Pet.cpp
@@ -1953,12 +1953,9 @@ void Pet::SynchronizeLevelWithOwner()
     }
 }
 
-void Pet::ApplyModeFlags(PetModeFlags mode, bool apply)
+void Pet::SetModeFlags(PetModeFlags mode)
 {
-    if (apply)
-        m_petModeFlags = PetModeFlags(m_petModeFlags | mode);
-    else
-        m_petModeFlags = PetModeFlags(m_petModeFlags & ~mode);
+    m_petModeFlags = mode;
 
     Unit* owner = GetOwner();
     if (!owner || owner->GetTypeId() != TYPEID_PLAYER)

--- a/src/game/Pet.h
+++ b/src/game/Pet.h
@@ -49,12 +49,17 @@ enum PetSaveMode
 // There might be a lot more
 enum PetModeFlags
 {
-    PET_MODE_UNKNOWN_0         = 0x0000001,
-    PET_MODE_UNKNOWN_2         = 0x0000100,
+    PET_MODE_STAY              = 0x0000000,
+    PET_MODE_FOLLOW            = 0x0000001,
+    PET_MODE_ATTACK            = 0x0000002,
+    PET_MODE_PASSIVE           = 0x0000000,
+    PET_MODE_DEFENSIVE         = 0x0000100,
+    PET_MODE_AGGRESSIVE        = 0x0000200,
+
     PET_MODE_DISABLE_ACTIONS   = 0x8000000,
 
     // autoset in client at summon
-    PET_MODE_DEFAULT           = PET_MODE_UNKNOWN_0 | PET_MODE_UNKNOWN_2,
+    PET_MODE_DEFAULT           = PET_MODE_FOLLOW | PET_MODE_DEFENSIVE,
 };
 
 enum HappinessState
@@ -227,7 +232,7 @@ class MANGOS_DLL_SPEC Pet : public Creature
         bool   HasTPForSpell(uint32 spellid);
         int32  GetTPForSpell(uint32 spellid);
 
-        void ApplyModeFlags(PetModeFlags mode, bool apply);
+        void SetModeFlags(PetModeFlags mode);
         PetModeFlags GetModeFlags() const { return m_petModeFlags; }
 
         bool HasSpell(uint32 spell) const override;

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -6236,7 +6236,7 @@ void Unit::Mount(uint32 mount, uint32 spellId)
             ((Player*)this)->UnsummonPetTemporaryIfAny();
         // Called by mount aura
         else if (Pet* pet = GetPet())
-            pet->ApplyModeFlags(PET_MODE_DISABLE_ACTIONS, true);
+            pet->SetModeFlags(PET_MODE_DISABLE_ACTIONS);
     }
 }
 
@@ -6257,7 +6257,8 @@ void Unit::Unmount(bool from_aura)
         SendMessageToSet(&data, true);
 
         if (Pet* pet = GetPet())
-            pet->ApplyModeFlags(PET_MODE_DISABLE_ACTIONS, false);
+            if (CharmInfo* charmInfo = pet->GetCharmInfo())
+                pet->SetModeFlags(PetModeFlags(charmInfo->GetReactState() | charmInfo->GetCommandState() * 0x100));
     }
 
     // only resummon old pet if the player is already added to a map


### PR DESCRIPTION
I think this can come in handy after recent pet work if the code works for you. (before this, after unmounting, the pet mode/reaction would always be follow/defensive even if you set your pet to anything else before mount)