### PR TITLE
[Spell] Wand shoot should not proc anything, e.g. not proc Arcane Con…

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -1099,6 +1099,10 @@ bool SpellMgr::IsSpellProcEventCanTriggeredBy(SpellProcEventEntry const* spellPr
     // No extra req need
     uint32 procEvent_procEx = PROC_EX_NONE;
 
+    // wand should not proc anything
+    if (procSpell && procSpell->Id == 5019)
+        return false;
+
     // check prockFlags for condition
     if ((procFlags & EventProcFlag) == 0)
         return false;


### PR DESCRIPTION
…centration

The spell prod flags in dbc includes range hit proc, but I think this should be wrong.