### PR TITLE
Fix spell execute log

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -3401,96 +3401,84 @@ void Spell::SendLogExecute()
         data << target->GetPackGUID();
 
     data << uint32(m_spellInfo->Id);
-    uint32 count1 = 1;
-    data << uint32(count1);                                 // count1 (effect count?)
-    for (uint32 i = 0; i < count1; ++i)
+    uint32 effectCount = 1;
+    data << uint32(effectCount);
+    for (uint32 i = 0; i < effectCount; ++i)
     {
-        data << uint32(m_spellInfo->Effect[EFFECT_INDEX_0]);// spell effect
-        uint32 count2 = 1;
-        data << uint32(count2);                             // count2 (target count?)
-        for (uint32 j = 0; j < count2; ++j)
+        data << uint32(m_spellInfo->Effect[EFFECT_INDEX_0]);
+        uint32 targetCount = 1;
+        data << uint32(targetCount);
+        for (uint32 j = 0; j < targetCount; ++j)
         {
             switch (m_spellInfo->Effect[EFFECT_INDEX_0])
             {
                 case SPELL_EFFECT_POWER_DRAIN:
                     if (Unit* unit = m_targets.getUnitTarget())
-                        data << unit->GetPackGUID();
+                        data << unit->GetObjectGuid();
                     else
-                        data << uint8(0);
-                    data << uint32(0);
-                    data << uint32(0);
-                    data << float(0);
+                        data << ObjectGuid();
+                    data << uint32(0);                      // amount
+                    data << uint32(0);                      // power
+                    data << float(0);                       // multiplier
                     break;
                 case SPELL_EFFECT_ADD_EXTRA_ATTACKS:
                     if (Unit* unit = m_targets.getUnitTarget())
-                        data << unit->GetPackGUID();
+                        data << unit->GetObjectGuid();
                     else
-                        data << uint8(0);
-                    data << uint32(0);                      // count?
-                    break;
-                case SPELL_EFFECT_INTERRUPT_CAST:
-                    if (Unit* unit = m_targets.getUnitTarget())
-                        data << unit->GetPackGUID();
-                    else
-                        data << uint8(0);
-                    data << uint32(0);                      // spellid
-                    break;
-                case SPELL_EFFECT_DURABILITY_DAMAGE:
-                    if (Unit* unit = m_targets.getUnitTarget())
-                        data << unit->GetPackGUID();
-                    else
-                        data << uint8(0);
-                    data << uint32(0);
-                    data << uint32(0);
-                    break;
-                case SPELL_EFFECT_OPEN_LOCK:
-                case SPELL_EFFECT_OPEN_LOCK_ITEM:
-                    if (Item* item = m_targets.getItemTarget())
-                        data << item->GetPackGUID();
-                    else
-                        data << uint8(0);
+                        data << ObjectGuid();
+                    data << uint32(0);                      // count
                     break;
                 case SPELL_EFFECT_CREATE_ITEM:
                     data << uint32(m_spellInfo->EffectItemType[EFFECT_INDEX_0]);
                     break;
-                case SPELL_EFFECT_SUMMON:
-                case SPELL_EFFECT_SUMMON_WILD:
-                case SPELL_EFFECT_SUMMON_GUARDIAN:
-                case SPELL_EFFECT_TRANS_DOOR:
-                case SPELL_EFFECT_SUMMON_PET:
-                case SPELL_EFFECT_SUMMON_POSSESSED:
-                case SPELL_EFFECT_SUMMON_TOTEM:
-                case SPELL_EFFECT_SUMMON_OBJECT_WILD:
-                case SPELL_EFFECT_CREATE_HOUSE:
-                case SPELL_EFFECT_DUEL:
-                case SPELL_EFFECT_SUMMON_TOTEM_SLOT1:
-                case SPELL_EFFECT_SUMMON_TOTEM_SLOT2:
-                case SPELL_EFFECT_SUMMON_TOTEM_SLOT3:
-                case SPELL_EFFECT_SUMMON_TOTEM_SLOT4:
-                case SPELL_EFFECT_SUMMON_PHANTASM:
-                case SPELL_EFFECT_SUMMON_CRITTER:
-                case SPELL_EFFECT_SUMMON_OBJECT_SLOT1:
-                case SPELL_EFFECT_SUMMON_OBJECT_SLOT2:
-                case SPELL_EFFECT_SUMMON_OBJECT_SLOT3:
-                case SPELL_EFFECT_SUMMON_OBJECT_SLOT4:
-                case SPELL_EFFECT_SUMMON_DEMON:
-                    if (Unit* unit = m_targets.getUnitTarget())
-                        data << unit->GetPackGUID();
-                    else if (m_targets.getItemTargetGuid())
-                        data << m_targets.getItemTargetGuid().WriteAsPacked();
-                    else if (GameObject* go = m_targets.getGOTarget())
-                        data << go->GetPackGUID();
+                case SPELL_EFFECT_OPEN_LOCK:
+                case SPELL_EFFECT_OPEN_LOCK_ITEM:
+                    if (Item* item = m_targets.getItemTarget())
+                        data << item->GetObjectGuid();
                     else
-                        data << uint8(0);                   // guid
+                        data << ObjectGuid();
+                    break;
+                case SPELL_EFFECT_INTERRUPT_CAST:
+                    if (Unit* unit = m_targets.getUnitTarget())
+                        data << unit->GetObjectGuid();
+                    else
+                        data << ObjectGuid();
+                    data << uint32(0);                      // spellid
                     break;
                 case SPELL_EFFECT_FEED_PET:
                     data << uint32(m_targets.getItemTargetEntry());
                     break;
                 case SPELL_EFFECT_DISMISS_PET:
                     if (Unit* unit = m_targets.getUnitTarget())
-                        data << unit->GetPackGUID();
+                        data << unit->GetObjectGuid();
                     else
-                        data << uint8(0);
+                        data << ObjectGuid();
+                    break;
+                case SPELL_EFFECT_DURABILITY_DAMAGE:
+                    if (Unit* unit = m_targets.getUnitTarget())
+                        data << unit->GetObjectGuid();
+                    else
+                        data << ObjectGuid();
+                    data << int32(0);                       // itemid, -1 for all
+                    data << int32(0);                       // unknown, -1 for all
+                    break;
+                case SPELL_EFFECT_INSTAKILL:
+                case SPELL_EFFECT_RESURRECT:
+                case SPELL_EFFECT_DISPEL:
+                case SPELL_EFFECT_THREAT:
+                case SPELL_EFFECT_DISTRACT:
+                case SPELL_EFFECT_SANCTUARY:
+                case SPELL_EFFECT_THREAT_ALL:
+                case SPELL_EFFECT_DISPEL_MECHANIC:
+                case SPELL_EFFECT_RESURRECT_NEW:
+                case SPELL_EFFECT_ATTACK_ME:
+                case SPELL_EFFECT_SKIN_PLAYER_CORPSE:
+                case SPELL_EFFECT_MODIFY_THREAT_PERCENT:
+                case SPELL_EFFECT_126:
+                    if (Unit* unit = m_targets.getUnitTarget())
+                        data << unit->GetObjectGuid();
+                    else
+                        data << ObjectGuid();
                     break;
                 default:
                     return;

--- a/src/game/Spell.h
+++ b/src/game/Spell.h
@@ -592,6 +592,57 @@ class Spell
         // we can't store original aura link to prevent access to deleted auras
         // and in same time need aura data and after aura deleting.
         SpellEntry const* m_triggeredByAuraSpell;
+
+        struct ExecuteLogInfo
+        {
+            ExecuteLogInfo() = default;
+            ExecuteLogInfo(ObjectGuid _targetGuid) : targetGuid(_targetGuid) {}
+
+            ObjectGuid targetGuid;
+
+            union
+            {
+                struct
+                {
+                    uint32 power;
+                    uint32 amount;
+                    float multiplier;
+                } powerDrain;
+
+                struct
+                {
+                    uint32 count;
+                } extraAttacks;
+
+                struct
+                {
+                    uint32 itemEntry;
+                } createItem;
+
+                struct
+                {
+                    uint32 spellId;
+                } interruptCast;
+
+                struct
+                {
+                    uint32 itemEntry;
+                } feedPet;
+
+                struct
+                {
+                    int32 itemEntry;
+                    int32 unk;
+                } durabilityDamage;
+            };
+        };
+
+        std::vector<ExecuteLogInfo> m_executeLogInfo[MAX_EFFECT_INDEX];
+
+        void AddExecuteLogInfo(SpellEffectIndex i, ExecuteLogInfo info)
+        {
+            m_executeLogInfo[i].push_back(info);
+        }
 };
 
 enum ReplenishType

--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -221,9 +221,11 @@ void Spell::EffectResurrectNew(SpellEffectIndex eff_idx)
     uint32 mana = m_spellInfo->EffectMiscValue[eff_idx];
     pTarget->setResurrectRequestData(m_caster->GetObjectGuid(), m_caster->GetMapId(), m_caster->GetPositionX(), m_caster->GetPositionY(), m_caster->GetPositionZ(), health, mana);
     SendResurrectRequest(pTarget);
+
+    AddExecuteLogInfo(eff_idx, ExecuteLogInfo(unitTarget->GetObjectGuid()));
 }
 
-void Spell::EffectInstaKill(SpellEffectIndex /*eff_idx*/)
+void Spell::EffectInstaKill(SpellEffectIndex eff_idx)
 {
     if (!unitTarget || !unitTarget->isAlive())
         return;
@@ -259,6 +261,8 @@ void Spell::EffectInstaKill(SpellEffectIndex /*eff_idx*/)
     m_caster->SendMessageToSet(&data, true);
 
     m_caster->DealDamage(unitTarget, unitTarget->GetHealth(), nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, m_spellInfo, false);
+
+    AddExecuteLogInfo(eff_idx, ExecuteLogInfo(unitTarget->GetObjectGuid()));
 }
 
 void Spell::EffectEnvironmentalDMG(SpellEffectIndex eff_idx)
@@ -1619,6 +1623,11 @@ void Spell::EffectPowerDrain(SpellEffectIndex eff_idx)
 
     unitTarget->ModifyPower(drain_power, -new_damage);
 
+    ExecuteLogInfo info(unitTarget->GetObjectGuid());
+    info.powerDrain.power = drain_power;
+    info.powerDrain.amount = new_damage;
+    info.powerDrain.multiplier = 0.0f;
+
     // Don`t restore from self drain
     if (drain_power == POWER_MANA && m_caster != unitTarget)
     {
@@ -1631,8 +1640,12 @@ void Spell::EffectPowerDrain(SpellEffectIndex eff_idx)
 
         int32 gain = int32(new_damage * manaMultiplier);
 
-        m_caster->EnergizeBySpell(m_caster, m_spellInfo->Id, gain, POWER_MANA);
+        m_caster->ModifyPower(POWER_MANA, gain);
+
+        info.powerDrain.multiplier = manaMultiplier;
     }
+
+    AddExecuteLogInfo(eff_idx, info);
 }
 
 void Spell::EffectSendEvent(SpellEffectIndex effectIndex)
