### PR TITLE
please check this instance_blackrock_depths

### DIFF
--- a/src/scriptdev2/scripts/eastern_kingdoms/blackrock_depths/instance_blackrock_depths.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/blackrock_depths/instance_blackrock_depths.cpp
@@ -107,8 +107,10 @@ void instance_blackrock_depths::OnCreatureCreate(Creature* pCreature)
         case NPC_HAMMERED_PATRON:
             m_sBarPatronNpcGuids.insert(pCreature->GetObjectGuid());
             if (m_auiEncounter[11] == DONE)
+            {
                 pCreature->SetFactionTemporary(FACTION_DARK_IRON, TEMPFACTION_RESTORE_RESPAWN);
                 pCreature->SetStandState(UNIT_STAND_STATE_STAND);
+            }
             break;
         case NPC_PRIVATE_ROCKNOT:
         case NPC_MISTRESS_NAGMARA:


### PR DESCRIPTION
The author may have forgotten to put curly braces after the if statement, which caused the call pCreature->SetStandState(UNIT_STAND_STATE_STAND) to be executed regardless of the if condition.

If this behavior was meant intentionally, then the formatting should be corrected:

if (m_auiEncounter[11] == DONE)
  pCreature->SetFactionTemporary(....);
pCreature->SetStandState(UNIT_STAND_STATE_STAND);