### PR TITLE
Allow 8 CPUs to be used for mmap extraction

### DIFF
--- a/contrib/extractor_binary/ExtractResources.sh
+++ b/contrib/extractor_binary/ExtractResources.sh
@@ -88,14 +88,14 @@ fi
 if [ "$USE_MMAPS" = "1" ]
 then
   ## Obtain number ob processes
-  echo "How many CPUs should be used for extracting mmaps? (1-4)"
+  echo "How many CPUs should be used for extracting mmaps? (1-8)"
   read line
   echo
-  if [ "$line" -ge "1" -a "$line" -le "4" ]
+  if [ "$line" -ge "1" -a "$line" -le "8" ]
   then
     NUM_CPU=$line
   else
-    echo "Only number between 1 and 4 supported!"
+    echo "Only number between 1 and 8 supported!"
     exit 1
   fi
   ## Extract MMaps delayed?


### PR DESCRIPTION
This commit: https://github.com/cmangos/mangos-classic/commit/0ed121835e5b967f4976ec2d20531529be5243f0 allowed the MoveMapGen.sh script to use 8 CPUs, this just allows the ExtractResources.sh script to take advantage of that.
