### PR TITLE
Unconditional exit from the for loop Pet.cpp

### DIFF
--- a/src/game/Pet.cpp
+++ b/src/game/Pet.cpp
@@ -892,7 +892,7 @@ int32 Pet::GetTPForSpell(uint32 spellid) const
             return 0;
 
         basetrainp = _spell_idx->second->reqtrainpoints;
-        break;
+        //break;
     }
 
     uint32 spenttrainp = 0;
@@ -1953,7 +1953,7 @@ void Pet::InitPetCreateSpells()
             for (SkillLineAbilityMap::const_iterator _spell_idx = bounds.first; _spell_idx != bounds.second; ++_spell_idx)
             {
                 usedtrainpoints += _spell_idx->second->reqtrainpoints;
-                break;
+                //break;
             }
         }
     }


### PR DESCRIPTION
PVS-Studio warning: V612 An unconditional 'break' within a loop. Pet.cpp 1956
V612 An unconditional 'break' within a loop. Pet.cpp 895
It was not clear what was meant here, but an unconditional break statement in the body of the for loop looks very suspicious.
 Even if there is no error here, it's better to refactor the code, and get rid of the unnecessary loop, because the iterator _spell_idx takes a single value.