### PR TITLE
Make spell miss visuals work

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -3335,31 +3335,52 @@ void Spell::WriteAmmoToPacket(WorldPacket* data)
 
 void Spell::WriteSpellGoTargets(WorldPacket* data)
 {
+    size_t count_pos = data->wpos();
+    *data << uint8(0);                                      // placeholder
+
     // This function also fill data for channeled spells:
     // m_needAliveTargetMask req for stop channeling if one target die
-    // Always hits on GO and expected all targets for Units
-    *data << (uint8)(m_UniqueTargetInfo.size() + m_UniqueGOTargetInfo.size());
+    uint32 hit  = m_UniqueGOTargetInfo.size();              // Always hits on GO
+    uint32 miss = 0;
 
     for (TargetList::iterator ihit = m_UniqueTargetInfo.begin(); ihit != m_UniqueTargetInfo.end(); ++ihit)
     {
-        *data << ihit->targetGUID;                          // in 1.12.1 expected all targets
-
         if (ihit->effectMask == 0)                          // No effect apply - all immuned add state
         {
             // possibly SPELL_MISS_IMMUNE2 for this??
             ihit->missCondition = SPELL_MISS_IMMUNE2;
+            ++miss;
         }
         else if (ihit->missCondition == SPELL_MISS_NONE)    // Add only hits
+        {
+            ++hit;
+            *data << ihit->targetGUID;
             m_needAliveTargetMask |= ihit->effectMask;
-        else if (IsChanneledSpell(m_spellInfo) && ihit->missCondition == SPELL_MISS_RESIST)
-            m_duration = 0;                                 // cancel aura to avoid visual effect continue
+        }
+        else
+        {
+            if (IsChanneledSpell(m_spellInfo) && ihit->missCondition == SPELL_MISS_RESIST)
+                m_duration = 0;                             // cancel aura to avoid visual effect continue
+            ++miss;
+        }
     }
 
     for (GOTargetList::const_iterator ighit = m_UniqueGOTargetInfo.begin(); ighit != m_UniqueGOTargetInfo.end(); ++ighit)
         *data << ighit->targetGUID;                         // Always hits
 
-    *data << uint8(0);                                      // unknown, not miss
+    data->put<uint8>(count_pos, hit);
 
+    *data << (uint8)miss;
+    for (TargetList::const_iterator ihit = m_UniqueTargetInfo.begin(); ihit != m_UniqueTargetInfo.end(); ++ihit)
+    {
+        if (ihit->missCondition != SPELL_MISS_NONE)         // Add only miss
+        {
+            *data << ihit->targetGUID;
+            *data << uint8(ihit->missCondition);
+            if (ihit->missCondition == SPELL_MISS_REFLECT)
+                *data << uint8(ihit->reflectResult);
+        }
+    }
     // Reset m_needAliveTargetMask for non channeled spell
     if (!IsChanneledSpell(m_spellInfo))
         m_needAliveTargetMask = 0;


### PR DESCRIPTION
For reasons unknown to me, Spell::WriteSpellGoTargets in mangos-classic writes all targets as if they were hit, even if they were not. Because of this, all spells visually hit the target in the game.

I've checked SMSG_SPELL_GO packet handler in 1.12.1 client. It's exactly the same in this part as in WotLK and even later patches. So I took Spell::WriteSpellGoTargets code from mangos-wotlk and now spell resists, absorbs, reflects, etc. are shown correctly.