### PR TITLE
Implement quest 6148

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -270,6 +270,7 @@ UPDATE creature_template SET ScriptName='npc_stinky_ignatz' WHERE entry=4880;
 
 /* EASTERN PLAGUELANDS */
 UPDATE creature_template SET ScriptName='npc_eris_havenfire' WHERE entry=14494;
+UPDATE creature_template SET ScriptName='npc_nathanos_blightcaller' WHERE entry=11878;
 
 /* ELWYNN FOREST */
 

--- a/src/scriptdev2/scripts/eastern_kingdoms/eastern_plaguelands.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/eastern_plaguelands.cpp
@@ -312,6 +312,7 @@ bool QuestAccept_npc_eris_havenfire(Player* pPlayer, Creature* pCreature, const 
 
 /*######
 ## npc_nathanos_blightcaller
+## TODO: remove this when generic map-wide IsSpawned condition is implemented
 ######*/
 
 enum


### PR DESCRIPTION
I would have preferred to handle this quest in database only, but I ran into a snag described more here:
https://github.com/cmangos/issues/issues/1276

The only reason I had to go this route and move Nathanos Blightcaller's AI from ACID to SD2 is to prevent multiple spawns of the creatures over a long distance.
Some SQL from the linked issue is required if this solution is used (waypoints, linking, creature_template changes).