@@ -1880,6 +1893,10 @@ void Spell::DoCreateItem(SpellEffectIndex eff_idx, uint32 itemtype)
 void Spell::EffectCreateItem(SpellEffectIndex eff_idx)
 {
     DoCreateItem(eff_idx, m_spellInfo->EffectItemType[eff_idx]);
+
+    ExecuteLogInfo info;
+    info.createItem.itemEntry = m_spellInfo->EffectItemType[eff_idx];
+    AddExecuteLogInfo(eff_idx, info);
 }
 
 void Spell::EffectPersistentAA(SpellEffectIndex eff_idx)
@@ -2113,6 +2130,8 @@ void Spell::EffectOpenLock(SpellEffectIndex eff_idx)
             }
         }
     }
+
+    AddExecuteLogInfo(eff_idx, ExecuteLogInfo(guid));
 }
 
 void Spell::EffectSummonChangeItem(SpellEffectIndex eff_idx)
@@ -2418,6 +2437,8 @@ void Spell::EffectDispel(SpellEffectIndex eff_idx)
             m_caster->SendMessageToSet(&data, true);
         }
     }
+
+    AddExecuteLogInfo(eff_idx, ExecuteLogInfo(unitTarget->GetObjectGuid()));
 }
 
 void Spell::EffectDualWield(SpellEffectIndex /*eff_idx*/)
