### PR TITLE
Fix scriptdev crash at exit

### DIFF
--- a/src/game/Level3.cpp
+++ b/src/game/Level3.cpp
@@ -1042,9 +1042,6 @@ bool ChatHandler::HandleLoadScriptsCommand(char* args)
         case SCRIPT_LOAD_ERR_WRONG_API:
             SendSysMessage(LANG_SCRIPTS_WRONG_API);
             break;
-        case SCRIPT_LOAD_ERR_OUTDATED:
-            SendSysMessage(LANG_SCRIPTS_OUTDATED);
-            break;
     }
 
     return true;

--- a/src/game/ScriptMgr.cpp
+++ b/src/game/ScriptMgr.cpp
@@ -79,11 +79,6 @@ ScriptMgr::ScriptMgr() :
     m_scheduledScripts = 0;
 }
 
-ScriptMgr::~ScriptMgr()
-{
-    UnloadScriptLibrary();
-}
-
 // /////////////////////////////////////////////////////////
 //              DB SCRIPTS (loaders of static data)
 // /////////////////////////////////////////////////////////

--- a/src/game/ScriptMgr.h
+++ b/src/game/ScriptMgr.h
@@ -527,14 +527,13 @@ enum ScriptLoadResult
     SCRIPT_LOAD_OK,
     SCRIPT_LOAD_ERR_NOT_FOUND,
     SCRIPT_LOAD_ERR_WRONG_API,
-    SCRIPT_LOAD_ERR_OUTDATED,
 };
 
 class ScriptMgr
 {
     public:
         ScriptMgr();
-        ~ScriptMgr();
+        ~ScriptMgr() {};
 
         void LoadGameObjectScripts();
         void LoadGameObjectTemplateScripts();

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -140,6 +140,7 @@ void World::CleanupsBeforeStop()
     KickAll();                                       // save and kick all players
     UpdateSessions(1);                               // real players unload required UpdateSessions call
     sBattleGroundMgr.DeleteAllBattleGrounds();       // unload battleground templates before different singletons destroyed
+    sScriptMgr.UnloadScriptLibrary();
 }
 
 /// Find a session by its id
@@ -1174,9 +1175,6 @@ void World::SetInitialWorldSettings()
             break;
         case SCRIPT_LOAD_ERR_WRONG_API:
             sLog.outError("Scripting library has wrong list functions (outdated?).");
-            break;
-        case SCRIPT_LOAD_ERR_OUTDATED:
-            sLog.outError("Scripting library build for old mangosd revision. You need rebuild it.");
             break;
     }
     sLog.outString();


### PR DESCRIPTION
The ScriptDev2 library was not being unloaded in the right place. See #83 for more detail.
