### PR TITLE
fix compile on linux

### DIFF
--- a/src/game/vmap/BIH.cpp
+++ b/src/game/vmap/BIH.cpp
@@ -19,6 +19,7 @@
 #include "BIH.h"
 
 #include <cmath>
+#include <stdexcept>
 
 void BIH::buildHierarchy(std::vector<uint32>& tempTree, buildData& dat, BuildStats& stats)
 {


### PR DESCRIPTION
add missing include which is required when compiling on linux.

See http://cmangos.net/thread-7398-post-45792.html and https://github.com/cmangos/issues/issues/1001 for more information.