### PR TITLE
Ignore line of sight for objects with MOD_M2 flag

### DIFF
--- a/src/game/vmap/BIH.h
+++ b/src/game/vmap/BIH.h
@@ -119,7 +119,7 @@ class BIH
         size_t primCount() const { return objects.size(); }
 
         template<typename RayCallback>
-        void intersectRay(const Ray& r, RayCallback& intersectCallback, float& maxDist, bool stopAtFirst = false) const
+        void intersectRay(const Ray& r, RayCallback& intersectCallback, float& maxDist, bool stopAtFirst = false, bool checkLOS = false) const
         {
             float intervalMin = -1.f;
             float intervalMax = -1.f;
@@ -222,7 +222,7 @@ class BIH
                             int n = tree[node + 1];
                             while (n > 0)
                             {
-                                bool hit = intersectCallback(r, objects[offset], maxDist, stopAtFirst);
+                                bool hit = intersectCallback(r, objects[offset], maxDist, stopAtFirst, checkLOS);
                                 if (stopAtFirst && hit) return;
                                 --n;
                                 ++offset;

--- a/src/game/vmap/BIHWrap.h
+++ b/src/game/vmap/BIHWrap.h
@@ -35,13 +35,13 @@ class BIHWrap
 
             MDLCallback(RayCallback& callback, const T* const* objects_array, uint32 objSize) : objects(objects_array), cb(callback), objectsSize(objSize) {}
 
-            bool operator()(const Ray& r, uint32 Idx, float& MaxDist, bool /*stopAtFirst*/)
+            bool operator()(const Ray& r, uint32 Idx, float& MaxDist, bool /*stopAtFirst*/, bool /*checkLOS*/)
             {
                 if (Idx >= objectsSize)
                     return false;
 
                 if (const T* obj = objects[Idx])
-                    return cb(r, *obj, MaxDist/*, stopAtFirst*/);
+                    return cb(r, *obj, MaxDist/*, stopAtFirst, checkLOS*/);
                 return false;
             }
 

--- a/src/game/vmap/MapTree.cpp
+++ b/src/game/vmap/MapTree.cpp
@@ -20,6 +20,7 @@
 #include "ModelInstance.h"
 #include "VMapManager2.h"
 #include "VMapDefinitions.h"
+#include "WorldModel.h"
 
 #include <string>
 #include <sstream>
@@ -35,9 +36,9 @@ namespace VMAP
     {
         public:
             MapRayCallback(ModelInstance* val): prims(val), hit(false) {}
-            bool operator()(const G3D::Ray& ray, uint32 entry, float& distance, bool pStopAtFirstHit = true)
+            bool operator()(const G3D::Ray& ray, uint32 entry, float& distance, bool pStopAtFirstHit = true, bool pCheckLOS = false)
             {
-                bool result = prims[entry].intersectRay(ray, distance, pStopAtFirstHit);
+                bool result = prims[entry].intersectRay(ray, distance, pStopAtFirstHit, pCheckLOS);
                 if (result)
                     hit = true;
                 return result;
@@ -140,11 +141,11 @@ namespace VMAP
     Else, pMaxDist is not modified and returns false;
     */
 
-    bool StaticMapTree::getIntersectionTime(const G3D::Ray& pRay, float& pMaxDist, bool pStopAtFirstHit) const
+    bool StaticMapTree::getIntersectionTime(const G3D::Ray& pRay, float& pMaxDist, bool pStopAtFirstHit, bool pCheckLOS) const
     {
         float distance = pMaxDist;
         MapRayCallback intersectionCallBack(iTreeValues);
-        iTree.intersectRay(pRay, intersectionCallBack, distance, pStopAtFirstHit);
+        iTree.intersectRay(pRay, intersectionCallBack, distance, pStopAtFirstHit, pCheckLOS);
         if (intersectionCallBack.didHit())
             pMaxDist = distance;
         return intersectionCallBack.didHit();
@@ -161,7 +162,7 @@ namespace VMAP
             return true;
         // direction with length of 1
         G3D::Ray ray = G3D::Ray::fromOriginAndDirection(pos1, (pos2 - pos1) / maxDist);
-        if (getIntersectionTime(ray, maxDist, true))
+        if (getIntersectionTime(ray, maxDist, true, true))
             return false;
 
         return true;
@@ -186,7 +187,7 @@ namespace VMAP
         Vector3 dir = (pPos2 - pPos1) / maxDist;            // direction with length of 1
         G3D::Ray ray(pPos1, dir);
         float dist = maxDist;
-        if (getIntersectionTime(ray, dist, false))
+        if (getIntersectionTime(ray, dist))
         {
             pResultHitPos = pPos1 + dir * dist;
             if (pModifyDist < 0)
@@ -218,7 +219,7 @@ namespace VMAP
         Vector3 dir = Vector3(0, 0, -1);
         G3D::Ray ray(pPos, dir);   // direction with length of 1
         float maxDist = maxSearchDist;
-        if (getIntersectionTime(ray, maxDist, false))
+        if (getIntersectionTime(ray, maxDist))
         {
             height = pPos.z - maxDist;
         }
@@ -299,6 +300,7 @@ namespace VMAP
             if (!iIsTiled && ModelSpawn::readFromFile(rf, spawn))
             {
                 WorldModel* model = vm->acquireModelInstance(iBasePath, spawn.name);
+                model->setModelFlags(spawn.flags);
                 DEBUG_FILTER_LOG(LOG_FILTER_MAP_LOADING, "StaticMapTree::InitMap(): loading %s", spawn.name.c_str());
                 if (model)
                 {
@@ -369,6 +371,7 @@ namespace VMAP
                 {
                     // acquire model instance
                     WorldModel* model = vm->acquireModelInstance(iBasePath, spawn.name);
+                    model->setModelFlags(spawn.flags);
                     if (!model)
                         ERROR_LOG("StaticMapTree::LoadMapTile() could not acquire WorldModel pointer for '%s'!", spawn.name.c_str());
 

--- a/src/game/vmap/MapTree.h
+++ b/src/game/vmap/MapTree.h
@@ -57,7 +57,7 @@ namespace VMAP
             std::string iBasePath;
 
         private:
-            bool getIntersectionTime(const G3D::Ray& pRay, float& pMaxDist, bool pStopAtFirstHit) const;
+            bool getIntersectionTime(const G3D::Ray& pRay, float& pMaxDist, bool pStopAtFirstHit = false, bool pCheckLOS = false) const;
             // bool containsLoadedMapTile(unsigned int pTileIdent) const { return(iLoadedMapTiles.containsKey(pTileIdent)); }
         public:
             static std::string getTileFileName(uint32 mapID, uint32 tileX, uint32 tileY);

--- a/src/game/vmap/ModelInstance.cpp
+++ b/src/game/vmap/ModelInstance.cpp
@@ -32,7 +32,7 @@ namespace VMAP
         iInvScale = 1.f / iScale;
     }
 
-    bool ModelInstance::intersectRay(const G3D::Ray& pRay, float& pMaxDist, bool pStopAtFirstHit) const
+    bool ModelInstance::intersectRay(const G3D::Ray& pRay, float& pMaxDist, bool pStopAtFirstHit, bool pCheckLOS) const
     {
         if (!iModel)
         {
@@ -53,7 +53,7 @@ namespace VMAP
         Vector3 p = iInvRot * (pRay.origin() - iPos) * iInvScale;
         Ray modRay(p, iInvRot * pRay.direction());
         float distance = pMaxDist * iInvScale;
-        bool hit = iModel->IntersectRay(modRay, distance, pStopAtFirstHit);
+        bool hit = iModel->IntersectRay(modRay, distance, pStopAtFirstHit, pCheckLOS);
         if (hit)
         {
             distance *= iScale;

--- a/src/game/vmap/ModelInstance.h
+++ b/src/game/vmap/ModelInstance.h
@@ -67,7 +67,7 @@ namespace VMAP
             ModelInstance(): iInvScale(0), iModel(nullptr) {}
             ModelInstance(const ModelSpawn& spawn, WorldModel* model);
             void setUnloaded() { iModel = nullptr; }
-            bool intersectRay(const G3D::Ray& pRay, float& pMaxDist, bool pStopAtFirstHit) const;
+            bool intersectRay(const G3D::Ray& pRay, float& pMaxDist, bool pStopAtFirstHit, bool pCheckLOS = false) const;
             void intersectPoint(const G3D::Vector3& p, AreaInfo& info) const;
             bool GetLocationInfo(const G3D::Vector3& p, LocationInfo& info) const;
             bool GetLiquidLevel(const G3D::Vector3& p, LocationInfo& info, float& liqHeight) const;

--- a/src/game/vmap/VMapTools.h
+++ b/src/game/vmap/VMapTools.h
@@ -40,9 +40,9 @@ namespace VMAP
             G3D::Vector3 hitLocation;
             G3D::Vector3 hitNormal;
 
-            void operator()(const G3D::Ray& ray, const TValue* entity, bool pStopAtFirstHit, float& distance)
+            void operator()(const G3D::Ray& ray, const TValue* entity, bool pStopAtFirstHit, bool checkLOS, float& distance)
             {
-                entity->intersect(ray, distance, pStopAtFirstHit, hitLocation, hitNormal);
+                entity->intersect(ray, distance, pStopAtFirstHit, checkLOS, hitLocation, hitNormal);
             }
     };
 

--- a/src/game/vmap/WorldModel.cpp
+++ b/src/game/vmap/WorldModel.cpp
@@ -19,6 +19,7 @@
 #include "WorldModel.h"
 #include "VMapDefinitions.h"
 #include "MapTree.h"
+#include "ModelInstance.h"
 #include <string.h>
 
 using G3D::Vector3;
@@ -351,7 +352,7 @@ namespace VMAP
     {
         GModelRayCallback(const std::vector<MeshTriangle>& tris, const std::vector<Vector3>& vert):
             vertices(vert.begin()), triangles(tris.begin()), hit(false) {}
-        bool operator()(const G3D::Ray& ray, uint32 entry, float& distance, bool /*pStopAtFirstHit*/)
+        bool operator()(const G3D::Ray& ray, uint32 entry, float& distance, bool /*pStopAtFirstHit*/, bool /*checkLOS*/)
         {
             bool result = IntersectTriangle(triangles[entry], vertices, ray, distance);
             if (result)  hit = true;
@@ -362,12 +363,12 @@ namespace VMAP
         bool hit;
     };
 
-    bool GroupModel::IntersectRay(const G3D::Ray& ray, float& distance, bool stopAtFirstHit) const
+    bool GroupModel::IntersectRay(const G3D::Ray& ray, float& distance, bool stopAtFirstHit, bool checkLOS) const
     {
         if (triangles.empty())
             return false;
         GModelRayCallback callback(triangles, vertices);
-        meshTree.intersectRay(ray, callback, distance, stopAtFirstHit);
+        meshTree.intersectRay(ray, callback, distance, stopAtFirstHit, checkLOS);
         return callback.hit;
     }
 
@@ -410,9 +411,9 @@ namespace VMAP
     struct WModelRayCallBack
     {
         WModelRayCallBack(const std::vector<GroupModel>& mod): models(mod.begin()), hit(false) {}
-        bool operator()(const G3D::Ray& ray, uint32 entry, float& distance, bool pStopAtFirstHit)
+        bool operator()(const G3D::Ray& ray, uint32 entry, float& distance, bool pStopAtFirstHit, bool pCheckLOS)
         {
-            bool result = models[entry].IntersectRay(ray, distance, pStopAtFirstHit);
+            bool result = models[entry].IntersectRay(ray, distance, pStopAtFirstHit, pCheckLOS);
             if (result)  hit = true;
             return hit;
         }
@@ -420,15 +421,18 @@ namespace VMAP
         bool hit;
     };
 
-    bool WorldModel::IntersectRay(const G3D::Ray& ray, float& distance, bool stopAtFirstHit) const
+    bool WorldModel::IntersectRay(const G3D::Ray& ray, float& distance, bool stopAtFirstHit, bool checkLOS) const
     {
+		if (checkLOS && (modelFlags & MOD_M2))
+			return false;
+
         // small M2 workaround, maybe better make separate class with virtual intersection funcs
         // in any case, there's no need to use a bound tree if we only have one submodel
         if (groupModels.size() == 1)
-            return groupModels[0].IntersectRay(ray, distance, stopAtFirstHit);
+            return groupModels[0].IntersectRay(ray, distance, stopAtFirstHit, checkLOS);
 
         WModelRayCallBack isc(groupModels);
-        groupTree.intersectRay(ray, isc, distance, stopAtFirstHit);
+        groupTree.intersectRay(ray, isc, distance, stopAtFirstHit, checkLOS);
         return isc.hit;
     }
 

--- a/src/game/vmap/WorldModel.h
+++ b/src/game/vmap/WorldModel.h
@@ -85,7 +85,7 @@ namespace VMAP
             //! pass mesh data to object and create BIH. Passed vectors get get swapped with old geometry!
             void setMeshData(std::vector<Vector3>& vert, std::vector<MeshTriangle>& tri);
             void setLiquidData(WmoLiquid*& liquid) { iLiquid = liquid; liquid = nullptr; }
-            bool IntersectRay(const G3D::Ray& ray, float& distance, bool stopAtFirstHit) const;
+            bool IntersectRay(const G3D::Ray& ray, float& distance, bool stopAtFirstHit, bool checkLOS = false) const;
             bool IsInsideObject(const Vector3& pos, const Vector3& down, float& z_dist) const;
             bool GetLiquidLevel(const Vector3& pos, float& liqHeight) const;
             uint32 GetLiquidType() const;
@@ -117,15 +117,18 @@ namespace VMAP
             //! pass group models to WorldModel and create BIH. Passed vector is swapped with old geometry!
             void setGroupModels(std::vector<GroupModel>& models);
             void setRootWmoID(uint32 id) { RootWMOID = id; }
-            bool IntersectRay(const G3D::Ray& ray, float& distance, bool stopAtFirstHit) const;
+            bool IntersectRay(const G3D::Ray& ray, float& distance, bool stopAtFirstHit, bool checkLOS = false) const;
             bool IntersectPoint(const G3D::Vector3& p, const G3D::Vector3& down, float& dist, AreaInfo& info) const;
             bool GetLocationInfo(const G3D::Vector3& p, const G3D::Vector3& down, float& dist, LocationInfo& info) const;
             bool writeFile(const std::string& filename);
             bool readFile(const std::string& filename);
+            void setModelFlags(uint32 newFlags) { modelFlags = newFlags; }
+            uint32 getModelFlags() const { return modelFlags; }
         protected:
             uint32 RootWMOID;
             std::vector<GroupModel> groupModels;
             BIH groupTree;
+            uint32 modelFlags;
 
 #ifdef MMAP_GENERATOR
         public:


### PR DESCRIPTION
This will allow to cast through trees and other objects (for example BG flags in arathi) while still using them for calculating paths.
