### PR TITLE
Fix duplicate dodge/miss/resist/evade/etc messages

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -978,11 +978,7 @@ void Spell::DoAllEffectOnTarget(TargetInfo* target)
             }
         }
     }
-
-    // In 1.12.1 we need explicit miss info
-    if (real_caster && missInfo && missInfo != SPELL_MISS_REFLECT)
-        real_caster->SendSpellMiss(unit, m_spellInfo->Id, missInfo);
-
+    
     // All calculated do it!
     // Do healing and triggers
     if (m_healing)


### PR DESCRIPTION
Looks like someone way back wrongly assumed that 1.12.1 needed dodge/miss/etc messages to be explicitly sent by the server, and their "fix" for this resulted in these messages showing up twice. Please verify & merge this change! (Or tell me if you find something wrong)