@@ -2432,7 +2453,7 @@ void Spell::EffectPull(SpellEffectIndex /*eff_idx*/)
     DEBUG_LOG("WORLD: Spell Effect DUMMY");
 }
 
-void Spell::EffectDistract(SpellEffectIndex /*eff_idx*/)
+void Spell::EffectDistract(SpellEffectIndex eff_idx)
 {
     // Check for possible target
     if (!unitTarget || unitTarget->isInCombat())
@@ -2451,6 +2472,8 @@ void Spell::EffectDistract(SpellEffectIndex /*eff_idx*/)
     unitTarget->SetFacingTo(orientation);
     // This is needed to change the facing server side as well (and it must be after the MoveDistract call)
     unitTarget->SetOrientation(orientation);
+
+    AddExecuteLogInfo(eff_idx, ExecuteLogInfo(unitTarget->GetObjectGuid()));
 }
 
 void Spell::EffectPickPocket(SpellEffectIndex /*eff_idx*/)
@@ -3119,7 +3142,7 @@ void Spell::EffectLearnPetSpell(SpellEffectIndex eff_idx)
         DEBUG_LOG("Spell: %s has learned spell %u from %s", pet->GetGuidStr().c_str(), learn_spellproto->Id, caster->GetGuidStr().c_str());
 }
 
