### PR TITLE
Fix typo in VMap BIH generation

### DIFF
--- a/src/game/vmap/BIH.cpp
+++ b/src/game/vmap/BIH.cpp
@@ -44,7 +44,8 @@ void BIH::subdivide(int left, int right, std::vector<uint32>& tempTree, buildDat
         return;
     }
     // calculate extents
-    int axis = -1, rightOrig;
+    int axis = -1;
+    int middle;
     float clipL;
     float clipR;
     float prevClip = G3D::fnan();
@@ -72,10 +73,12 @@ void BIH::subdivide(int left, int right, std::vector<uint32>& tempTree, buildDat
         // partition L/R subsets
         clipL = -G3D::inf();
         clipR = G3D::inf();
-        rightOrig = right; // save this for later
         float nodeL = G3D::inf();
         float nodeR = -G3D::inf();
-        for (int i = left; i <= right;)
+
+        middle = right;
+
+        for (int i = left; i <= middle;)
         {
             int obj = dat.indices[i];
             float minb = dat.primBound[obj].low()[axis];
@@ -92,9 +95,9 @@ void BIH::subdivide(int left, int right, std::vector<uint32>& tempTree, buildDat
             {
                 // move to the right most
                 int t = dat.indices[i];
-                dat.indices[i] = dat.indices[right];
-                dat.indices[right] = t;
-                --right;
+                dat.indices[i] = dat.indices[middle];
+                dat.indices[middle] = t;
+                --middle;
                 if (clipR > minb)
                     clipR = minb;
             }
@@ -123,12 +126,12 @@ void BIH::subdivide(int left, int right, std::vector<uint32>& tempTree, buildDat
                 // update nodebox and recurse
                 nodeBox.lo[axis] = nodeL;
                 nodeBox.hi[axis] = nodeR;
-                subdivide(left, rightOrig, tempTree, dat, gridBox, nodeBox, nextIndex, depth + 1, stats);
+                subdivide(left, right, tempTree, dat, gridBox, nodeBox, nextIndex, depth + 1, stats);
                 return;
             }
         }
         // ensure we are making progress in the subdivision
-        if (right == rightOrig)
+        if (middle == right)
         {
             // all left
             if (prevAxis == axis && G3D::fuzzyEq(prevSplit, split))
@@ -149,17 +152,16 @@ void BIH::subdivide(int left, int right, std::vector<uint32>& tempTree, buildDat
             gridBox.hi[axis] = split;
             prevClip = G3D::fnan();
         }
-        else if (left > right)
+        else if (left > middle)
         {
             // all right
             if (prevAxis == axis && G3D::fuzzyEq(prevSplit, split))
             {
                 // we are stuck here - create a leaf
-                stats.updateLeaf(depth, rightOrig - left + 1);
-                createNode(tempTree, nodeIndex, left, rightOrig);
+                stats.updateLeaf(depth, right - left + 1);
+                createNode(tempTree, nodeIndex, left, right);
                 return;
             }
-            right = rightOrig;
             if (clipR >= split)
             {
                 // keep looping on right half
@@ -213,8 +215,8 @@ void BIH::subdivide(int left, int right, std::vector<uint32>& tempTree, buildDat
     // compute index of child nodes
     int nextIndex = tempTree.size();
     // allocate left node
-    int nl = right - left + 1;
-    int nr = rightOrig - (right + 1) + 1;
+    int nl = middle - left + 1;
+    int nr = right - (middle + 1) + 1;
     if (nl > 0)
     {
         tempTree.push_back(0);
@@ -243,11 +245,11 @@ void BIH::subdivide(int left, int right, std::vector<uint32>& tempTree, buildDat
     nodeBoxR.lo[axis] = clipR;
     // recurse
     if (nl > 0)
-        subdivide(left, right, tempTree, dat, gridBoxL, nodeBoxL, nextIndex, depth + 1, stats);
+        subdivide(left, middle, tempTree, dat, gridBoxL, nodeBoxL, nextIndex, depth + 1, stats);
     else
         stats.updateLeaf(depth + 1, 0);
     if (nr > 0)
-        subdivide(right + 1, rightOrig, tempTree, dat, gridBoxR, nodeBoxR, nextIndex + 3, depth + 1, stats);
+        subdivide(middle + 1, right, tempTree, dat, gridBoxR, nodeBoxR, nextIndex + 3, depth + 1, stats);
     else
         stats.updateLeaf(depth + 1, 0);
 }

--- a/src/game/vmap/BIH.cpp
+++ b/src/game/vmap/BIH.cpp
@@ -155,8 +155,8 @@ void BIH::subdivide(int left, int right, std::vector<uint32>& tempTree, buildDat
             if (prevAxis == axis && G3D::fuzzyEq(prevSplit, split))
             {
                 // we are stuck here - create a leaf
-                stats.updateLeaf(depth, right - left + 1);
-                createNode(tempTree, nodeIndex, left, right);
+                stats.updateLeaf(depth, rightOrig - left + 1);
+                createNode(tempTree, nodeIndex, left, rightOrig);
                 return;
             }
             right = rightOrig;


### PR DESCRIPTION
Due to this typo some objects could be left out during BIH generation and thus never checked for intersection. This breaks height and LoS calculations in some areas.

The occurrence of this bug can be seen in "Md_Mushroomcave.wmo". It can be found in several locations, for example (-6140, -2960, 400), map 0. In some parts of the cave mobs will either fall through the ground or fly up into the sky when chasing the player. LoS is not obstructed there as well.

P. S. This typo presents in all MaNGOS cores.