### PR TITLE
Implementation of time-based one-time password & fixed PIN authentication

### DIFF
--- a/sql/base/realmd.sql
+++ b/sql/base/realmd.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.13  Distrib 5.6.17, for Win64 (x86_64)
+-- MySQL dump 10.13
 --
--- Host: 127.0.0.1    Database: realmd3
+-- Host: localhost    Database: realmd
 -- ------------------------------------------------------
--- Server version 5.6.21
+-- Server version	5.6.21
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -40,8 +40,7 @@ CREATE TABLE `account` (
   `expansion` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `mutetime` bigint(40) unsigned NOT NULL DEFAULT '0',
   `locale` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `security` int(11) DEFAULT '0',
-  `pin` int(11) DEFAULT '0',
+  `security` varchar(16) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_username` (`username`),
   KEY `idx_gmlevel` (`gmlevel`)
@@ -54,7 +53,7 @@ CREATE TABLE `account` (
 
 LOCK TABLES `account` WRITE;
 /*!40000 ALTER TABLE `account` DISABLE KEYS */;
-INSERT INTO `account` VALUES (1,'ADMINISTRATOR','a34b29541b87b7e4823683ce6c7bf6ae68beaaac',3,'','0','0','','2006-04-25 10:18:56','127.0.0.1',0,0,'0000-00-00 00:00:00',0,0,0,0,0,0),(2,'GAMEMASTER','7841e21831d7c6bc0b57fbe7151eb82bd65ea1f9',2,'','0','0','','2006-04-25 10:18:56','127.0.0.1',0,0,'0000-00-00 00:00:00',0,0,0,0,0,0),(3,'MODERATOR','a7f5fbff0b4eec2d6b6e78e38e8312e64d700008',1,'','0','0','','2006-04-25 10:19:35','127.0.0.1',0,0,'0000-00-00 00:00:00',0,0,0,0,0,0),(4,'PLAYER','3ce8a96d17c5ae88a30681024e86279f1a38c041',0,'','0','0','','2006-04-25 10:19:35','127.0.0.1',0,0,'0000-00-00 00:00:00',0,0,0,0,0,0);
+INSERT INTO `account` VALUES (1,'ADMINISTRATOR','a34b29541b87b7e4823683ce6c7bf6ae68beaaac',3,'','0','0','','2006-04-25 10:18:56','127.0.0.1',0,0,'0000-00-00 00:00:00',0,0,0,0,NULL),(2,'GAMEMASTER','7841e21831d7c6bc0b57fbe7151eb82bd65ea1f9',2,'','0','0','','2006-04-25 10:18:56','127.0.0.1',0,0,'0000-00-00 00:00:00',0,0,0,0,NULL),(3,'MODERATOR','a7f5fbff0b4eec2d6b6e78e38e8312e64d700008',1,'','0','0','','2006-04-25 10:19:35','127.0.0.1',0,0,'0000-00-00 00:00:00',0,0,0,0,NULL),(4,'PLAYER','3ce8a96d17c5ae88a30681024e86279f1a38c041',0,'','0','0','','2006-04-25 10:19:35','127.0.0.1',0,0,'0000-00-00 00:00:00',0,0,0,0,NULL);
 /*!40000 ALTER TABLE `account` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -144,7 +143,7 @@ DROP TABLE IF EXISTS `realmd_db_version`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `realmd_db_version` (
-  `required_z2678_01_realmd` bit(1) DEFAULT NULL
+  `required_z2685_01_realmd` bit(1) DEFAULT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Last applied sql update to DB';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -226,4 +225,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-09-05  6:29:23
+-- Dump completed on 2016-09-07  6:59:39

--- a/sql/base/realmd.sql
+++ b/sql/base/realmd.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.13
+-- MySQL dump 10.13  Distrib 5.6.17, for Win64 (x86_64)
 --
--- Host: localhost    Database: realmd
+-- Host: 127.0.0.1    Database: realmd3
 -- ------------------------------------------------------
--- Server version	5.5.32
+-- Server version 5.6.21
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -16,30 +16,12 @@
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 
 --
--- Table structure for table `realmd_db_version`
---
-
-DROP TABLE IF EXISTS `realmd_db_version`;
-CREATE TABLE `realmd_db_version` (
-  `required_z2678_01_realmd` bit(1) DEFAULT NULL
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Last applied sql update to DB';
-
---
--- Dumping data for table `realmd_db_version`
---
-
-LOCK TABLES `realmd_db_version` WRITE;
-/*!40000 ALTER TABLE `realmd_db_version` DISABLE KEYS */;
-INSERT INTO `realmd_db_version` VALUES
-(NULL);
-/*!40000 ALTER TABLE `realmd_db_version` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
 -- Table structure for table `account`
 --
 
 DROP TABLE IF EXISTS `account`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `account` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Identifier',
   `username` varchar(32) NOT NULL DEFAULT '',
@@ -58,10 +40,13 @@ CREATE TABLE `account` (
   `expansion` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `mutetime` bigint(40) unsigned NOT NULL DEFAULT '0',
   `locale` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `security` int(11) DEFAULT '0',
+  `pin` int(11) DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_username` (`username`),
   KEY `idx_gmlevel` (`gmlevel`)
 ) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Account System';
