### PR TITLE
UpdateAutoRepeatSpells

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -19103,3 +19103,65 @@ void Player::ForceHealAndPowerUpdateInZone()
         }
     }
 }
+
+void Player::_UpdateAutoRepeatSpell()
+{
+    // check "realtime" interrupts
+    if (IsMoving() || IsNonMeleeSpellCasted(false, false, true))
+    {
+        // cancel wand shoot
+        if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_spellInfo->Category == 351)
+            InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
+
+        m_AutoRepeatFirstCast = true;
+        return;
+    }
+
+    ObjectGuid targetGuid = GetSelectionGuid();
+
+    if (!targetGuid.IsEmpty() && targetGuid.IsUnit())
+    {
+        Unit* unitTarget = GetMap()->GetUnit(targetGuid);
+        // Only do real time target updating if target doesn't remain the same
+        if (unitTarget != m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_targets.getUnitTarget())
+        {
+            m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_targets.setUnitTarget(unitTarget);
+
+            // Interrupt immediately on if new target fails the castcheck, and don't allow shooting of yourself.
+            if (unitTarget == this || m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->CheckCast(true) != SPELL_CAST_OK)
+                InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
+
+            m_AutoRepeatFirstCast = true;
+            return;
+        }
+    }
+
+    // apply delay
+    if (m_AutoRepeatFirstCast && getAttackTimer(RANGED_ATTACK) < 500)
+    {
+        setAttackTimer(RANGED_ATTACK, 500);
+        m_AutoRepeatFirstCast = false;
+    }
+
+    // castroutine
+    if (isAttackReady(RANGED_ATTACK))
+    {
+        // Check if able to cast
+        if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->CheckCast(true) != SPELL_CAST_OK)
+        {
+            InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
+            return;
+        }
+
+        // Always stand before shooting, at least players
+        if (getStandState() != UNIT_STAND_STATE_STAND)
+            SetStandState(UNIT_STAND_STATE_STAND);
+
+        // we want to shoot
+        Spell* spell = new Spell(this, m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_spellInfo, true);
+        spell->SpellStart(&(m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_targets));
+
+        // all went good, reset attack
+        resetAttackTimer(RANGED_ATTACK);
+    }
+}

--- a/src/game/Entities/Player.h
+++ b/src/game/Entities/Player.h
@@ -2082,6 +2082,8 @@ class Player : public Unit
         virtual CombatData* GetCombatData() override { if (m_charmInfo && m_charmInfo->GetCombatData()) return m_charmInfo->GetCombatData(); return m_combatData; }
         void ForceHealAndPowerUpdateInZone();
 
+        virtual void _UpdateAutoRepeatSpell() override;
+
 #ifdef BUILD_PLAYERBOT
         // A Player can either have a playerbotMgr (to manage its bots), or have playerbotAI (if it is a bot), or
         // neither. Code that enables bots must create the playerbotMgr and set it using SetPlayerbotMgr.

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -3556,7 +3556,7 @@ void Unit::_UpdateSpells(uint32 time)
 void Unit::_UpdateAutoRepeatSpell()
 {
     // check "realtime" interrupts
-    if ((GetTypeId() == TYPEID_PLAYER && ((Player*)this)->IsMoving()) || IsNonMeleeSpellCasted(false, false, true))
+    if (IsNonMeleeSpellCasted(false, false, true))
     {
         // cancel wand shoot
         if (m_currentSpells[CURRENT_AUTOREPEAT_SPELL]->m_spellInfo->Category == 351)

--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -2146,7 +2146,7 @@ class Unit : public WorldObject
         explicit Unit();
 
         void _UpdateSpells(uint32 time);
-        void _UpdateAutoRepeatSpell();
+        virtual void _UpdateAutoRepeatSpell();
         bool m_AutoRepeatFirstCast;
 
         uint32 m_attackTimer[MAX_ATTACK];
@@ -2202,6 +2202,7 @@ class Unit : public WorldObject
         bool m_isSpawningLinked;
 
         CombatData* m_combatData;
+        Spell* m_currentSpells[CURRENT_MAX_SPELL];
 
     private:
         void CleanupDeletedAuras();
@@ -2218,7 +2219,6 @@ class Unit : public WorldObject
         bool   m_dummyCombatState;                          // Used to keep combat state during some aura
 
         AttackerSet m_attackers;                            // Used to help know who is currently attacking this unit
-        Spell* m_currentSpells[CURRENT_MAX_SPELL];
         uint32 m_castCounter;                               // count casts chain of triggered spells for prevent infinity cast crashes
 
         UnitVisibility m_Visibility;


### PR DESCRIPTION
Interrupt all auto-casting on movement (hunters and casters cannot run-and-gun)
Properly switch target for auto
repeat spells on target switch for units

Ref: https://github.com/cmangos/issues/issues/489