### PR TITLE
Hunter Hit Chance

### DIFF
--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -2437,6 +2437,8 @@ float Unit::MeleeSpellMissChance(Unit* pVictim, WeaponAttackType attType, int32 
     // PvP - PvE melee chances
     if (pVictim->GetTypeId() == TYPEID_PLAYER)
         hitChance = 95.0f + skillDiff * 0.04f;
+    else if (attType == RANGED_ATTACK)
+        hitChance = 95.0f + skillDiff * 0.24f;
     else if (skillDiff < -10)
         hitChance = 93.0f + (skillDiff + 10) * 0.4f;        // 7% base chance to miss for big skill diff (%6 in 3.x)
     else


### PR DESCRIPTION
For ranged attacks gain 0,24 % +Hitchance per weaponskill. This results in 15*0,24 = 3,6% against bosses (as in every hunter guide described). This fix also ignores the bonus for lower weaponskill differences for melee classes. Melees got a bonus in classic, because they had glancings while ranged attacks dont.