### PR TITLE
Suppress default greeting text for quest dialog when interaction wit…

### DIFF
--- a/src/game/SpellHandler.cpp
+++ b/src/game/SpellHandler.cpp
@@ -285,6 +285,10 @@ void WorldSession::HandleGameObjectUseOpcode(WorldPacket& recv_data)
         return;
     }
 
+    // Supress default greeting text for quest dialog when interaction with quest giver game object is not appropiate.
+    if (obj->GetGoType() == GAMEOBJECT_TYPE_QUESTGIVER && !obj->ActivateToQuest(_player) && !obj->GetGOInfo()->GetGossipMenuId())
+        return;
+
     obj->Use(_player);
 }
 


### PR DESCRIPTION
Suppress default greeting text for quest dialog when interaction with quest giver game object is not appropriate. 

See [WANTED Poster Greets You #142](https://github.com/classicdb/database/issues/142#issuecomment-226333443) and [Gadgetzan #860](https://github.com/classicdb/database/issues/860) for more history and details motivating this pull request.