### PR TITLE
Changed "cmake -i" to "cmake ." in some build instructions

### DIFF
--- a/contrib/extractor/README.linux
+++ b/contrib/extractor/README.linux
@@ -2,6 +2,6 @@ Linux instructions
 ------------------
 
 1. install cmake
-2. cmake -i
+2. cmake .
 3. make
 4. ./ad

--- a/contrib/mysql_to_pgsql/README
+++ b/contrib/mysql_to_pgsql/README
@@ -1,13 +1,13 @@
 Using cmake on a Windows
 ------------------
     1. install cmake (http://www.cmake.org/cmake/resources/software.html)
-    2. cmake -i
+    2. cmake .
     3. Project.sln
     4. {Debug/Release}/mysql2pgsql.exe
 
 Using cmake on a Unix/Linux
 ------------------
     1. install cmake
-    2. cmake -i
+    2. cmake .
     3. make
     4. ./mysql2pgsql


### PR DESCRIPTION
`cmake -i` is no longer supported and will give the error `The "cmake -i" wizard mode is no longer supported.` when used. I simply changed some build instructions to use `cmake .`