-void Spell::EffectTaunt(SpellEffectIndex /*eff_idx*/)
+void Spell::EffectTaunt(SpellEffectIndex eff_idx)
 {
     if (!unitTarget)
         return;
@@ -3138,6 +3161,8 @@ void Spell::EffectTaunt(SpellEffectIndex /*eff_idx*/)
     // Also use this effect to set the taunter's threat to the taunted creature's highest value
     if (unitTarget->CanHaveThreatList() && unitTarget->getThreatManager().getCurrentVictim())
         unitTarget->getThreatManager().addThreat(m_caster, unitTarget->getThreatManager().getCurrentVictim()->getThreat());
+
+    AddExecuteLogInfo(eff_idx, ExecuteLogInfo(unitTarget->GetObjectGuid()));
 }
 
 void Spell::EffectWeaponDmg(SpellEffectIndex eff_idx)
@@ -3260,7 +3285,7 @@ void Spell::EffectWeaponDmg(SpellEffectIndex eff_idx)
     }
 }
 
-void Spell::EffectThreat(SpellEffectIndex /*eff_idx*/)
+void Spell::EffectThreat(SpellEffectIndex eff_idx)
 {
     if (!unitTarget || !unitTarget->isAlive() || !m_caster->isAlive())
         return;
@@ -3269,6 +3294,8 @@ void Spell::EffectThreat(SpellEffectIndex /*eff_idx*/)
         return;
 
     unitTarget->AddThreat(m_caster, float(damage), false, GetSpellSchoolMask(m_spellInfo), m_spellInfo);
+
+    AddExecuteLogInfo(eff_idx, ExecuteLogInfo(unitTarget->GetObjectGuid()));
 }
 
 void Spell::EffectHealMaxHealth(SpellEffectIndex /*eff_idx*/)
@@ -3283,7 +3310,7 @@ void Spell::EffectHealMaxHealth(SpellEffectIndex /*eff_idx*/)
     m_healing += heal;
 }
 
