### PR TITLE
"Gnomish Shrink Ray" fix with roll

### DIFF
--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -469,8 +469,9 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                 {
                     if (unitTarget && m_CastItem)
                     {
+                        uint32 roll = urand(0, 99)
                         // These rates are hella random; someone feel free to correct them
-                        if (uint32 roll = urand(0, 99) < 3)                   // Whole party will grow
+                        if (roll < 3)                   // Whole party will grow
                             m_caster->CastSpell(m_caster, 13004, TRIGGERED_OLD_TRIGGERED);
                         else if (roll < 6)                                    // Whole party will shrink
                             m_caster->CastSpell(m_caster, 13010, TRIGGERED_OLD_TRIGGERED);

--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -469,7 +469,7 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                 {
                     if (unitTarget && m_CastItem)
                     {
-                        uint32 roll = urand(0, 99)
+                        uint32 roll = urand(0, 99);
                         // These rates are hella random; someone feel free to correct them
                         if (roll < 3)                   // Whole party will grow
                             m_caster->CastSpell(m_caster, 13004, TRIGGERED_OLD_TRIGGERED);


### PR DESCRIPTION
The author assumed that the roll variable would be assigned with a random value, and then this value would be compared with 3. However, the priority of the comparison operation is higher than of the assignment operation (see the table "Operation priorities in C/C++", so the random number will be compared with 3 first, and then the result of the comparison (0 or 1) will be written to the roll variable.