### PR TITLE
Improved Mend Pet fix

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4251,11 +4251,12 @@ SpellCastResult Spell::CheckCast(bool strict)
             bool dispelTarget = false;
             uint32 mechanic = m_spellInfo->EffectMiscValue[0];
             SpellEntry const* spell = nullptr;
-
+            
             Unit::SpellAuraHolderMap& Auras = target->GetSpellAuraHolderMap();
             for (Unit::SpellAuraHolderMap::iterator iter = Auras.begin(); iter != Auras.end(); ++iter)
             {
                 spell = iter->second->GetSpellProto();
+                
                 if (spell->Dispel == mechanic)
                 {
                     dispelTarget = true;
@@ -4263,8 +4264,12 @@ SpellCastResult Spell::CheckCast(bool strict)
                 }
             }
 
+            // Need to see if target is a pet in order to avoid showing dispel fail message
+            Creature* target = (Creature*)m_targets.getUnitTarget();
+
             if (!dispelTarget)
-                return SPELL_FAILED_NOTHING_TO_DISPEL;
+                if (!target->IsPet())
+                    return SPELL_FAILED_NOTHING_TO_DISPEL;
         }
     }
 

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -3185,6 +3185,11 @@ void Spell::SendCastResult(Player* caster, SpellEntry const* spellInfo, SpellCas
 {
     WorldPacket data(SMSG_CAST_FAILED, (4 + 1 + 1));
     data << uint32(spellInfo->Id);
+    
+    if (spellInfo->Id == 24406 && result == SPELL_FAILED_NOTHING_TO_DISPEL) // Improved mend pet - don't send anything to player if nothing to dispel
+    {
+        return;
+    }
 
     if (result != SPELL_CAST_OK)
     {
@@ -4246,7 +4251,7 @@ SpellCastResult Spell::CheckCast(bool strict)
 
         // Classic only (seems to be handled client side tbc and later (not verified)) - Only check effect 0
         // Spells such as Abolish Poison have dispel on effect 1 but should be castable even if target not poisoned
-        if (m_spellInfo->Effect[0] == SPELL_EFFECT_DISPEL && m_spellInfo->Id != 24406) // Ignore Hunter's Improved Mend Pet
+        if (m_spellInfo->Effect[0] == SPELL_EFFECT_DISPEL)
         {
             bool dispelTarget = false;
             uint32 mechanic = m_spellInfo->EffectMiscValue[0];
@@ -4256,7 +4261,7 @@ SpellCastResult Spell::CheckCast(bool strict)
             for (Unit::SpellAuraHolderMap::iterator iter = Auras.begin(); iter != Auras.end(); ++iter)
             {
                 spell = iter->second->GetSpellProto();
-                if (spell->Dispel == mechanic)
+                if (spell->Dispel == mechanic || (m_spellInfo->Id == 24406 && (spell->Dispel == DISPEL_MAGIC || spell->Dispel == DISPEL_CURSE || spell->Dispel == DISPEL_DISEASE || spell->Dispel == DISPEL_POISON)))
                 {
                     dispelTarget = true;
                     break;

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4263,11 +4263,10 @@ SpellCastResult Spell::CheckCast(bool strict)
                 }
             }
 
-            // Need to see if target is a pet in order to avoid showing dispel fail message
-            Creature* target = (Creature*)m_targets.getUnitTarget();
-
             if (!dispelTarget)
-                if (!target->IsPet())
+                if (m_spellInfo->Id == 24406) // Hunter's Improved Mend Pet
+                    return SPELL_CAST_OK;
+                else
                     return SPELL_FAILED_NOTHING_TO_DISPEL;
         }
     }

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4246,7 +4246,7 @@ SpellCastResult Spell::CheckCast(bool strict)
 
         // Classic only (seems to be handled client side tbc and later (not verified)) - Only check effect 0
         // Spells such as Abolish Poison have dispel on effect 1 but should be castable even if target not poisoned
-        if (m_spellInfo->Effect[0] == SPELL_EFFECT_DISPEL)
+        if (m_spellInfo->Effect[0] == SPELL_EFFECT_DISPEL && m_spellInfo->Id != 24406) // Ignore Hunter's Improved Mend Pet
         {
             bool dispelTarget = false;
             uint32 mechanic = m_spellInfo->EffectMiscValue[0];
@@ -4264,10 +4264,7 @@ SpellCastResult Spell::CheckCast(bool strict)
             }
 
             if (!dispelTarget)
-                if (m_spellInfo->Id == 24406) // Hunter's Improved Mend Pet
-                    return SPELL_CAST_OK;
-                else
-                    return SPELL_FAILED_NOTHING_TO_DISPEL;
+                return SPELL_FAILED_NOTHING_TO_DISPEL;
         }
     }
 

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -3186,11 +3186,6 @@ void Spell::SendCastResult(Player* caster, SpellEntry const* spellInfo, SpellCas
     WorldPacket data(SMSG_CAST_FAILED, (4 + 1 + 1));
     data << uint32(spellInfo->Id);
     
-    if (spellInfo->Id == 24406 && result == SPELL_FAILED_NOTHING_TO_DISPEL) // Improved mend pet - don't send anything to player if nothing to dispel
-    {
-        return;
-    }
-
     if (result != SPELL_CAST_OK)
     {
         data << uint8(2); // status = fail

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4251,12 +4251,11 @@ SpellCastResult Spell::CheckCast(bool strict)
             bool dispelTarget = false;
             uint32 mechanic = m_spellInfo->EffectMiscValue[0];
             SpellEntry const* spell = nullptr;
-            
+
             Unit::SpellAuraHolderMap& Auras = target->GetSpellAuraHolderMap();
             for (Unit::SpellAuraHolderMap::iterator iter = Auras.begin(); iter != Auras.end(); ++iter)
             {
                 spell = iter->second->GetSpellProto();
-                
                 if (spell->Dispel == mechanic)
                 {
                     dispelTarget = true;

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -4394,8 +4394,8 @@ void Aura::PeriodicTick()
             if (spellProto->SpellFamilyName == SPELLFAMILY_HUNTER && spellProto->SpellFamilyFlags && spellProto->SpellIconID == 267)
             {
                 // Check caster has one of the ranks of Improved Mend Pet
-                if (pCaster->HasSpell(19572) || pCaster->HasSpell(19573)) {
-
+                if (pCaster->HasSpell(19572) || pCaster->HasSpell(19573))
+                {
                     // The first tick is fired when channel starts, so only check other ticks
                     if (GetAuraTicks() > 1)
                     {
@@ -4409,9 +4409,7 @@ void Aura::PeriodicTick()
                             triggerAmount = 50; //rank 2
 
                         if (roll_chance_i(triggerAmount))
-                        {
                             pCaster->CastSpell(target, 24406, true, nullptr, this);
-                        }
                     }
                 }
             }

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -4396,20 +4396,17 @@ void Aura::PeriodicTick()
                 // Check caster has one of the ranks of Improved Mend Pet
                 if (pCaster->HasSpell(19572) || pCaster->HasSpell(19573))
                 {
-                    // The first tick is fired when channel starts, so only check other ticks
-                    if (GetAuraTicks() > 1)
-                    {
-                        int32 triggerAmount = 0;
+                    int32 triggerAmount = 0;
 
-                        // Set threshold for dispel check
-                        if (pCaster->HasSpell(19572))
-                            triggerAmount = 15; //rank 1
+                    // Set threshold for dispel check
+                    if (pCaster->HasSpell(19572))
+                        triggerAmount = 15; //rank 1
 
-                        if (pCaster->HasSpell(19573))
-                            triggerAmount = 50; //rank 2
+                    if (pCaster->HasSpell(19573))
+                        triggerAmount = 50; //rank 2
 
-                        if (roll_chance_i(triggerAmount))
-                            pCaster->CastSpell(target, 24406, true, nullptr, this);
+                    if (roll_chance_i(triggerAmount)) {
+                        pCaster->CastSpell(target, 24406, true, nullptr, this);
                     }
                 }
             }

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -4389,22 +4389,22 @@ void Aura::PeriodicTick()
                     }
                 }
             }
-            
+
             // Hunter's Improved Mend Pet dispel check
             if (spellProto->SpellFamilyName == SPELLFAMILY_HUNTER && spellProto->SpellFamilyFlags && spellProto->SpellIconID == 267)
             {
                 // Check caster has one of the ranks of Improved Mend Pet
                 if (pCaster->HasSpell(19572) || pCaster->HasSpell(19573)) {
-                    
+
                     // The first tick is fired when channel starts, so only check other ticks
                     if (GetAuraTicks() > 1)
                     {
                         int32 triggerAmount = 0;
-                        
+
                         // Set threshold for dispel check
                         if (pCaster->HasSpell(19572))
                             triggerAmount = 15; //rank 1
-                            
+
                         if (pCaster->HasSpell(19573))
                             triggerAmount = 50; //rank 2
 

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -4389,6 +4389,33 @@ void Aura::PeriodicTick()
                     }
                 }
             }
+            
+            // Hunter's Improved Mend Pet dispel check
+            if (spellProto->SpellFamilyName == SPELLFAMILY_HUNTER && spellProto->SpellFamilyFlags && spellProto->SpellIconID == 267)
+            {
+                // Check caster has one of the ranks of Improved Mend Pet
+                if (pCaster->HasSpell(19572) || pCaster->HasSpell(19573)) {
+                    
+                    // The first tick is fired when channel starts, so only check other ticks
+                    if (GetAuraTicks() > 1)
+                    {
+                        int32 triggerAmount = 0;
+                        
+                        // Set threshold for dispel check
+                        if (pCaster->HasSpell(19572))
+                            triggerAmount = 15; //rank 1
+                            
+                        if (pCaster->HasSpell(19573))
+                            triggerAmount = 50; //rank 2
+
+                        if (roll_chance_i(triggerAmount))
+                        {
+                            pCaster->CastSpell(target, 24406, true, nullptr, this);
+                        }
+                    }
+                }
+            }
+            
             break;
         }
         case SPELL_AURA_PERIODIC_MANA_LEECH:

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -4393,21 +4393,15 @@ void Aura::PeriodicTick()
             // Hunter's Improved Mend Pet dispel check
             if (spellProto->SpellFamilyName == SPELLFAMILY_HUNTER && spellProto->SpellFamilyFlags && spellProto->SpellIconID == 267)
             {
-                // Check caster has one of the ranks of Improved Mend Pet
-                if (pCaster->HasSpell(19572) || pCaster->HasSpell(19573))
+                int32 triggerAmount = 0;
+                
+                Unit::AuraList const& aurasOverrideClassScripts = pCaster->GetAurasByType(SPELL_AURA_OVERRIDE_CLASS_SCRIPTS);
+                for (Unit::AuraList::const_iterator iter = aurasOverrideClassScripts.begin(); iter != aurasOverrideClassScripts.end(); ++iter)
                 {
-                    int32 triggerAmount = 0;
-
-                    // Set threshold for dispel check
-                    if (pCaster->HasSpell(19572))
-                        triggerAmount = 15; //rank 1
-
-                    if (pCaster->HasSpell(19573))
-                        triggerAmount = 50; //rank 2
-
-                    if (roll_chance_i(triggerAmount))
-                        pCaster->CastSpell(target, 24406, true, nullptr, this);
+                    triggerAmount = (*iter)->GetModifier()->m_amount;
                 }
+                if (triggerAmount > 0 && roll_chance_i(triggerAmount))
+                    pCaster->CastSpell(target, 24406, true, nullptr, this);
             }
             
             break;

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -4405,9 +4405,8 @@ void Aura::PeriodicTick()
                     if (pCaster->HasSpell(19573))
                         triggerAmount = 50; //rank 2
 
-                    if (roll_chance_i(triggerAmount)) {
+                    if (roll_chance_i(triggerAmount))
                         pCaster->CastSpell(target, 24406, true, nullptr, this);
-                    }
                 }
             }
             

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -1266,7 +1266,7 @@ SpellAuraProcResult Unit::HandleOverrideClassScriptAuraProc(Unit* pVictim, uint3
             if (!roll_chance_i(triggerAmount))
                 return SPELL_AURA_PROC_FAILED;
 
-            triggered_spell_id = 24406;
+            //triggered_spell_id = 24406; // we don't actually want to cast this until the first tick
             break;
         }
         case 4309:


### PR DESCRIPTION
This is my first time both working with cmangos and C++, so I apologise for any mess or bits that are just plain silly. I made the PR then realised it had issues, and panicked and made a mess of the PR. Now I just hope someone more knowledgeable can give me some feedback about it and how best to implement it.

This PR attempts to fix the fact Improved Mend Pet does not roll to dispel every tick (https://github.com/cmangos/issues/issues/306) and it'd be desirable if it removed the "Nothing to dispel" message.

The way I have set the chance is currently hard-coded as I couldn't figure out how to pull the information from the spell or the talent information.

It currently also ignores the "Nothing to dispel" check/error and just casts a dispel regardless -- this particular behaviour is undesirable, but I'm not sure how to get around not needing to return a spell result.