-void Spell::EffectInterruptCast(SpellEffectIndex /*eff_idx*/)
+void Spell::EffectInterruptCast(SpellEffectIndex eff_idx)
 {
     if (!unitTarget)
         return;
@@ -3302,6 +3329,10 @@ void Spell::EffectInterruptCast(SpellEffectIndex /*eff_idx*/)
             {
                 unitTarget->ProhibitSpellSchool(GetSpellSchoolMask(curSpellInfo), GetSpellDuration(m_spellInfo));
                 unitTarget->InterruptSpell(CurrentSpellTypes(i), false);
+
+                ExecuteLogInfo info(unitTarget->GetObjectGuid());
+                info.interruptCast.spellId = curSpellInfo->Id;
+                AddExecuteLogInfo(eff_idx, info);
             }
         }
     }
@@ -3826,7 +3857,7 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
     m_caster->GetMap()->ScriptsStart(sSpellScripts, m_spellInfo->Id, m_caster, unitTarget);
 }
 
-void Spell::EffectSanctuary(SpellEffectIndex /*eff_idx*/)
+void Spell::EffectSanctuary(SpellEffectIndex eff_idx)
 {
     if (!unitTarget)
         return;
@@ -3838,6 +3869,8 @@ void Spell::EffectSanctuary(SpellEffectIndex /*eff_idx*/)
     // Vanish allows to remove all threat and cast regular stealth so other spells can be used
     if (m_spellInfo->IsFitToFamily(SPELLFAMILY_ROGUE, uint64(0x0000000000000800)))
         ((Player*)m_caster)->RemoveSpellsCausingAura(SPELL_AURA_MOD_ROOT);
+
+    AddExecuteLogInfo(eff_idx, ExecuteLogInfo(unitTarget->GetObjectGuid()));
 }
 
 void Spell::EffectAddComboPoints(SpellEffectIndex /*eff_idx*/)
@@ -4283,9 +4316,13 @@ void Spell::EffectFeedPet(SpellEffectIndex eff_idx)
     // TODO: fix crash when a spell has two effects, both pointed at the same item target
 
     m_caster->CastCustomSpell(m_caster, m_spellInfo->EffectTriggerSpell[eff_idx], &benefit, nullptr, nullptr, true);
+
+    ExecuteLogInfo info;
+    info.feedPet.itemEntry = foodItem->GetProto()->ItemId;
+    AddExecuteLogInfo(eff_idx, info);
 }
 
-void Spell::EffectDismissPet(SpellEffectIndex /*eff_idx*/)
+void Spell::EffectDismissPet(SpellEffectIndex eff_idx)
 {
     if (m_caster->GetTypeId() != TYPEID_PLAYER)
         return;
@@ -4297,6 +4334,8 @@ void Spell::EffectDismissPet(SpellEffectIndex /*eff_idx*/)
         return;
 
     pet->Unsummon(PET_SAVE_AS_CURRENT, m_caster);
+
+    AddExecuteLogInfo(eff_idx, ExecuteLogInfo(pet->GetObjectGuid()));
 }
 
 void Spell::EffectSummonObject(SpellEffectIndex eff_idx)
@@ -4358,7 +4397,7 @@ void Spell::EffectSummonObject(SpellEffectIndex eff_idx)
         ((Creature*)m_originalCaster)->AI()->JustSummoned(pGameObj);
 }
 
-void Spell::EffectResurrect(SpellEffectIndex /*eff_idx*/)
+void Spell::EffectResurrect(SpellEffectIndex eff_idx)
 {
     if (!unitTarget || unitTarget->GetTypeId() != TYPEID_PLAYER)
         return;
@@ -4401,9 +4440,11 @@ void Spell::EffectResurrect(SpellEffectIndex /*eff_idx*/)
 
     pTarget->setResurrectRequestData(m_caster->GetObjectGuid(), m_caster->GetMapId(), m_caster->GetPositionX(), m_caster->GetPositionY(), m_caster->GetPositionZ(), health, mana);
     SendResurrectRequest(pTarget);
+
+    AddExecuteLogInfo(eff_idx, ExecuteLogInfo(unitTarget->GetObjectGuid()));
 }
 