+/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Dumping data for table `account`
@@ -69,11 +54,7 @@ CREATE TABLE `account` (
 
 LOCK TABLES `account` WRITE;
 /*!40000 ALTER TABLE `account` DISABLE KEYS */;
-INSERT INTO `account` VALUES
-(1,'ADMINISTRATOR','a34b29541b87b7e4823683ce6c7bf6ae68beaaac',3,'','0','0','','2006-04-25 10:18:56','127.0.0.1',0,0,'0000-00-00 00:00:00',0,0,0,0),
-(2,'GAMEMASTER','7841e21831d7c6bc0b57fbe7151eb82bd65ea1f9',2,'','0','0','','2006-04-25 10:18:56','127.0.0.1',0,0,'0000-00-00 00:00:00',0,0,0,0),
-(3,'MODERATOR','a7f5fbff0b4eec2d6b6e78e38e8312e64d700008',1,'','0','0','','2006-04-25 10:19:35','127.0.0.1',0,0,'0000-00-00 00:00:00',0,0,0,0),
-(4,'PLAYER','3ce8a96d17c5ae88a30681024e86279f1a38c041',0,'','0','0','','2006-04-25 10:19:35','127.0.0.1',0,0,'0000-00-00 00:00:00',0,0,0,0);
+INSERT INTO `account` VALUES (1,'ADMINISTRATOR','a34b29541b87b7e4823683ce6c7bf6ae68beaaac',3,'','0','0','','2006-04-25 10:18:56','127.0.0.1',0,0,'0000-00-00 00:00:00',0,0,0,0,0,0),(2,'GAMEMASTER','7841e21831d7c6bc0b57fbe7151eb82bd65ea1f9',2,'','0','0','','2006-04-25 10:18:56','127.0.0.1',0,0,'0000-00-00 00:00:00',0,0,0,0,0,0),(3,'MODERATOR','a7f5fbff0b4eec2d6b6e78e38e8312e64d700008',1,'','0','0','','2006-04-25 10:19:35','127.0.0.1',0,0,'0000-00-00 00:00:00',0,0,0,0,0,0),(4,'PLAYER','3ce8a96d17c5ae88a30681024e86279f1a38c041',0,'','0','0','','2006-04-25 10:19:35','127.0.0.1',0,0,'0000-00-00 00:00:00',0,0,0,0,0,0);
 /*!40000 ALTER TABLE `account` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -82,6 +63,8 @@ UNLOCK TABLES;
 --
 
 DROP TABLE IF EXISTS `account_banned`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `account_banned` (
   `id` int(11) NOT NULL DEFAULT '0' COMMENT 'Account id',
   `bandate` bigint(40) NOT NULL DEFAULT '0',
@@ -91,6 +74,7 @@ CREATE TABLE `account_banned` (
   `active` tinyint(4) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`,`bandate`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Ban List';
+/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Dumping data for table `account_banned`
@@ -106,6 +90,8 @@ UNLOCK TABLES;
 --
 
 DROP TABLE IF EXISTS `ip_banned`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ip_banned` (
   `ip` varchar(32) NOT NULL DEFAULT '0.0.0.0',
   `bandate` bigint(40) NOT NULL,
@@ -114,6 +100,7 @@ CREATE TABLE `ip_banned` (
   `banreason` varchar(255) NOT NULL DEFAULT 'no reason',
   PRIMARY KEY (`ip`,`bandate`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Banned IPs';
+/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Dumping data for table `ip_banned`
@@ -129,6 +116,8 @@ UNLOCK TABLES;
 --
 
 DROP TABLE IF EXISTS `realmcharacters`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `realmcharacters` (
   `realmid` int(11) unsigned NOT NULL DEFAULT '0',
   `acctid` bigint(20) unsigned NOT NULL,
@@ -136,6 +125,7 @@ CREATE TABLE `realmcharacters` (
   PRIMARY KEY (`realmid`,`acctid`),
   KEY `acctid` (`acctid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Realm Character Tracker';
+/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Dumping data for table `realmcharacters`
@@ -147,10 +137,34 @@ LOCK TABLES `realmcharacters` WRITE;
 UNLOCK TABLES;
 
 --
+-- Table structure for table `realmd_db_version`
+--
+
+DROP TABLE IF EXISTS `realmd_db_version`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `realmd_db_version` (
+  `required_z2678_01_realmd` bit(1) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Last applied sql update to DB';
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `realmd_db_version`
+--
+
+LOCK TABLES `realmd_db_version` WRITE;
+/*!40000 ALTER TABLE `realmd_db_version` DISABLE KEYS */;
+INSERT INTO `realmd_db_version` VALUES (NULL);
+/*!40000 ALTER TABLE `realmd_db_version` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
 -- Table structure for table `realmlist`
 --
 
 DROP TABLE IF EXISTS `realmlist`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `realmlist` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(32) NOT NULL DEFAULT '',
@@ -165,6 +179,7 @@ CREATE TABLE `realmlist` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_name` (`name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Realm System';
+/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Dumping data for table `realmlist`
@@ -172,8 +187,7 @@ CREATE TABLE `realmlist` (
 
 LOCK TABLES `realmlist` WRITE;
 /*!40000 ALTER TABLE `realmlist` DISABLE KEYS */;
-INSERT INTO `realmlist` VALUES
-(1,'MaNGOS','127.0.0.1',8085,1,0,1,0,0,'');
+INSERT INTO `realmlist` VALUES (1,'MaNGOS','127.0.0.1',8085,1,0,1,0,0,'');
 /*!40000 ALTER TABLE `realmlist` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -182,6 +196,8 @@ UNLOCK TABLES;
 --
 
 DROP TABLE IF EXISTS `uptime`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `uptime` (
   `realmid` int(11) unsigned NOT NULL,
   `starttime` bigint(20) unsigned NOT NULL DEFAULT '0',
@@ -190,6 +206,7 @@ CREATE TABLE `uptime` (
   `maxplayers` smallint(5) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`realmid`,`starttime`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Uptime system';
+/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Dumping data for table `uptime`
@@ -209,4 +226,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2013-09-10  0:00:00
+-- Dump completed on 2016-09-05  6:29:23

--- a/sql/updates/realmd/z2685_01_realmd_account.sql
+++ b/sql/updates/realmd/z2685_01_realmd_account.sql
@@ -1,0 +1,3 @@
+ALTER TABLE realmd_db_version CHANGE COLUMN required_z2678_01_realmd required_z2685_01_realmd BIT(1) NULL DEFAULT NULL;
+
+ALTER TABLE account ADD COLUMN security VARCHAR(16) NULL DEFAULT NULL AFTER locale;

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -27,6 +27,7 @@
 #include "RealmList.h"
 #include "AuthSocket.h"
 #include "AuthCodes.h"
+#include "Util.h"
 
 #include <openssl/md5.h>
 //#include "Util.h" -- for commented utf8ToUpperOnlyLatin
@@ -135,6 +136,11 @@ typedef struct AUTH_RECONNECT_PROOF_C
     uint8   R3[20];
     uint8   number_of_keys;
 } sAuthReconnectProof_C;
+
+struct PINData {
+	uint8 salt[16];
+	uint8 hash[20];
+};
 
 typedef struct XFER_INIT
 {
@@ -373,7 +379,7 @@ bool AuthSocket::_HandleLogonChallenge()
         ///- Get the account details from the account table
         // No SQL injection (escaped user name)
 
-        result = LoginDatabase.PQuery("SELECT sha_pass_hash,id,locked,last_ip,gmlevel,v,s FROM account WHERE username = '%s'", _safelogin.c_str());
+        result = LoginDatabase.PQuery("SELECT sha_pass_hash,id,locked,last_ip,gmlevel,v,s,security,pin FROM account WHERE username = '%s'", _safelogin.c_str());
         if (result)
         {
             ///- If the IP is 'locked', check that the player comes indeed from the correct IP address
@@ -458,14 +464,20 @@ bool AuthSocket::_HandleLogonChallenge()
                     pkt.append(N.AsByteArray(32), 32);
                     pkt.append(s.AsByteArray(), s.GetNumBytes());// 32 bytes
                     pkt.append(unk3.AsByteArray(16), 16);
-                    uint8 securityFlags = 0;
-                    pkt << uint8(securityFlags);            // security flags (0x0...0x04)
+                    securityFlags = (*result)[7].GetUInt8();
 
-                    if (securityFlags & 0x01)               // PIN input
+                    if (securityFlags)               // PIN input
                     {
-                        pkt << uint32(0);
-                        pkt << uint64(0) << uint64(0);      // 16 bytes hash?
-                    }
+						BASIC_LOG("[AuthChallenge] account %s is using PIN authentication", _login.c_str());
+						pkt << uint8(1); // securityFlags, only '1' is available in classic (PIN input)
+						pin = (*result)[8].GetUInt32();
+						gridSeed = static_cast<uint32>(rand32());
+						serverSecuritySalt.SetRand(16 * 8); // 16 bytes random
+                        pkt << gridSeed;
+						pkt.append(serverSecuritySalt.AsByteArray(16), 16);
+					} else {
+						pkt << uint8(0);
+					}
 
                     uint8 secLevel = (*result)[4].GetUInt8();
                     _accountSecurityLevel = secLevel <= SEC_ADMINISTRATOR ? AccountTypes(secLevel) : SEC_ADMINISTRATOR;
@@ -496,6 +508,12 @@ bool AuthSocket::_HandleLogonProof()
     sAuthLogonProof_C lp;
     if (!Read((char*)&lp, sizeof(sAuthLogonProof_C)))
         return false;
+
+	PINData pinData;
+	if(lp.securityFlags) {
+		if(!Read((char*)&pinData, sizeof(pinData)))
+			return false;
+	}
 
     /// <ul><li> If the client has no valid version
     if (!FindBuildInfo(_build))
@@ -586,8 +604,19 @@ bool AuthSocket::_HandleLogonProof()
     BigNumber M;
     M.SetBinary(sha.GetDigest(), 20);
 
+	///- Check PIN data is correct
+	bool pinResult = true;
+
+	if(securityFlags && !lp.securityFlags) {
+		pinResult = false; // expected PIN data but did not receive it
+	}
+
+	if(securityFlags && lp.securityFlags) {
+		pinResult = VerifyPinData(pinData);
+	}
+
     ///- Check if SRP6 results match (password is correct), else send an error
-    if (!memcmp(M.AsByteArray(), lp.M1, 20))
+    if (!memcmp(M.AsByteArray(), lp.M1, 20) && pinResult)
     {
         BASIC_LOG("User '%s' successfully authenticated", _login.c_str());
 
@@ -973,4 +1002,72 @@ bool AuthSocket::_HandleXferAccept()
     ReadSkip(1);
 
     return true;
+}
+
+/// Very PIN entry data
+bool AuthSocket::VerifyPinData(const PINData& data)
+{
+	// remap the grid to match the client's layout
+	std::vector<uint8> grid { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+	std::vector<uint8> remappedGrid(grid.size());
+
+	uint8* remappedIndex = remappedGrid.data();
+
+	for(size_t i = grid.size(); i > 0; --i) {
+		auto remainder = gridSeed % i;
+		gridSeed /= i;
+		*remappedIndex = grid[remainder];
+
+		size_t copySize = i;
+		copySize -= remainder;
+		--copySize;
+
+		uint8* srcPtr = grid.data() + remainder + 1;
+		uint8* dstPtr = grid.data() + remainder;
+
+		std::copy(srcPtr, srcPtr + copySize, dstPtr);
+		++remappedIndex;
+	}
+
+	// convert the PIN to bytes (for ex. '1234' to {1, 2, 3, 4})
+	std::vector<uint8> pinBytes;
+	
+	while(pin != 0) {
+		pinBytes.push_back(pin % 10);
+		pin /= 10;
+	}
+
+	std::reverse(pinBytes.begin(), pinBytes.end());
+
+	// validate PIN length
+	if(pinBytes.size() < 4 || pinBytes.size() > 10) {
+		return false; // PIN outside of expected range
+	}
+
+	// remap the PIN to calculate the expected client input sequence
+	for(std::size_t i = 0; i < pinBytes.size(); ++i) {
+		auto index = std::find(remappedGrid.begin(), remappedGrid.end(), pinBytes[i]);
+		pinBytes[i] = std::distance(remappedGrid.begin(), index);
+	}
+
+	// convert PIN bytes to their ASCII values
+	for(size_t i = 0; i < pinBytes.size(); ++i) {
+		pinBytes[i] += 0x30;
+	}
+
+	// validate the PIN, x = H(client_salt | H(server_salt | ascii(pin_bytes)))
+	Sha1Hash sha;
+	sha.UpdateData(serverSecuritySalt.AsByteArray(), serverSecuritySalt.GetNumBytes());
+	sha.UpdateData(pinBytes.data(), pinBytes.size());
+	sha.Finalize();
+	BigNumber hash;
+	hash.SetBinary(sha.GetDigest(), sha.GetLength());
+
+	sha.Initialize();
+	sha.UpdateData(data.salt, sizeof(data.salt));
+	sha.UpdateData(hash.AsByteArray(), hash.GetNumBytes());
+	sha.Finalize();
+	hash.SetBinary(sha.GetDigest(), sha.GetLength());
+
+	return !memcmp(hash.AsByteArray(), data.hash, 20);
 }

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -666,7 +666,8 @@ bool AuthSocket::_HandleLogonProof()
         }
         else
         {
-            // unknown security flag
+            DEBUG_LOG("Unknown lock flags set for %s", _safelogin.c_str());
+            pinResult = false;
         }
     }
 
@@ -1135,7 +1136,7 @@ uint32 AuthSocket::generateTotpPin(const std::string& secret, int interval) {
     int key_size = base32_decode((const uint8_t*)secret.data(), decoded_key.data(), decoded_key.size());
 
     if (key_size == -1) {
-        DEBUG_LOG("Unable to base32 decode TOTP key for user %s", _safelogin);
+        DEBUG_LOG("Unable to base32 decode TOTP key for user %s", _safelogin.c_str());
         return -1;
     }
 

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -49,6 +49,14 @@ enum AccountFlags
     ACCOUNT_FLAG_PROPASS    = 0x00800000,
 };
 
+enum LockFlag : uint32 {
+    NONE           = 0x00,
+    IP_LOCK        = 0x01,
+    FIXED_PIN      = 0x02,
+    TOTP           = 0x04,
+    ALWAYS_ENFORCE = 0x08
+};
+
 // GCC have alternative #pragma pack(N) syntax and old gcc version not support pack(push,N), also any gcc version not support it at some paltform
 #if defined( __GNUC__ )
 #pragma pack(1)
@@ -142,14 +150,6 @@ typedef struct AUTH_RECONNECT_PROOF_C
 struct PINData {
     uint8 salt[16];
     uint8 hash[20];
-};
-
-enum LockFlag {
-    NONE           = 0x00,
-    IP_LOCK        = 0x01,
-    FIXED_PIN      = 0x02,
-    TOTP           = 0x04,
-    ALWAYS_ENFORCE = 0x08
 };
 
 typedef struct XFER_INIT

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -467,20 +467,6 @@ bool AuthSocket::_HandleLogonChallenge()
                         pkt << uint64(0) << uint64(0);      // 16 bytes hash?
                     }
 
-                    if (securityFlags & 0x02)               // Matrix input
-                    {
-                        pkt << uint8(0);
-                        pkt << uint8(0);
-                        pkt << uint8(0);
-                        pkt << uint8(0);
-                        pkt << uint64(0);
-                    }
-
-                    if (securityFlags & 0x04)               // Security token input
-                    {
-                        pkt << uint8(1);
-                    }
-
                     uint8 secLevel = (*result)[4].GetUInt8();
                     _accountSecurityLevel = secLevel <= SEC_ADMINISTRATOR ? AccountTypes(secLevel) : SEC_ADMINISTRATOR;
 

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -1049,7 +1049,7 @@ bool AuthSocket::VerifyPinData(const PINData& data)
         return false; // PIN outside of expected range
 
     // remap the PIN to calculate the expected client input sequence
-    for(std::size_t i = 0; i < pinBytes.size(); ++i)
+    for(size_t i = 0; i < pinBytes.size(); ++i)
     {
         auto index = std::find(remappedGrid.begin(), remappedGrid.end(), pinBytes[i]);
         pinBytes[i] = std::distance(remappedGrid.begin(), index);

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -477,7 +477,9 @@ bool AuthSocket::_HandleLogonChallenge()
                         pkt << uint8(1); // securityFlags, only '1' is available in classic (PIN input)
                         pkt << gridSeedPkt;
                         pkt.append(serverSecuritySalt.AsByteArray(16), 16);
-                    } else {
+                    }
+                    else
+                    {
                         pkt << uint8(0);
                     }
 
@@ -512,7 +514,8 @@ bool AuthSocket::_HandleLogonProof()
         return false;
 
     PINData pinData;
-    if(lp.securityFlags) {
+    if(lp.securityFlags)
+    {
         if(!Read((char*)&pinData, sizeof(pinData)))
             return false;
     }
@@ -609,13 +612,11 @@ bool AuthSocket::_HandleLogonProof()
     ///- Check PIN data is correct
     bool pinResult = true;
 
-    if(securityFlags && !lp.securityFlags) {
+    if(securityFlags && !lp.securityFlags)
         pinResult = false; // expected PIN data but did not receive it
-    }
 
-    if(securityFlags && lp.securityFlags) {
+    if(securityFlags && lp.securityFlags)
         pinResult = VerifyPinData(pinData);
-    }
 
     ///- Check if SRP6 results match (password is correct), else send an error
     if (!memcmp(M.AsByteArray(), lp.M1, 20) && pinResult)
@@ -1015,7 +1016,8 @@ bool AuthSocket::VerifyPinData(const PINData& data)
 
     uint8* remappedIndex = remappedGrid.data();
 
-    for(size_t i = grid.size(); i > 0; --i) {
+    for(size_t i = grid.size(); i > 0; --i)
+    {
         auto remainder = gridSeed % i;
         gridSeed /= i;
         *remappedIndex = grid[remainder];
@@ -1034,7 +1036,8 @@ bool AuthSocket::VerifyPinData(const PINData& data)
     // convert the PIN to bytes (for ex. '1234' to {1, 2, 3, 4})
     std::vector<uint8> pinBytes;
 	    
-    while(pin != 0) {
+    while(pin != 0)
+    {
         pinBytes.push_back(pin % 10);
         pin /= 10;
     }
@@ -1042,20 +1045,19 @@ bool AuthSocket::VerifyPinData(const PINData& data)
     std::reverse(pinBytes.begin(), pinBytes.end());
 
     // validate PIN length
-    if(pinBytes.size() < 4 || pinBytes.size() > 10) {
+    if(pinBytes.size() < 4 || pinBytes.size() > 10)
         return false; // PIN outside of expected range
-    }
 
     // remap the PIN to calculate the expected client input sequence
-    for(std::size_t i = 0; i < pinBytes.size(); ++i) {
+    for(std::size_t i = 0; i < pinBytes.size(); ++i)
+    {
         auto index = std::find(remappedGrid.begin(), remappedGrid.end(), pinBytes[i]);
         pinBytes[i] = std::distance(remappedGrid.begin(), index);
     }
 
     // convert PIN bytes to their ASCII values
-    for(size_t i = 0; i < pinBytes.size(); ++i) {
+    for(size_t i = 0; i < pinBytes.size(); ++i)
         pinBytes[i] += 0x30;
-    }
 
     // validate the PIN, x = H(client_salt | H(server_salt | ascii(pin_bytes)))
     Sha1Hash sha;

--- a/src/realmd/AuthSocket.h
+++ b/src/realmd/AuthSocket.h
@@ -45,7 +45,7 @@ class AuthSocket : public MaNGOS::Socket
 
         void SendProof(Sha1Hash sha);
         void LoadRealmlist(ByteBuffer& pkt, uint32 acctid);
-		bool VerifyPinData(const PINData& data);
+        bool VerifyPinData(const PINData& data);
 
         bool _HandleLogonChallenge();
         bool _HandleLogonProof();
@@ -71,9 +71,9 @@ class AuthSocket : public MaNGOS::Socket
         std::string _login;
         std::string _safelogin;
 
-		BigNumber serverSecuritySalt;
-		uint8 securityFlags;
-		uint32 gridSeed, pin;
+        BigNumber serverSecuritySalt;
+        uint8 securityFlags;
+        uint32 gridSeed, pin;
 
         // Since GetLocaleByName() is _NOT_ bijective, we have to store the locale as a string. Otherwise we can't differ
         // between enUS and enGB, which is important for the patch system

--- a/src/realmd/AuthSocket.h
+++ b/src/realmd/AuthSocket.h
@@ -34,6 +34,8 @@
 
 #include <functional>
 
+struct PINData; // forward decl
+
 class AuthSocket : public MaNGOS::Socket
 {
     public:
@@ -43,6 +45,7 @@ class AuthSocket : public MaNGOS::Socket
 
         void SendProof(Sha1Hash sha);
         void LoadRealmlist(ByteBuffer& pkt, uint32 acctid);
+		bool VerifyPinData(const PINData& data);
 
         bool _HandleLogonChallenge();
         bool _HandleLogonProof();
@@ -67,6 +70,10 @@ class AuthSocket : public MaNGOS::Socket
 
         std::string _login;
         std::string _safelogin;
+
+		BigNumber serverSecuritySalt;
+		uint8 securityFlags;
+		uint32 gridSeed, pin;
 
         // Since GetLocaleByName() is _NOT_ bijective, we have to store the locale as a string. Otherwise we can't differ
         // between enUS and enGB, which is important for the patch system

--- a/src/realmd/AuthSocket.h
+++ b/src/realmd/AuthSocket.h
@@ -34,7 +34,8 @@
 
 #include <functional>
 
-struct PINData; // forward decl
+struct PINData;
+enum LockFlag;
 
 class AuthSocket : public MaNGOS::Socket
 {
@@ -45,7 +46,8 @@ class AuthSocket : public MaNGOS::Socket
 
         void SendProof(Sha1Hash sha);
         void LoadRealmlist(ByteBuffer& pkt, uint32 acctid);
-        bool VerifyPinData(const PINData& data);
+        bool VerifyPinData(uint32 pin, const PINData& clientData);
+        uint32 generateTotpPin(const std::string& secret, int interval);
 
         bool _HandleLogonChallenge();
         bool _HandleLogonProof();
@@ -66,14 +68,15 @@ class AuthSocket : public MaNGOS::Socket
         BigNumber K;
         BigNumber _reconnectProof;
 
-        bool _authed;
+        bool _authed, promptPin;
 
         std::string _login;
         std::string _safelogin;
+        std::string securityInfo;
 
         BigNumber serverSecuritySalt;
-        uint8 securityFlags;
-        uint32 gridSeed, pin;
+        LockFlag lockFlags;
+        uint32 gridSeed;
 
         // Since GetLocaleByName() is _NOT_ bijective, we have to store the locale as a string. Otherwise we can't differ
         // between enUS and enGB, which is important for the patch system

--- a/src/realmd/AuthSocket.h
+++ b/src/realmd/AuthSocket.h
@@ -35,7 +35,7 @@
 #include <functional>
 
 struct PINData;
-enum LockFlag;
+enum LockFlag : uint32;
 
 class AuthSocket : public MaNGOS::Socket
 {

--- a/src/shared/Auth/Hmac.cpp
+++ b/src/shared/Auth/Hmac.cpp
@@ -19,17 +19,14 @@
 #include "Auth/Hmac.h"
 #include "BigNumber.h"
 
-HmacHash::HmacHash()
+HmacHash::HmacHash(const uint8* data, int length)
 {
-    uint8 temp[SEED_KEY_SIZE] = { 0x38, 0xA7, 0x83, 0x15, 0xF8, 0x92, 0x25, 0x30, 0x71, 0x98, 0x67, 0xB1, 0x8C, 0x4, 0xE2, 0xAA };
-    memcpy(&m_key, &temp, SEED_KEY_SIZE);
     HMAC_CTX_init(&m_ctx);
-    HMAC_Init_ex(&m_ctx, &m_key, SEED_KEY_SIZE, EVP_sha1(), NULL);
+    HMAC_Init_ex(&m_ctx, data, length, EVP_sha1(), NULL);
 }
 
 HmacHash::~HmacHash()
 {
-    memset(&m_key, 0x00, SEED_KEY_SIZE);
     HMAC_CTX_cleanup(&m_ctx);
 }
 
@@ -41,11 +38,6 @@ void HmacHash::UpdateBigNumber(BigNumber* bn)
 void HmacHash::UpdateData(const uint8* data, int length)
 {
     HMAC_Update(&m_ctx, data, length);
-}
-
-void HmacHash::Initialize()
-{
-    HMAC_Init_ex(&m_ctx, &m_key, SEED_KEY_SIZE, EVP_sha1(), NULL);
 }
 
 void HmacHash::Finalize()

--- a/src/shared/Auth/Hmac.h
+++ b/src/shared/Auth/Hmac.h
@@ -25,12 +25,10 @@
 
 class BigNumber;
 
-#define SEED_KEY_SIZE 16
-
 class HmacHash
 {
     public:
-        HmacHash();
+        HmacHash(const uint8* data, int length);
         ~HmacHash();
         void UpdateBigNumber(BigNumber* bn);
         void UpdateData(const uint8* data, int length);
@@ -40,7 +38,6 @@ class HmacHash
         int GetLength() { return SHA_DIGEST_LENGTH; };
     private:
         HMAC_CTX m_ctx;
-        uint8 m_key[SEED_KEY_SIZE];
         uint8 m_digest[SHA_DIGEST_LENGTH];
 };
 #endif

--- a/src/shared/Auth/base32.cpp
+++ b/src/shared/Auth/base32.cpp
@@ -1,0 +1,95 @@
+// Base32 implementation
+//
+// Copyright 2010 Google Inc.
+// Author: Markus Gutschke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string.h>
+
+#include "base32.h"
+
+int base32_decode(const uint8_t *encoded, uint8_t *result, int bufSize) {
+  int buffer = 0;
+  int bitsLeft = 0;
+  int count = 0;
+  for (const uint8_t *ptr = encoded; count < bufSize && *ptr; ++ptr) {
+    uint8_t ch = *ptr;
+    if (ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n' || ch == '-') {
+      continue;
+    }
+    buffer <<= 5;
+
+    // Deal with commonly mistyped characters
+    if (ch == '0') {
+      ch = 'O';
+    } else if (ch == '1') {
+      ch = 'L';
+    } else if (ch == '8') {
+      ch = 'B';
+    }
+
+    // Look up one base32 digit
+    if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')) {
+      ch = (ch & 0x1F) - 1;
+    } else if (ch >= '2' && ch <= '7') {
+      ch -= '2' - 26;
+    } else {
+      return -1;
+    }
+
+    buffer |= ch;
+    bitsLeft += 5;
+    if (bitsLeft >= 8) {
+      result[count++] = buffer >> (bitsLeft - 8);
+      bitsLeft -= 8;
+    }
+  }
+  if (count < bufSize) {
+    result[count] = '\000';
+  }
+  return count;
+}
+
+int base32_encode(const uint8_t *data, int length, uint8_t *result,
+                  int bufSize) {
+  if (length < 0 || length > (1 << 28)) {
+    return -1;
+  }
+  int count = 0;
+  if (length > 0) {
+    int buffer = data[0];
+    int next = 1;
+    int bitsLeft = 8;
+    while (count < bufSize && (bitsLeft > 0 || next < length)) {
+      if (bitsLeft < 5) {
+        if (next < length) {
+          buffer <<= 8;
+          buffer |= data[next++] & 0xFF;
+          bitsLeft += 8;
+        } else {
+          int pad = 5 - bitsLeft;
+          buffer <<= pad;
+          bitsLeft += pad;
+        }
+      }
+      int index = 0x1F & (buffer >> (bitsLeft - 5));
+      bitsLeft -= 5;
+      result[count++] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"[index];
+    }
+  }
+  if (count < bufSize) {
+    result[count] = '\000';
+  }
+  return count;
+}

--- a/src/shared/Auth/base32.h
+++ b/src/shared/Auth/base32.h
@@ -1,0 +1,39 @@
+// Base32 implementation
+//
+// Copyright 2010 Google Inc.
+// Author: Markus Gutschke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Encode and decode from base32 encoding using the following alphabet:
+//   ABCDEFGHIJKLMNOPQRSTUVWXYZ234567
+// This alphabet is documented in RFC 4648/3548
+//
+// We allow white-space and hyphens, but all other characters are considered
+// invalid.
+//
+// All functions return the number of output bytes or -1 on error. If the
+// output buffer is too small, the result will silently be truncated.
+
+#ifndef _BASE32_H_
+#define _BASE32_H_
+
+#include <stdint.h>
+
+int base32_decode(const uint8_t *encoded, uint8_t *result, int bufSize);
+
+int base32_encode(const uint8_t *data, int length, uint8_t *result,
+                  int bufSize);
+
+
+#endif /* _BASE32_H_ */

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -28,6 +28,8 @@ set(SRC_GRP_AUTH
     Auth/md5.h
     Auth/Sha1.cpp
     Auth/Sha1.h
+    Auth/base32.h
+    Auth/base32.cpp
 )
 
 set(SRC_GRP_CONFIG

--- a/src/shared/revision_sql.h
+++ b/src/shared/revision_sql.h
@@ -1,6 +1,6 @@
 #ifndef __REVISION_SQL_H__
 #define __REVISION_SQL_H__
- #define REVISION_DB_REALMD "required_z2678_01_realmd"
+ #define REVISION_DB_REALMD "required_z2685_01_realmd"
  #define REVISION_DB_CHARACTERS "required_z2682_01_characters_pvpstats"
  #define REVISION_DB_MANGOS "required_z2684_01_mangos_creature_template"
 #endif // __REVISION_SQL_H__

--- a/win/VC120/shared.vcxproj
+++ b/win/VC120/shared.vcxproj
@@ -405,6 +405,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\shared\Auth\AuthCrypt.cpp" />
+    <ClCompile Include="..\..\src\shared\Auth\base32.cpp" />
     <ClCompile Include="..\..\src\shared\Auth\BigNumber.cpp" />
     <ClCompile Include="..\..\src\shared\Auth\Hmac.cpp" />
     <ClCompile Include="..\..\src\shared\Auth\md5.c" />
@@ -432,6 +433,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\dep\include\mersennetwister\MersenneTwister.h" />
     <ClInclude Include="..\..\src\shared\Auth\AuthCrypt.h" />
+    <ClInclude Include="..\..\src\shared\Auth\base32.h" />
     <ClInclude Include="..\..\src\shared\Auth\BigNumber.h" />
     <ClInclude Include="..\..\src\shared\Auth\Hmac.h" />
     <ClInclude Include="..\..\src\shared\Auth\md5.h" />

--- a/win/VC120/shared.vcxproj.filters
+++ b/win/VC120/shared.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClCompile Include="..\..\src\shared\Network\Socket.cpp">
       <Filter>Network</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\shared\Auth\base32.cpp">
+      <Filter>Auth</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\shared\Database\Database.h">
@@ -199,6 +202,9 @@
       <Filter>Network</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\shared\TSS.h" />
+    <ClInclude Include="..\..\src\shared\Auth\base32.h">
+      <Filter>Auth</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\src\shared\revision.h" />

--- a/win/VC140/shared.vcxproj
+++ b/win/VC140/shared.vcxproj
@@ -405,6 +405,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\shared\Auth\AuthCrypt.cpp" />
+    <ClCompile Include="..\..\src\shared\Auth\base32.cpp" />
     <ClCompile Include="..\..\src\shared\Auth\BigNumber.cpp" />
     <ClCompile Include="..\..\src\shared\Auth\Hmac.cpp" />
     <ClCompile Include="..\..\src\shared\Auth\md5.c" />
@@ -433,6 +434,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\dep\include\mersennetwister\MersenneTwister.h" />
     <ClInclude Include="..\..\src\shared\Auth\AuthCrypt.h" />
+    <ClInclude Include="..\..\src\shared\Auth\base32.h" />
     <ClInclude Include="..\..\src\shared\Auth\BigNumber.h" />
     <ClInclude Include="..\..\src\shared\Auth\Hmac.h" />
     <ClInclude Include="..\..\src\shared\Auth\md5.h" />

--- a/win/VC140/shared.vcxproj.filters
+++ b/win/VC140/shared.vcxproj.filters
@@ -93,6 +93,9 @@
     <ClCompile Include="..\..\src\shared\Network\Listener.cpp">
       <Filter>Network</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\shared\Auth\base32.cpp">
+      <Filter>Auth</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\shared\Database\Database.h">
@@ -196,6 +199,9 @@
       <Filter>Network</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\shared\TSS.h" />
+    <ClInclude Include="..\..\src\shared\Auth\base32.h">
+      <Filter>Auth</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\src\shared\revision.h" />


### PR DESCRIPTION
_This is continued from https://github.com/cmangos/mangos-classic/pull/191 now that TOTP has been implemented._

TOTP is now implemented on top of the PIN system and is backwards compatible with the 'old' IP locking system. 

An example can be viewed here: https://www.youtube.com/watch?v=VXAOxSBGFXg

**_Database changes:_**

1) I've 'extended' the realmd _'locked'_ column in the realm database to support additional flags. These are:

```
NONE           = 0x00,
IP_LOCK        = 0x01, // for backwards compatibility
FIXED_PIN      = 0x02,
TOTP           = 0x04,
ALWAYS_ENFORCE = 0x08
```

This allows a fair degree of flexibility with the upgraded lock system. Through setting flags, the user can:
- Continue to use the existing IP lock system, as is (value: 1)
- IP lock & 2FA to unlock the account (only prompt for PIN on IP change) (value: 3 or 5)
- IP lock & 2FA to unlock the account (_always_ prompt for PIN) (value: 11 or 13)
- No IP lock & 2FA (_always_ prompt for PIN) (value: 10 or 12)

The fixed PIN and TOTP flags are mutually exclusive.

2) The realmd database has a single new column, 'security'. This contains a string representing either a fixed PIN or a 16-character base32 encoded string, depending on whether the user is using a fixed PIN or TOTP.

_**Shared secret generation:**_

When generating a TOTP key, you should generate a random 10-byte array, base32 encode it and display the 16-character result to the user. The user will then add this key to their mobile authenticator to 'link' it with their account. If you want to learn more about the specifics, I'd recommend having a look at [https://tools.ietf.org/html/rfc6238](https://tools.ietf.org/html/rfc6238).

If you don't have a mobile, you can use an application called WinAuth, otherwise you can use Google Authenticator (or any other app implementing the same algorithm).
