### PR TITLE
Fix compiler warning

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -3543,7 +3543,7 @@ void SpellMgr::CheckUsedSpells(char const* table)
                 {
                     if (!spellEntry->IsFitToFamilyMask(familyMask))
                     {
-                        sLog.outError("Spell %u '%s' not fit to (" I64FMT ") but used in %s.", spell, name.c_str(), familyMask, code.c_str());
+                        sLog.outError("Spell %u '%s' not fit to (" I64FMT ") but used in %s.", spell, name.c_str(), long long unsigned int(familyMask), code.c_str());
                         continue;
                     }
                 }
@@ -3658,10 +3658,10 @@ void SpellMgr::CheckUsedSpells(char const* table)
             {
                 if (effectIdx >= 0)
                     sLog.outError("Spells '%s' not found for family %i (" I64FMT ") icon(%i) visual(%i) category(%i) effect%d(%i) aura%d(%i) but used in %s",
-                                  name.c_str(), family, familyMask, spellIcon, spellVisual, category, effectIdx + 1, effectType, effectIdx + 1, auraType, code.c_str());
+                                  name.c_str(), family, long long unsigned int(familyMask), spellIcon, spellVisual, category, effectIdx + 1, effectType, effectIdx + 1, auraType, code.c_str());
                 else
                     sLog.outError("Spells '%s' not found for family %i (" I64FMT ") icon(%i) visual(%i) category(%i) effect(%i) aura(%i) but used in %s",
-                                  name.c_str(), family, familyMask, spellIcon, spellVisual, category, effectType, auraType, code.c_str());
+                                  name.c_str(), family, long long unsigned int(familyMask), spellIcon, spellVisual, category, effectType, auraType, code.c_str());
                 continue;
             }
         }


### PR DESCRIPTION
Fix compiler warnings

SpellMgr.cpp: In member function ‘void SpellMgr::CheckUsedSpells(const char*)’:
SpellMgr.cpp:3546:141: warning: format ‘%llX’ expects argument of type ‘long long unsigned int’, but argument 5 has type ‘uint64 {aka long unsigned int}’ [-Wformat=]
                         sLog.outError("Spell %u '%s' not fit to (" I64FMT ") but used in %s.", spell, name.c_str(), familyMask, code.c_str());
                                                                                                                                             ^
SpellMgr.cpp:3661:167: warning: format ‘%llX’ expects argument of type ‘long long unsigned int’, but argument 5 has type ‘uint64 {aka long unsigned int}’ [-Wformat=]
                                   name.c_str(), family, familyMask, spellIcon, spellVisual, category, effectIdx + 1, effectType, effectIdx + 1, auraType, code.c_str());
                                                                                                                                                                       ^
SpellMgr.cpp:3664:137: warning: format ‘%llX’ expects argument of type ‘long long unsigned int’, but argument 5 has type ‘uint64 {aka long unsigned int}’ [-Wformat=]
                                   name.c_str(), family, familyMask, spellIcon, spellVisual, category, effectType, auraType, code.c_str());