### PR TITLE
Knock Away - Script Effect

### DIFF
--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -3424,6 +3424,10 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
 
                     return;
                 }
+                case 18670:
+                case 18945:
+                    m_caster->getThreatManager().modifyThreatPercent(unitTarget, -50);
+                    return;
                 case 22539:                                 // Shadow Flame (All script effects, not just end ones to
                 case 22972:                                 // prevent player from dodging the last triggered spell)
                 case 22975:

--- a/src/scriptdev2/scripts/eastern_kingdoms/blackwing_lair/boss_broodlord_lashlayer.cpp
+++ b/src/scriptdev2/scripts/eastern_kingdoms/blackwing_lair/boss_broodlord_lashlayer.cpp
@@ -29,10 +29,10 @@ enum
     SAY_AGGRO                   = -1469000,
     SAY_LEASH                   = -1469001,
 
-    SPELL_CLEAVE                = 26350,
+    SPELL_CLEAVE                = 15284,
+    SPELL_KNOCK_AWAY            = 18670,
     SPELL_BLAST_WAVE            = 23331,
     SPELL_MORTAL_STRIKE         = 24573,
-    SPELL_KNOCK_AWAY            = 25778
 };
 
 struct boss_broodlordAI : public ScriptedAI
@@ -110,14 +110,11 @@ struct boss_broodlordAI : public ScriptedAI
         else
             m_uiMortalStrikeTimer -= uiDiff;
 
+        // Knock Away Timer
         if (m_uiKnockAwayTimer < uiDiff)
         {
-            DoCastSpellIfCan(m_creature->getVictim(), SPELL_KNOCK_AWAY);
-            // Drop 50% aggro - TODO should be scriptedEffect?
-            if (m_creature->getThreatManager().getThreat(m_creature->getVictim()))
-                m_creature->getThreatManager().modifyThreatPercent(m_creature->getVictim(), -50);
-
-            m_uiKnockAwayTimer = urand(15000, 30000);
+            if (DoCastSpellIfCan(m_creature->getVictim(), SPELL_KNOCK_AWAY) == CAST_OK)
+                m_uiKnockAwayTimer = urand(15000, 30000);
         }
         else
             m_uiKnockAwayTimer -= uiDiff;

--- a/src/scriptdev2/scripts/kalimdor/temple_of_ahnqiraj/boss_bug_trio.cpp
+++ b/src/scriptdev2/scripts/kalimdor/temple_of_ahnqiraj/boss_bug_trio.cpp
@@ -32,9 +32,9 @@ enum
     SPELL_SUMMON_CLOUD      = 26590,            // summons 15933
 
     // vem
+    SPELL_KNOCK_AWAY        = 18670,
     SPELL_CHARGE            = 26561,
     SPELL_VENGEANCE         = 25790,
-    SPELL_KNOCKBACK         = 26027,
 
     // yauj
     SPELL_HEAL              = 25807,
@@ -123,12 +123,12 @@ struct boss_vemAI : public ScriptedAI
     ScriptedInstance* m_pInstance;
 
     uint32 m_uiChargeTimer;
-    uint32 m_uiKnockBackTimer;
+    uint32 m_uiKnockAwayTimer;
 
     void Reset() override
     {
         m_uiChargeTimer     = urand(15000, 27000);
-        m_uiKnockBackTimer  = urand(8000, 20000);
+        m_uiKnockAwayTimer  = urand(10000, 20000);
     }
 
     void JustDied(Unit* /*pKiller*/) override
@@ -159,6 +159,15 @@ struct boss_vemAI : public ScriptedAI
         if (!m_creature->SelectHostileTarget() || !m_creature->getVictim())
             return;
 
+        // KnockAway_Timer
+        if (m_uiKnockAwayTimer < uiDiff)
+        {
+            if (DoCastSpellIfCan(m_creature->getVictim(), SPELL_KNOCK_AWAY) == CAST_OK)
+                m_uiKnockAwayTimer = urand(10000, 20000);
+        }
+        else
+            m_uiKnockAwayTimer -= uiDiff;
+
         // Charge_Timer
         if (m_uiChargeTimer < uiDiff)
         {
@@ -170,20 +179,6 @@ struct boss_vemAI : public ScriptedAI
         }
         else
             m_uiChargeTimer -= uiDiff;
-
-        // KnockBack_Timer
-        if (m_uiKnockBackTimer < uiDiff)
-        {
-            if (DoCastSpellIfCan(m_creature, SPELL_KNOCKBACK) == CAST_OK)
-            {
-                if (m_creature->getThreatManager().getThreat(m_creature->getVictim()))
-                    m_creature->getThreatManager().modifyThreatPercent(m_creature->getVictim(), -80);
-
-                m_uiKnockBackTimer = urand(15000, 25000);
-            }
-        }
-        else
-            m_uiKnockBackTimer -= uiDiff;
 
         DoMeleeAttackIfReady();
     }


### PR DESCRIPTION
+ some versions of 'Knock Away' lower the target's threat by 50% (used by Molten Giants, Broodlord Razorgore and Vem)
+ assign correct spells to Broodlord Razorgore and Vem