### PR TITLE
Threat can not be negative 

### DIFF
--- a/src/game/ThreatManager.cpp
+++ b/src/game/ThreatManager.cpp
@@ -101,6 +101,9 @@ void HostileReference::fireStatusChanged(ThreatRefStatusChangeEvent& pThreatRefS
 
 void HostileReference::addThreat(float pMod)
 {
+    if (pMod + iThreat < 0)
+        pMod = -iThreat;
+
     iThreat += pMod;
     // the threat is changed. Source and target unit have to be availabe
     // if the link was cut before relink it again


### PR DESCRIPTION
Issue:
You can use threat modifying spells like Feint or Duck several times at the beginning of a fight. So you can have a negative threat value, which you should not be able to.

Sources:
KLHThreatmeter
The version for classic has the the same code as I used.

"A character's threat level cannot be negative." 
http://wowwiki.wikia.com/wiki/Threat?oldid=728711