### PR TITLE
fix crash when using eyes of the beast

### DIFF
--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -2127,7 +2127,7 @@ void Aura::HandleModPossessPet(bool apply, bool Real)
 
     if (apply)
     {
-        if (caster->GetTypeId() == TYPEID_PLAYER)
+        if (caster->GetTypeId() == TYPEID_CORPSE)
         {
             //remove any existing charm just in case
             caster->Uncharm();


### PR DESCRIPTION
fix server crashes whenever a hunter uses "eyes of the beast"

see https://github.com/cmangos/issues/issues/968 for more information.