### PR TITLE
Fix CMake warnings about missing dependencies

### DIFF
--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -480,8 +480,6 @@ if(UNIX)
   endif()
 endif()
 
-add_dependencies(${LIBRARY_NAME} revision.h)
-
 # Generate precompiled header
 if(PCH)
   cotire(${LIBRARY_NAME})

--- a/src/mangosd/CMakeLists.txt
+++ b/src/mangosd/CMakeLists.txt
@@ -61,8 +61,6 @@ add_executable(${EXECUTABLE_NAME}
   ${EXECUTABLE_SRCS}
 )
 
-add_dependencies(${EXECUTABLE_NAME} revision.h)
-
 target_link_libraries(${EXECUTABLE_NAME}
   game
   shared

--- a/src/realmd/CMakeLists.txt
+++ b/src/realmd/CMakeLists.txt
@@ -45,8 +45,6 @@ add_executable(${EXECUTABLE_NAME}
   ${EXECUTABLE_SRCS}
 )
 
-add_dependencies(${EXECUTABLE_NAME} revision.h)
-
 target_link_libraries(${EXECUTABLE_NAME}
   shared
   framework


### PR DESCRIPTION
The revision.h file is gone since 8c94d21