### PR TITLE
item_orb_of_draconic_energy fix

### DIFF
--- a/src/scriptdev2/scripts/world/item_scripts.cpp
+++ b/src/scriptdev2/scripts/world/item_scripts.cpp
@@ -41,7 +41,9 @@ bool ItemUse_item_orb_of_draconic_energy(Player* pPlayer, Item* pItem, const Spe
 {
     Creature* pEmberstrife = GetClosestCreatureWithEntry(pPlayer, NPC_EMBERSTRIFE, 20.0f);
     // If Emberstrife is already mind controled or above 10% HP: force spell cast failure
-    if (pEmberstrife && pEmberstrife->HasAura(SPELL_DOMINION_SOUL) || pEmberstrife->GetHealth() / pEmberstrife->GetMaxHealth() > 0.1f)
+    if (pEmberstrife && pEmberstrife->HasAura(SPELL_DOMINION_SOUL) 
+        || ((float)pEmberstrife->GetHealth()) /
+        ((float)pEmberstrife->GetMaxHealth()) > 0.1f)
     {
         pPlayer->SendEquipError(EQUIP_ERR_NONE, pItem, NULL);
 


### PR DESCRIPTION
Integer division
PVS-Studio warning: V674 The '0.1f' literal of the 'float' type is compared to a value of the 'unsigned int' type. item_scripts.cpp 44
The method Unit::GetHealth() returns the value of the uint32_t type, and the method Unit::GetMaxHealth() also returns the value of the uint32_t type, so the result of the division is an integer, and it's pointless comparing it with 0.1f.

To correctly identify 10% of the health, this code can be rewritten like this.