### PR TITLE
Lazypeonquest - Fix peon behaviour

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -1383,8 +1383,9 @@ INSERT INTO script_texts (entry,content_default,sound,type,language,emote,commen
 (-1000793,'We shall earn our deaths at the very least!',0,0,0,0,'volcor SAY_AGGRO_2'),
 (-1000794,'Don\'t give up! Fight, to the death!',0,0,0,0,'volcor SAY_AGGRO_3'),
 
-(-1000795,'OK boss, I get back to tree hitting.',0,0,0,0,'lazy peon SAY_AWAKE_1'),
-(-1000796,'Sleepy... so sleepy...',0,0,0,0,'lazy peon SAY_AWAKE_2'),
+(-1000795,'Ow! Ok, I\'ll get back to work, $N!',0,0,1,0,'Lazy Peon SAY_PEON_AWOKEN'),
+
+(-1000796,'REUSE_ME',0,0,0,0,'REUSE_ME'),
 
 (-1000797,'%s squawks and heads toward Veil Shalas. Hurry and follow!',0,2,0,0,'skywing SAY_SKYWING_START'),
 (-1000798,'%s pauses briefly before the tree and then heads inside.',0,2,0,0,'skywing SAY_SKYWING_TREE_DOWN'),

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4690,6 +4690,14 @@ SpellCastResult Spell::CheckCast(bool strict)
         {
             case SPELL_EFFECT_DUMMY:
             {
+                //By Spell ID
+                if (m_spellInfo->Id == 19938)               // Awaken Lazy Peon
+                {
+                    Unit* target = m_targets.getUnitTarget();
+                    if (!target || !target->HasAura(17743 /*SPELL_PEON_SLEEP*/) || target->GetEntry() != 10556 /*NPC_SLEEPING_PEON*/)
+                        return SPELL_FAILED_BAD_TARGETS;
+                }
+                //By SpellIconID
                 if (m_spellInfo->SpellIconID == 1648)       // Execute
                 {
                     Unit* target = m_targets.getUnitTarget();

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4690,15 +4690,16 @@ SpellCastResult Spell::CheckCast(bool strict)
         {
             case SPELL_EFFECT_DUMMY:
             {
-                //By Spell ID
+                // By Spell ID
                 if (m_spellInfo->Id == 19938)               // Awaken Lazy Peon
                 {
                     Unit* target = m_targets.getUnitTarget();
-                    if (!target || !target->HasAura(17743 /*SPELL_PEON_SLEEP*/) || target->GetEntry() != 10556 /*NPC_SLEEPING_PEON*/)
+                    // 17743 = Lazy Peon Sleep | 10556 = Lazy Peon
+                    if (!target || !target->HasAura(17743) || target->GetEntry() != 10556)
                         return SPELL_FAILED_BAD_TARGETS;
                 }
-                //By SpellIconID
-                if (m_spellInfo->SpellIconID == 1648)       // Execute
+                // By SpellIconID
+                else if (m_spellInfo->SpellIconID == 1648)       // Execute
                 {
                     Unit* target = m_targets.getUnitTarget();
                     if (!target || target->GetHealth() > target->GetMaxHealth() * 0.2)

--- a/src/scriptdev2/scripts/kalimdor/durotar.cpp
+++ b/src/scriptdev2/scripts/kalimdor/durotar.cpp
@@ -61,12 +61,14 @@ struct npc_lazy_peonAI : public ScriptedAI
     bool m_bIsAtPile;
     float m_fSpawnO;
 
-    void RestartWakeTimer() {
+    void RestartWakeTimer()
+    {
         m_uiWakeTimer = urand(100000, 120000); //Random wakeup timer 1m40s to 2m, retail times unknown, 2m is duration of sleep aura
         m_uiSleepTimer = 0; //Ensure only one of the two timers is running at any given time
     }
 
-    void RestartSleepTimer() {
+    void RestartSleepTimer()
+    {
         m_uiSleepTimer = 80000; //Go to sleep after 1m20s, confirmed blizzlike
         m_uiWakeTimer = 0; //Ensure only one of the two timers is running at any given time
     }
@@ -113,9 +115,6 @@ struct npc_lazy_peonAI : public ScriptedAI
 
     void MovementInform(uint32 uiMotionType, uint32 uiPointId) override
     {
-        /*if (!uiPointId)
-            return;*/
-
         if (uiMotionType == POINT_MOTION_TYPE && uiPointId)
         {
             switch (uiPointId)

--- a/src/scriptdev2/scripts/kalimdor/durotar.cpp
+++ b/src/scriptdev2/scripts/kalimdor/durotar.cpp
@@ -51,131 +51,6 @@ struct npc_lazy_peonAI : public ScriptedAI
     npc_lazy_peonAI(Creature* pCreature) : ScriptedAI(pCreature)
     {
         Reset();
-        //tree waypoint
-        //TODO do this via invisible creatures once they're added in the db (or actual waypoints)
-        switch (m_creature->GetGUIDLow())
-        {
-            case 6527:
-            {
-                m_fTreeX = -754.196;
-                m_fTreeY = -4141.18;
-                m_fTreeZ = 39.4156;
-                m_fTreeO = 1.54425;
-                break;
-            }
-            case 7373:
-            {
-                m_fTreeX = -775.806;
-                m_fTreeY = -4196.64;
-                m_fTreeZ = 44.5941;
-                m_fTreeO = 2.26289;
-                break;
-            }
-            case 6525:
-            {
-                m_fTreeX = -757.896;
-                m_fTreeY = -4324.19;
-                m_fTreeZ = 45.1184;
-                m_fTreeO = 4.3012;
-                break;
-            }
-            case 7374:
-            {
-                m_fTreeX = -622.255;
-                m_fTreeY = -4348.61;
-                m_fTreeZ = 41.0623;
-                m_fTreeO = 4.83115;
-                break;
-            }
-            case 6524:
-            {
-                m_fTreeX = -634.882;
-                m_fTreeY = -4480.31;
-                m_fTreeZ = 46.2619;
-                m_fTreeO = 4.71333;
-                break;
-            }
-            case 7376:
-            {
-                m_fTreeX = -498.072;
-                m_fTreeY = -4455.45;
-                m_fTreeZ = 51.0777;
-                m_fTreeO = 3.27999;
-                break;
-            }
-            case 3348:
-            {
-                m_fTreeX = -510.965;
-                m_fTreeY = -4372.57;
-                m_fTreeZ = 45.6692;
-                m_fTreeO = 0.480042;
-                break;
-            }
-            case 3346:
-            {
-                m_fTreeX = -334.424;
-                m_fTreeY = -4439.34;
-                m_fTreeZ = 54.6275;
-                m_fTreeO = 4.45416;
-                break;
-            }
-            case 3347:
-            {
-                m_fTreeX = -229.428;
-                m_fTreeY = -4449.48;
-                m_fTreeZ = 63.3728;
-                m_fTreeO = 0.016658;
-                break;
-            }
-            case 3345:
-            {
-                m_fTreeX = -225.614;
-                m_fTreeY = -4284.88;
-                m_fTreeZ = 65.0956;
-                m_fTreeO = 5.00395;
-                break;
-            }
-            case 7372:
-            {
-                m_fTreeX = -213.599;
-                m_fTreeY = -4220.75;
-                m_fTreeZ = 62.2392;
-                m_fTreeO = 1.93932;
-                break;
-            }
-            case 7375:
-            {
-                m_fTreeX = -265.354;
-                m_fTreeY = -4145.13;
-                m_fTreeZ = 55.767;
-                m_fTreeO = 5.78542;
-                break;
-            }
-            case 6523:
-            {
-                m_fTreeX = -320.191;
-                m_fTreeY = -4122.77;
-                m_fTreeZ = 51.3316;
-                m_fTreeO = 1.09659;
-                break;
-            }
-            case 6526:
-            {
-                m_fTreeX = -375.545;
-                m_fTreeY = -4018.32;
-                m_fTreeZ = 50.3465;
-                m_fTreeO = 2.86373;
-                break;
-            }
-            default:
-            {
-                //if there's no tree point, set it to current so the peon doesn't wander off
-                m_fTreeX = m_creature->GetPositionX();
-                m_fTreeY = m_creature->GetPositionY();
-                m_fTreeZ = m_creature->GetPositionZ();
-                m_fTreeO = m_creature->GetOrientation();
-            }
-        }
     }
 
     uint32 m_uiSleepTimer; //Time, until the npc goes to sleep
@@ -184,10 +59,6 @@ struct npc_lazy_peonAI : public ScriptedAI
     uint32 m_uiKneelTimer; //Time, delay kneeling to allow sound to finish playing
     uint32 m_uiGetUpTimer; //Time, npc stays at the pile so kneel animation can finish
     bool m_bIsAtPile;
-    float m_fTreeX;
-    float m_fTreeY;
-    float m_fTreeZ;
-    float m_fTreeO;
     float m_fSpawnO;
 
     void RestartWakeTimer() {
@@ -242,33 +113,36 @@ struct npc_lazy_peonAI : public ScriptedAI
 
     void MovementInform(uint32 uiMotionType, uint32 uiPointId) override
     {
-        if (uiMotionType != POINT_MOTION_TYPE || !uiPointId)
-            return;
+        /*if (!uiPointId)
+            return;*/
 
-        switch (uiPointId)
+        if (uiMotionType == POINT_MOTION_TYPE && uiPointId)
         {
-            case 1: //lumber pile
+            switch (uiPointId)
             {
-                m_creature->SetWalk(true);
-                m_bIsAtPile = true;
-                break;
+                case 1: //lumber pile
+                {
+                    m_creature->SetWalk(true);
+                    m_bIsAtPile = true;
+                    break;
+                }
+                case 2: //spawn
+                {
+                    m_creature->SetFacingTo(m_fSpawnO);
+                    m_creature->GetMotionMaster()->MoveTargetedHome(); //hacky way of getting the peon to sleep
+                    m_creature->HandleEmote(EMOTE_STATE_NONE);
+                    RestartWakeTimer();
+                    break;
+                }
             }
-            case 2: //tree
-            {
-                m_creature->SetFacingTo(m_fTreeO);
-                m_creature->PlayDistanceSound(SOUND_PEON_WORK);
-                m_creature->HandleEmote(EMOTE_STATE_WORK_CHOPWOOD);
-                m_uiChopTimer = urand(25000, 30000); //timer duration guessed, true retail time unknown
-                break;
-            }
-            case 3: //spawn
-            {
-                m_creature->SetFacingTo(m_fSpawnO);
-                m_creature->GetMotionMaster()->MoveTargetedHome(); //hacky way of getting the peon to sleep
-                m_creature->HandleEmote(EMOTE_STATE_NONE);
-                RestartWakeTimer();
-                break;
-            }
+        }
+        else if (uiMotionType == WAYPOINT_MOTION_TYPE)
+        {
+            //tree
+            m_creature->GetMotionMaster()->MoveIdle();
+            m_creature->PlayDistanceSound(SOUND_PEON_WORK);
+            m_creature->HandleEmote(EMOTE_STATE_WORK_CHOPWOOD);
+            m_uiChopTimer = urand(25000, 30000); //timer duration guessed, true retail time unknown
         }
     }
 
@@ -279,7 +153,7 @@ struct npc_lazy_peonAI : public ScriptedAI
             if (m_uiGetUpTimer <= uiDiff)
             {
                 m_uiGetUpTimer = 0;
-                m_creature->GetMotionMaster()->MovePoint(2, m_fTreeX, m_fTreeY, m_fTreeZ);
+                m_creature->GetMotionMaster()->MoveWaypoint();
                 m_bIsAtPile = false;
             }
             else
@@ -321,7 +195,7 @@ struct npc_lazy_peonAI : public ScriptedAI
                 float fX, fY, fZ;
                 m_creature->GetRespawnCoord(fX, fY, fZ, &m_fSpawnO);
                 m_uiSleepTimer = 0;
-                m_creature->GetMotionMaster()->MovePoint(3, fX, fY, fZ);
+                m_creature->GetMotionMaster()->MovePoint(2, fX, fY, fZ);
                 m_bIsAtPile = false;
                 m_uiGetUpTimer = 0;
                 m_uiKneelTimer = 0;

--- a/src/scriptdev2/scripts/kalimdor/durotar.cpp
+++ b/src/scriptdev2/scripts/kalimdor/durotar.cpp
@@ -33,14 +33,17 @@ EndContentData */
 
 enum
 {
-    SAY_PEON_AWAKE_1        = -1000795,
-    SAY_PEON_AWAKE_2        = -1000796,
+    SAY_PEON_AWOKEN = -1000795,
 
-    SPELL_PEON_SLEEP        = 17743,
-    SPELL_AWAKEN_PEON       = 19938,
+    SOUND_PEON_WORK = 6197,
+    SOUND_PEON_AWAKE_1 = 6292,
+    SOUND_PEON_AWAKE_2 = 6294,
 
-    NPC_SLEEPING_PEON       = 10556,
-    GO_LUMBERPILE           = 175784,
+    SPELL_PEON_SLEEP = 17743,
+    SPELL_AWAKEN_PEON = 19938,
+
+    NPC_SLEEPING_PEON = 10556,
+    GO_LUMBERPILE = 175784,
 };
 
 struct npc_lazy_peonAI : public ScriptedAI
@@ -48,38 +51,190 @@ struct npc_lazy_peonAI : public ScriptedAI
     npc_lazy_peonAI(Creature* pCreature) : ScriptedAI(pCreature)
     {
         Reset();
-        m_uiStopSleepingTimer = urand(30000, 120000);       // Set on spawn to a potential small timer, to get nice results for initial case
+        //tree waypoint
+        //TODO do this via invisible creatures once they're added in the db (or actual waypoints)
+        switch (m_creature->GetGUIDLow())
+        {
+            case 6527:
+            {
+                m_fTreeX = -754.196;
+                m_fTreeY = -4141.18;
+                m_fTreeZ = 39.4156;
+                m_fTreeO = 1.54425;
+                break;
+            }
+            case 7373:
+            {
+                m_fTreeX = -775.806;
+                m_fTreeY = -4196.64;
+                m_fTreeZ = 44.5941;
+                m_fTreeO = 2.26289;
+                break;
+            }
+            case 6525:
+            {
+                m_fTreeX = -757.896;
+                m_fTreeY = -4324.19;
+                m_fTreeZ = 45.1184;
+                m_fTreeO = 4.3012;
+                break;
+            }
+            case 7374:
+            {
+                m_fTreeX = -622.255;
+                m_fTreeY = -4348.61;
+                m_fTreeZ = 41.0623;
+                m_fTreeO = 4.83115;
+                break;
+            }
+            case 6524:
+            {
+                m_fTreeX = -634.882;
+                m_fTreeY = -4480.31;
+                m_fTreeZ = 46.2619;
+                m_fTreeO = 4.71333;
+                break;
+            }
+            case 7376:
+            {
+                m_fTreeX = -498.072;
+                m_fTreeY = -4455.45;
+                m_fTreeZ = 51.0777;
+                m_fTreeO = 3.27999;
+                break;
+            }
+            case 3348:
+            {
+                m_fTreeX = -510.965;
+                m_fTreeY = -4372.57;
+                m_fTreeZ = 45.6692;
+                m_fTreeO = 0.480042;
+                break;
+            }
+            case 3346:
+            {
+                m_fTreeX = -334.424;
+                m_fTreeY = -4439.34;
+                m_fTreeZ = 54.6275;
+                m_fTreeO = 4.45416;
+                break;
+            }
+            case 3347:
+            {
+                m_fTreeX = -229.428;
+                m_fTreeY = -4449.48;
+                m_fTreeZ = 63.3728;
+                m_fTreeO = 0.016658;
+                break;
+            }
+            case 3345:
+            {
+                m_fTreeX = -225.614;
+                m_fTreeY = -4284.88;
+                m_fTreeZ = 65.0956;
+                m_fTreeO = 5.00395;
+                break;
+            }
+            case 7372:
+            {
+                m_fTreeX = -213.599;
+                m_fTreeY = -4220.75;
+                m_fTreeZ = 62.2392;
+                m_fTreeO = 1.93932;
+                break;
+            }
+            case 7375:
+            {
+                m_fTreeX = -265.354;
+                m_fTreeY = -4145.13;
+                m_fTreeZ = 55.767;
+                m_fTreeO = 5.78542;
+                break;
+            }
+            case 6523:
+            {
+                m_fTreeX = -320.191;
+                m_fTreeY = -4122.77;
+                m_fTreeZ = 51.3316;
+                m_fTreeO = 1.09659;
+                break;
+            }
+            case 6526:
+            {
+                m_fTreeX = -375.545;
+                m_fTreeY = -4018.32;
+                m_fTreeZ = 50.3465;
+                m_fTreeO = 2.86373;
+                break;
+            }
+            default:
+            {
+                //if there's no tree point, set it to current so the peon doesn't wander off
+                m_fTreeX = m_creature->GetPositionX();
+                m_fTreeY = m_creature->GetPositionY();
+                m_fTreeZ = m_creature->GetPositionZ();
+                m_fTreeO = m_creature->GetOrientation();
+            }
+        }
     }
 
-    uint32 m_uiResetSleepTimer;                             // Time, until the npc stops harvesting lumber
-    uint32 m_uiStopSleepingTimer;                           // Time, until the npcs (re)starts working on its own
+    uint32 m_uiSleepTimer; //Time, until the npc goes to sleep
+    uint32 m_uiWakeTimer;  //Time, until the npc wakes up on its own
+    uint32 m_uiChopTimer; //Time, until the npc stops chopping at the tree
+    uint32 m_uiKneelTimer; //Time, delay kneeling to allow sound to finish playing
+    uint32 m_uiGetUpTimer; //Time, npc stays at the pile so kneel animation can finish
+    bool m_bIsAtPile;
+    float m_fTreeX;
+    float m_fTreeY;
+    float m_fTreeZ;
+    float m_fTreeO;
+    float m_fSpawnO;
+
+    void RestartWakeTimer() {
+        m_uiWakeTimer = urand(100000, 120000); //Random wakeup timer 1m40s to 2m, retail times unknown, 2m is duration of sleep aura
+        m_uiSleepTimer = 0; //Ensure only one of the two timers is running at any given time
+    }
+
+    void RestartSleepTimer() {
+        m_uiSleepTimer = 80000; //Go to sleep after 1m20s, confirmed blizzlike
+        m_uiWakeTimer = 0; //Ensure only one of the two timers is running at any given time
+    }
 
     void Reset() override
     {
-        m_uiResetSleepTimer = 0;
-        m_uiStopSleepingTimer = urand(90000, 120000);       // Sleeping aura has only 2min duration
+        RestartWakeTimer();
+        m_uiGetUpTimer = 0;
+        m_uiKneelTimer = 0;
+        m_uiChopTimer = 0;
+        m_bIsAtPile = false;
     }
 
-    // Can also be self invoked for random working
-    void StartLumbering(Unit* pInvoker)
+    void Awaken(Unit* pInvoker)
     {
-        m_uiStopSleepingTimer = 0;
+        if (pInvoker->GetTypeId() == TYPEID_PLAYER)
+        {
+            DoScriptText(SAY_PEON_AWOKEN, m_creature, pInvoker);
+            m_creature->PlayDistanceSound(urand(0, 1) ? SOUND_PEON_AWAKE_1 : SOUND_PEON_AWAKE_2);
+            m_creature->SetWalk(false); //peon will run if awoken by player
+            ((Player*)pInvoker)->KilledMonsterCredit(m_creature->GetEntry(), m_creature->GetObjectGuid());
+        }
+        else
+            m_creature->SetWalk(true); //peon will walk if awoken on its own
+
+        m_creature->RemoveAurasDueToSpell(SPELL_PEON_SLEEP);
+        RestartSleepTimer();
+        GoLumberPile();
+    }
+
+    void GoLumberPile()
+    {
         if (GameObject* pLumber = GetClosestGameObjectWithEntry(m_creature, GO_LUMBERPILE, 15.0f))
         {
-            m_creature->RemoveAurasDueToSpell(SPELL_PEON_SLEEP);
-
             float fX, fY, fZ;
-            m_creature->SetWalk(false);
             pLumber->GetContactPoint(m_creature, fX, fY, fZ, CONTACT_DISTANCE);
-
-            if (pInvoker->GetTypeId() == TYPEID_PLAYER)
-            {
-                DoScriptText(SAY_PEON_AWAKE_1, m_creature);
-                ((Player*)pInvoker)->KilledMonsterCredit(m_creature->GetEntry(), m_creature->GetObjectGuid());
-                m_creature->GetMotionMaster()->MovePoint(1, fX, fY, fZ);
-            }
-            else
-                m_creature->GetMotionMaster()->MovePoint(2, fX, fY, fZ);
+            m_creature->HandleEmote(EMOTE_STATE_NONE); //cancel chopping
+            m_creature->GetMotionMaster()->MovePoint(1, fX, fY, fZ);
+            m_uiKneelTimer = 2500; //timer duration guessed, true retail time unknown
         }
         else
             script_error_log("No GameObject of entry %u was found in range or something really bad happened.", GO_LUMBERPILE);
@@ -90,32 +245,98 @@ struct npc_lazy_peonAI : public ScriptedAI
         if (uiMotionType != POINT_MOTION_TYPE || !uiPointId)
             return;
 
-        m_creature->HandleEmote(EMOTE_STATE_WORK_CHOPWOOD);
-        // TODO - random bevahior for self-invoked awakening guesswork
-        m_uiResetSleepTimer = uiPointId == 1 ? 80000 : urand(30000, 60000);
+        switch (uiPointId)
+        {
+            case 1: //lumber pile
+            {
+                m_creature->SetWalk(true);
+                m_bIsAtPile = true;
+                break;
+            }
+            case 2: //tree
+            {
+                m_creature->SetFacingTo(m_fTreeO);
+                m_creature->PlayDistanceSound(SOUND_PEON_WORK);
+                m_creature->HandleEmote(EMOTE_STATE_WORK_CHOPWOOD);
+                m_uiChopTimer = urand(25000, 30000); //timer duration guessed, true retail time unknown
+                break;
+            }
+            case 3: //spawn
+            {
+                m_creature->SetFacingTo(m_fSpawnO);
+                m_creature->GetMotionMaster()->MoveTargetedHome(); //hacky way of getting the peon to sleep
+                m_creature->HandleEmote(EMOTE_STATE_NONE);
+                RestartWakeTimer();
+                break;
+            }
+        }
     }
 
     void UpdateAI(const uint32 uiDiff) override
     {
-        if (m_uiResetSleepTimer)
+        if (m_uiGetUpTimer)
         {
-            if (m_uiResetSleepTimer <= uiDiff)
+            if (m_uiGetUpTimer <= uiDiff)
             {
-                DoScriptText(SAY_PEON_AWAKE_2, m_creature);
-                m_creature->HandleEmote(EMOTE_STATE_NONE);
-                EnterEvadeMode();
-                m_uiResetSleepTimer = 0;
+                m_uiGetUpTimer = 0;
+                m_creature->GetMotionMaster()->MovePoint(2, m_fTreeX, m_fTreeY, m_fTreeZ);
+                m_bIsAtPile = false;
             }
             else
-                m_uiResetSleepTimer -= uiDiff;
+                m_uiGetUpTimer -= uiDiff;
         }
 
-        if (m_uiStopSleepingTimer)
+        if (m_uiKneelTimer)
         {
-            if (m_uiStopSleepingTimer <= uiDiff)
-                StartLumbering(m_creature);
+            if (m_uiKneelTimer <= uiDiff)
+            {
+                if (m_bIsAtPile)
+                {
+                    m_uiKneelTimer = 0;
+                    m_creature->HandleEmote(EMOTE_ONESHOT_KNEEL);
+                    m_uiGetUpTimer = 3000; //timer duration guessed, true retail time unknown
+                }
+                else
+                    m_uiKneelTimer = 1; //guarantee it's checked again on next update
+            }
             else
-                m_uiStopSleepingTimer -= uiDiff;
+                m_uiKneelTimer -= uiDiff;
+        }
+
+        if (m_uiChopTimer)
+        {
+            if (m_uiChopTimer <= uiDiff)
+            {
+                m_uiChopTimer = 0;
+                GoLumberPile();
+            }
+            else
+                m_uiChopTimer -= uiDiff;
+        }
+
+        if (m_uiSleepTimer)
+        {
+            if (m_uiSleepTimer <= uiDiff)
+            {
+                float fX, fY, fZ;
+                m_creature->GetRespawnCoord(fX, fY, fZ, &m_fSpawnO);
+                m_uiSleepTimer = 0;
+                m_creature->GetMotionMaster()->MovePoint(3, fX, fY, fZ);
+                m_bIsAtPile = false;
+                m_uiGetUpTimer = 0;
+                m_uiKneelTimer = 0;
+                m_uiChopTimer = 0;
+            }
+            else
+                m_uiSleepTimer -= uiDiff;
+        }
+
+        if (m_uiWakeTimer)
+        {
+            if (m_uiWakeTimer <= uiDiff)
+                Awaken(m_creature);
+            else
+                m_uiWakeTimer -= uiDiff;
         }
     }
 };
@@ -130,11 +351,12 @@ bool EffectDummyCreature_lazy_peon_awake(Unit* pCaster, uint32 uiSpellId, SpellE
     // always check spellid and effectindex
     if (uiSpellId == SPELL_AWAKEN_PEON && uiEffIndex == EFFECT_INDEX_0)
     {
+        //TODO some of these checks are now redundant, should be removed by someone who knows how to do so without breaking things
         if (!pCreatureTarget->HasAura(SPELL_PEON_SLEEP) || pCaster->GetTypeId() != TYPEID_PLAYER || pCreatureTarget->GetEntry() != NPC_SLEEPING_PEON)
             return true;
 
         if (npc_lazy_peonAI* pPeonAI = dynamic_cast<npc_lazy_peonAI*>(pCreatureTarget->AI()))
-            pPeonAI->StartLumbering(pCaster);
+            pPeonAI->Awaken(pCaster);
 
         // always return true when we are handling this spell and effect
         return true;


### PR DESCRIPTION
Peons will chop at the trees, not their piles, and will sleep at their spawns.
It is no longer possible to hit awake peons.
Peons are now playing sounds as they should & using the correct classic text.

Meant to go together with [my PR to cmangos/classic-db](https://github.com/cmangos/classic-db/pull/18).

Posting so @Phatcat can do his testing, probably shouldn't be merged until he's done double-checking.