### PR TITLE
Fix delayed spell handling

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -1098,7 +1098,7 @@ void Spell::DoAllEffectOnTarget(TargetInfo* target)
 
 void Spell::DoSpellHitOnUnit(Unit* unit, uint32 effectMask, bool isReflected)
 {
-    if (!unit || !effectMask)
+    if (!unit)
         return;
 
     Unit* realCaster = GetAffectiveCaster();


### PR DESCRIPTION
Spell::DoSpellHitOnUnit returns immediately for delayed spells, which have all the effects handled at launch, thus preventing some needed code from execution. The check remains since the time when the method had nothing but a loop with HandleEffets and served only for optimization. Now it can be safely removed.

One of consequences of this check is the possibility do damage the target with some spells (e.g. Shadow Bolt), after it becomes friendly or non-attackable. For example, it is possible to kill a player after duel ended.