-void Spell::EffectAddExtraAttacks(SpellEffectIndex /*eff_idx*/)
+void Spell::EffectAddExtraAttacks(SpellEffectIndex eff_idx)
 {
     if (!unitTarget || !unitTarget->isAlive())
         return;
@@ -4412,6 +4453,10 @@ void Spell::EffectAddExtraAttacks(SpellEffectIndex /*eff_idx*/)
         return;
 
     unitTarget->m_extraAttacks = damage;
+
+    ExecuteLogInfo info(unitTarget->GetObjectGuid());
+    info.extraAttacks.count = damage;
+    AddExecuteLogInfo(eff_idx, info);
 }
 
 void Spell::EffectParry(SpellEffectIndex /*eff_idx*/)
@@ -4832,6 +4877,8 @@ void Spell::EffectDispelMechanic(SpellEffectIndex eff_idx)
                 next = Auras.begin();
         }
     }
+
+    AddExecuteLogInfo(eff_idx, ExecuteLogInfo(unitTarget->GetObjectGuid()));
 }
 
 void Spell::EffectSummonDeadPet(SpellEffectIndex /*eff_idx*/)
@@ -4883,6 +4930,12 @@ void Spell::EffectDurabilityDamage(SpellEffectIndex eff_idx)
     if (slot < 0)
     {
         ((Player*)unitTarget)->DurabilityPointsLossAll(damage, (slot < -1));
+
+        ExecuteLogInfo info(unitTarget->GetObjectGuid());
+        info.durabilityDamage.itemEntry = -1;
+        info.durabilityDamage.unk = -1;
+        AddExecuteLogInfo(eff_idx, info);
+
         return;
     }
 
@@ -4891,7 +4944,14 @@ void Spell::EffectDurabilityDamage(SpellEffectIndex eff_idx)
         return;
 
     if (Item* item = ((Player*)unitTarget)->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
+    {
         ((Player*)unitTarget)->DurabilityPointsLoss(item, damage);
+
+        ExecuteLogInfo info(unitTarget->GetObjectGuid());
+        info.durabilityDamage.itemEntry = item->GetProto()->ItemId;
+        info.durabilityDamage.unk = -1;
+        AddExecuteLogInfo(eff_idx, info);
+    }
 }
 
 void Spell::EffectDurabilityDamagePCT(SpellEffectIndex eff_idx)
@@ -4920,12 +4980,14 @@ void Spell::EffectDurabilityDamagePCT(SpellEffectIndex eff_idx)
         ((Player*)unitTarget)->DurabilityLoss(item, double(damage) / 100.0f);
 }
 
-void Spell::EffectModifyThreatPercent(SpellEffectIndex /*eff_idx*/)
+void Spell::EffectModifyThreatPercent(SpellEffectIndex eff_idx)
 {
     if (!unitTarget)
         return;
 
     unitTarget->getThreatManager().modifyThreatPercent(m_caster, damage);
+
+    AddExecuteLogInfo(eff_idx, ExecuteLogInfo(unitTarget->GetObjectGuid()));
 }
 
 void Spell::EffectTransmitted(SpellEffectIndex eff_idx)
@@ -5115,13 +5177,15 @@ void Spell::EffectSpiritHeal(SpellEffectIndex /*eff_idx*/)
 }
 
 // remove insignia spell effect
-void Spell::EffectSkinPlayerCorpse(SpellEffectIndex /*eff_idx*/)
+void Spell::EffectSkinPlayerCorpse(SpellEffectIndex eff_idx)
 {
     DEBUG_LOG("Effect: SkinPlayerCorpse");
     if ((m_caster->GetTypeId() != TYPEID_PLAYER) || (unitTarget->GetTypeId() != TYPEID_PLAYER) || (unitTarget->isAlive()))
         return;
 
     ((Player*)unitTarget)->RemovedInsignia((Player*)m_caster);
+
+    AddExecuteLogInfo(eff_idx, ExecuteLogInfo(unitTarget->GetObjectGuid()));
 }
 void Spell::EffectBind(SpellEffectIndex eff_idx)
 {


### PR DESCRIPTION
SMSG_SPELLLOGEXECUTE now has the correct structure and data for all effects and targets.

See #195.
