### PR TITLE
flag (no interact) quest GIVER Game Object when player not eligible for that quest

### DIFF
--- a/src/game/Object.cpp
+++ b/src/game/Object.cpp
@@ -517,9 +517,8 @@ void Object::BuildValuesUpdate(uint8 updatetype, ByteBuffer* data, UpdateMask* u
                                 break;
                         }
                     }
-                    else
+                    else    // flag (no interact) quest object when player not eligible for quest
                     {
-                        // flag (no interact) quest object when player not eligible for quest
                         if (gameObject->GetGoType() == GAMEOBJECT_TYPE_QUESTGIVER &&
                             !gameObject->ActivateToQuest(target) && !gameObject->GetGOInfo()->GetGossipMenuId())
                         {


### PR DESCRIPTION
Using GAMEOBJECT_DYN_FLAGS will flag quest giver Game Object (GO) GO_DYNFLAG_LO_NO_INTERACT if the player is not eligible for the quest. Lack of eligibility is determined by the player **not** being active to quest and there being no quest text to display. 

This was motivated by the need to suppress the default greeting text on various quest giver game object such as wanted posters when the player clicked on these items but was not eligible for that quest or that part of a quest chain etc.

See [WANTED Poster Greets You #142](https://github.com/classicdb/database/issues/142#issuecomment-226333443) and [Gadgetzan #860](https://github.com/classicdb/database/issues/860) for more history and details motivating this pull request.
