### PR TITLE
BELNISTRASZ agro fix in razorfen_downs script

### DIFF
--- a/src/scriptdev2/scripts/kalimdor/razorfen_downs/razorfen_downs.cpp
+++ b/src/scriptdev2/scripts/kalimdor/razorfen_downs/razorfen_downs.cpp
@@ -101,7 +101,7 @@ struct npc_belnistraszAI : public npc_escortAI
         {
             if (!m_bAggro)
             {
-                DoScriptText(urand(0, 1) ? SAY_BELNISTRASZ_AGGRO_1 : SAY_BELNISTRASZ_AGGRO_1, m_creature, pAttacker);
+                DoScriptText(urand(0, 1) ? SAY_BELNISTRASZ_AGGRO_1 : SAY_BELNISTRASZ_AGGRO_2, m_creature, pAttacker);
                 m_bAggro = true;
             }
 


### PR DESCRIPTION
The second and third operands of the ternary operator are identical; this is most likely an error. Judging by the code of the project, we can assume that one of the operands should have the value SAY_BELNISTRASZ_AGGRO_2.