### PR TITLE
Redundant condition player.cpp

### DIFF
--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -10538,7 +10538,7 @@ void Player::UpdateItemDuration(uint32 time, bool realtimeonly)
         Item* item = *itr;
         ++itr;                                              // current element can be erased in UpdateDuration
 
-        if ((realtimeonly && (item->GetProto()->ExtraFlags & ITEM_EXTRA_REAL_TIME_DURATION)) || !realtimeonly)
+        if (!(realtimeonly) || (item->GetProto()->ExtraFlags & ITEM_EXTRA_REAL_TIME_DURATION) )
             item->UpdateDuration(this, time);
     }
 }


### PR DESCRIPTION
Redundant condition
PVS-Studio warning: V728 An excessive check can be simplified. The '||' operator is surrounded by opposite expressions '!realtimeonly' and 'realtimeonly'. Player.cpp 10536
The check (a && b) || !a can be simplified to !a || b, which can be seen in the truth table:
http://www.viva64.com/media/images/content/b/0476_CMaNGOS_ru/image2.png
Thus, the original expression can be simplified to this code: