### PR TITLE
Copy-Paste fix BattleGround

### DIFF
--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -210,9 +210,6 @@ BattleGround::BattleGround(): m_BuffChange(false), m_StartDelayTime(0), m_startM
     m_PlayersCount[TEAM_INDEX_ALLIANCE]    = 0;
     m_PlayersCount[TEAM_INDEX_HORDE]       = 0;
 
-    m_PlayersCount[TEAM_INDEX_ALLIANCE]    = 0;
-    m_PlayersCount[TEAM_INDEX_HORDE]       = 0;
-
     m_TeamScores[TEAM_INDEX_ALLIANCE]      = 0;
     m_TeamScores[TEAM_INDEX_HORDE]         = 0;
 


### PR DESCRIPTION
PVS-Studio warning: V760 Two identical blocks of text were found. The second block begins from line 213. BattleGround.cpp 210
The same actions are performed twice in this fragment. This code is most likely as a result of using Copy-Paste.