### PR TITLE
An error in the condition "Consecrated Weapon and Blessed Wizard Oil" duration

### DIFF
--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -2869,7 +2869,7 @@ void Spell::EffectEnchantItemTmp(SpellEffectIndex eff_idx)
     else if (m_spellInfo->SpellIconID == 241 && m_spellInfo->Id != 7434)
         duration = 3600;                                    // 1 hour
     // Consecrated Weapon and Blessed Wizard Oil
-    else if (m_spellInfo->Id == 28891 && m_spellInfo->Id == 28898)
+    else if (m_spellInfo->Id == 28891 || m_spellInfo->Id == 28898)
         duration = 3600;                                    // 1 hour
     // some fishing pole bonuses
     else if (m_spellInfo->HasAttribute(SPELL_ATTR_HIDDEN_CLIENTSIDE))


### PR DESCRIPTION
PVS-Studio warning: V547 Expression is always false. Probably the '||' operator should be used here. SpellEffects.cpp 2872

In the specified condition, the variable m_spellInfo->Id is verified against two different values at the same time. The result of this check is always false, of course. The author most likely made a mistake and instead of '||' operator used '&&'.

It should be noted that the program commented on strange code behavior, and perhaps, it was caused by this error exactly.