### PR TITLE
fixes error of uninitialized member of World

### DIFF
--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -98,6 +98,7 @@ World::World(): mail_timer(0), mail_timer_expires(0)
     m_startTime = m_gameTime;
     m_maxActiveSessionCount = 0;
     m_maxQueuedSessionCount = 0;
+    m_MaintenanceTimeChecker = 0;
 
     m_defaultDbcLocale = LOCALE_enUS;
     m_availableDbcLocaleMask = 0;


### PR DESCRIPTION
m_MaintenanceTimeChecker isnt properly initialized in
World() and therefore its first usage in  World::Update()
is undifined behaviour.

Found while debugging another bug in my code (https://github.com/cmangos/mangos-classic/pull/242) using Valgrind:
```
[...]
---------------------------------------
      CMANGOS: World initialized       
---------------------------------------

SERVER STARTUP TIME: 1 minutes 14 seconds


==23688== Thread 5:
==23688== Conditional jump or move depends on uninitialised value(s)
==23688==    at 0xE50A19: World::Update(unsigned int) (World.cpp:1432)
==23688==    by 0xA8E27C: WorldRunnable::run() (WorldRunnable.cpp:59)
==23688==    by 0xF4B944: MaNGOS::Thread::ThreadTask(void*) (Threading.cpp:84)
==23688==    by 0xF4CCE3: void std::_Bind_simple<void (*(void*))(void*)>::_M_invoke<0ul>(std::_Index_tuple<0ul>) (functional:1531)
==23688==    by 0xF4CBED: std::_Bind_simple<void (*(void*))(void*)>::operator()() (functional:1520)
==23688==    by 0xF4CB7D: std::thread::_Impl<std::_Bind_simple<void (*(void*))(void*)> >::_M_run() (thread:115)
==23688==    by 0x640CC7F: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==23688==    by 0x6BFC6B9: start_thread (pthread_create.c:333)
==23688==    by 0x6F1882C: clone (clone.S:109)
==23688== 
[...]
```