### PR TITLE
Spell log fixes

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -3401,96 +3401,84 @@ void Spell::SendLogExecute()
         data << target->GetPackGUID();
 
     data << uint32(m_spellInfo->Id);
-    uint32 count1 = 1;
-    data << uint32(count1);                                 // count1 (effect count?)
-    for (uint32 i = 0; i < count1; ++i)
+    uint32 effectCount = 1;
+    data << uint32(effectCount);
+    for (uint32 i = 0; i < effectCount; ++i)
     {
-        data << uint32(m_spellInfo->Effect[EFFECT_INDEX_0]);// spell effect
-        uint32 count2 = 1;
-        data << uint32(count2);                             // count2 (target count?)
-        for (uint32 j = 0; j < count2; ++j)
+        data << uint32(m_spellInfo->Effect[EFFECT_INDEX_0]);
+        uint32 targetCount = 1;
+        data << uint32(targetCount);
+        for (uint32 j = 0; j < targetCount; ++j)
         {
             switch (m_spellInfo->Effect[EFFECT_INDEX_0])
             {
                 case SPELL_EFFECT_POWER_DRAIN:
                     if (Unit* unit = m_targets.getUnitTarget())
-                        data << unit->GetPackGUID();
+                        data << unit->GetObjectGuid();
                     else
-                        data << uint8(0);
-                    data << uint32(0);
-                    data << uint32(0);
-                    data << float(0);
+                        data << ObjectGuid();
+                    data << uint32(0);                      // amount
+                    data << uint32(0);                      // power
+                    data << float(0);                       // multiplier
                     break;
                 case SPELL_EFFECT_ADD_EXTRA_ATTACKS:
                     if (Unit* unit = m_targets.getUnitTarget())
-                        data << unit->GetPackGUID();
+                        data << unit->GetObjectGuid();
                     else
-                        data << uint8(0);
-                    data << uint32(0);                      // count?
-                    break;
-                case SPELL_EFFECT_INTERRUPT_CAST:
-                    if (Unit* unit = m_targets.getUnitTarget())
-                        data << unit->GetPackGUID();
-                    else
-                        data << uint8(0);
-                    data << uint32(0);                      // spellid
-                    break;
-                case SPELL_EFFECT_DURABILITY_DAMAGE:
-                    if (Unit* unit = m_targets.getUnitTarget())
-                        data << unit->GetPackGUID();
-                    else
-                        data << uint8(0);
-                    data << uint32(0);
-                    data << uint32(0);
-                    break;
-                case SPELL_EFFECT_OPEN_LOCK:
-                case SPELL_EFFECT_OPEN_LOCK_ITEM:
-                    if (Item* item = m_targets.getItemTarget())
-                        data << item->GetPackGUID();
-                    else
-                        data << uint8(0);
+                        data << ObjectGuid();
+                    data << uint32(0);                      // count
                     break;
                 case SPELL_EFFECT_CREATE_ITEM:
                     data << uint32(m_spellInfo->EffectItemType[EFFECT_INDEX_0]);
                     break;
-                case SPELL_EFFECT_SUMMON:
-                case SPELL_EFFECT_SUMMON_WILD:
-                case SPELL_EFFECT_SUMMON_GUARDIAN:
-                case SPELL_EFFECT_TRANS_DOOR:
-                case SPELL_EFFECT_SUMMON_PET:
-                case SPELL_EFFECT_SUMMON_POSSESSED:
-                case SPELL_EFFECT_SUMMON_TOTEM:
-                case SPELL_EFFECT_SUMMON_OBJECT_WILD:
-                case SPELL_EFFECT_CREATE_HOUSE:
-                case SPELL_EFFECT_DUEL:
-                case SPELL_EFFECT_SUMMON_TOTEM_SLOT1:
-                case SPELL_EFFECT_SUMMON_TOTEM_SLOT2:
-                case SPELL_EFFECT_SUMMON_TOTEM_SLOT3:
-                case SPELL_EFFECT_SUMMON_TOTEM_SLOT4:
-                case SPELL_EFFECT_SUMMON_PHANTASM:
-                case SPELL_EFFECT_SUMMON_CRITTER:
-                case SPELL_EFFECT_SUMMON_OBJECT_SLOT1:
-                case SPELL_EFFECT_SUMMON_OBJECT_SLOT2:
-                case SPELL_EFFECT_SUMMON_OBJECT_SLOT3:
-                case SPELL_EFFECT_SUMMON_OBJECT_SLOT4:
-                case SPELL_EFFECT_SUMMON_DEMON:
-                    if (Unit* unit = m_targets.getUnitTarget())
-                        data << unit->GetPackGUID();
-                    else if (m_targets.getItemTargetGuid())
-                        data << m_targets.getItemTargetGuid().WriteAsPacked();
-                    else if (GameObject* go = m_targets.getGOTarget())
-                        data << go->GetPackGUID();
+                case SPELL_EFFECT_OPEN_LOCK:
+                case SPELL_EFFECT_OPEN_LOCK_ITEM:
+                    if (Item* item = m_targets.getItemTarget())
+                        data << item->GetObjectGuid();
                     else
-                        data << uint8(0);                   // guid
+                        data << ObjectGuid();
+                    break;
+                case SPELL_EFFECT_INTERRUPT_CAST:
+                    if (Unit* unit = m_targets.getUnitTarget())
+                        data << unit->GetObjectGuid();
+                    else
+                        data << ObjectGuid();
+                    data << uint32(0);                      // spellid
                     break;
                 case SPELL_EFFECT_FEED_PET:
                     data << uint32(m_targets.getItemTargetEntry());
                     break;
                 case SPELL_EFFECT_DISMISS_PET:
                     if (Unit* unit = m_targets.getUnitTarget())
-                        data << unit->GetPackGUID();
+                        data << unit->GetObjectGuid();
                     else
-                        data << uint8(0);
+                        data << ObjectGuid();
+                    break;
+                case SPELL_EFFECT_DURABILITY_DAMAGE:
+                    if (Unit* unit = m_targets.getUnitTarget())
+                        data << unit->GetObjectGuid();
+                    else
+                        data << ObjectGuid();
+                    data << int32(0);                       // itemid, -1 for all
+                    data << int32(0);                       // unknown, -1 for all
+                    break;
+                case SPELL_EFFECT_INSTAKILL:
+                case SPELL_EFFECT_RESURRECT:
+                case SPELL_EFFECT_DISPEL:
+                case SPELL_EFFECT_THREAT:
+                case SPELL_EFFECT_DISTRACT:
+                case SPELL_EFFECT_SANCTUARY:
+                case SPELL_EFFECT_THREAT_ALL:
+                case SPELL_EFFECT_DISPEL_MECHANIC:
+                case SPELL_EFFECT_RESURRECT_NEW:
+                case SPELL_EFFECT_ATTACK_ME:
+                case SPELL_EFFECT_SKIN_PLAYER_CORPSE:
+                case SPELL_EFFECT_MODIFY_THREAT_PERCENT:
+                case SPELL_EFFECT_126:
+                    if (Unit* unit = m_targets.getUnitTarget())
+                        data << unit->GetObjectGuid();
+                    else
+                        data << ObjectGuid();
                     break;
                 default:
                     return;

--- a/src/game/Spell.h
+++ b/src/game/Spell.h
@@ -592,6 +592,57 @@ class Spell
         // we can't store original aura link to prevent access to deleted auras
         // and in same time need aura data and after aura deleting.
         SpellEntry const* m_triggeredByAuraSpell;
+
+        struct ExecuteLogInfo
+        {
+            ExecuteLogInfo() = default;
+            ExecuteLogInfo(ObjectGuid _targetGuid) : targetGuid(_targetGuid) {}
+
+            ObjectGuid targetGuid;
+
+            union
+            {
+                struct
+                {
+                    uint32 power;
+                    uint32 amount;
+                    float multiplier;
+                } powerDrain;
+
+                struct
+                {
+                    uint32 count;
+                } extraAttacks;
+
+                struct
+                {
+                    uint32 itemEntry;
+                } createItem;
+
+                struct
+                {
+                    uint32 spellId;
+                } interruptCast;
+
+                struct
+                {
+                    uint32 itemEntry;
+                } feedPet;
+
+                struct
+                {
+                    int32 itemEntry;
+                    int32 unk;
+                } durabilityDamage;
+            };
+        };
+
+        std::vector<ExecuteLogInfo> m_executeLogInfo[MAX_EFFECT_INDEX];
+
+        void AddExecuteLogInfo(SpellEffectIndex i, ExecuteLogInfo info)
+        {
+            m_executeLogInfo[i].push_back(info);
+        }
 };
 
 enum ReplenishType

--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -254,8 +254,7 @@ void Spell::EffectInstaKill(SpellEffectIndex /*eff_idx*/)
 
     WorldObject* caster = GetCastingObject();               // we need the original casting object
 
-    WorldPacket data(SMSG_SPELLINSTAKILLLOG, (8 + 8 + 4));
-    data << (caster && caster->GetTypeId() != TYPEID_GAMEOBJECT ? m_caster->GetObjectGuid() : ObjectGuid()); // Caster GUID
+    WorldPacket data(SMSG_SPELLINSTAKILLLOG, (8 + 4));
     data << unitTarget->GetObjectGuid();                    // Victim GUID
     data << uint32(m_spellInfo->Id);
     m_caster->SendMessageToSet(&data, true);

--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -2396,17 +2396,14 @@ void Spell::EffectDispel(SpellEffectIndex eff_idx)
         if (!success_list.empty())
         {
             int32 count = success_list.size();
-            WorldPacket data(SMSG_SPELLDISPELLOG, 8 + 8 + 4 + 1 + 4 + count * 5);
+            WorldPacket data(SMSG_SPELLDISPELLOG, 8 + 8 + 4 + count * 4);
             data << unitTarget->GetPackGUID();              // Victim GUID
             data << m_caster->GetPackGUID();                // Caster GUID
-            data << uint32(m_spellInfo->Id);                // Dispel spell id
-            data << uint8(0);                               // not used
             data << uint32(count);                          // count
             for (std::list<std::pair<SpellAuraHolder*, uint32> >::iterator j = success_list.begin(); j != success_list.end(); ++j)
             {
                 SpellAuraHolder* dispelledHolder = j->first;
                 data << uint32(dispelledHolder->GetId());   // Spell Id
-                data << uint8(0);                           // 0 - dispelled !=0 cleansed
                 unitTarget->RemoveAuraHolderDueToSpellByDispel(dispelledHolder->GetId(), j->second, dispelledHolder->GetCasterGuid(), m_caster);
             }
             m_caster->SendMessageToSet(&data, true);
@@ -2434,10 +2431,9 @@ void Spell::EffectDispel(SpellEffectIndex eff_idx)
         if (!fail_list.empty())
         {
             // Failed to dispel
-            WorldPacket data(SMSG_DISPEL_FAILED, 8 + 8 + 4 + 4 * fail_list.size());
+            WorldPacket data(SMSG_DISPEL_FAILED, 8 + 8 + 4 * fail_list.size());
             data << m_caster->GetObjectGuid();              // Caster GUID
             data << unitTarget->GetObjectGuid();            // Victim GUID
-            data << uint32(m_spellInfo->Id);                // Dispel spell id
             for (std::list< uint32 >::iterator j = fail_list.begin(); j != fail_list.end(); ++j)
                 data << uint32(*j);                         // Spell Id
             m_caster->SendMessageToSet(&data, true);


### PR DESCRIPTION
SMSG_SPELLLOGEXECUTE now has the correct structure and data for all effects and targets.

SMSG_SPELLDISPELLOG and SMSG_DISPEL_FAILED now have the correct structures.