### PR TITLE
fix segfault when account tries to login twice

### DIFF
--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -187,7 +187,6 @@ World::AddSession_(WorldSession* s)
     if (!RemoveSession(s->GetAccountId()))
     {
         s->KickPlayer();
-        delete s;                                           // session not added yet in session list, so not listed in queue
         return;
     }
 


### PR DESCRIPTION
Whenever an account gets logged in twice, the server crashes.
See https://github.com/cmangos/issues/issues/979 and https://github.com/cmangos/issues/issues/977 for more information.