### PR TITLE
Prevent GCD being ignored by Macros

### DIFF
--- a/src/game/Entities/Player.h
+++ b/src/game/Entities/Player.h
@@ -1290,6 +1290,8 @@ class Player : public Unit
         void Regenerate(Powers power);
         void RegenerateHealth();
         void setRegenTimer(uint32 time) {m_regenTimer = time;}
+
+        uint32 GetWeaponChangeTimer() { return m_weaponChangeTimer; }
         void setWeaponChangeTimer(uint32 time) {m_weaponChangeTimer = time;}
 
         uint32 GetMoney() const { return GetUInt32Value(PLAYER_FIELD_COINAGE); }

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -4022,6 +4022,12 @@ SpellCastResult Spell::CheckCast(bool strict)
     if (strict && !m_IsTriggeredSpell && HasGlobalCooldown())
         return SPELL_FAILED_NOT_READY;
 
+    // check players m_weaponChangeTimer to prevent GCD being ignored by Macros when using
+    // ** /cast some ability **
+    // after a new weapon has been equipted
+    if (m_caster->isAlive() && m_caster->GetTypeId() == TYPEID_PLAYER && ((Player*)m_caster)->GetWeaponChangeTimer() != 0)
+            return SPELL_FAILED_CASTER_AURASTATE;
+
     // only allow triggered spells if at an ended battleground
     if (!m_IsTriggeredSpell && m_caster->GetTypeId() == TYPEID_PLAYER)
         if (BattleGround* bg = ((Player*)m_caster)->GetBattleGround())


### PR DESCRIPTION
**Currently it is possible to ignore/skip GCD  using a macro.**
This happens for example when you equip a new weapon using a macro in an ongoing fight and cast an ability instantly after that.

**For example:**
```
/equip My Weapon
/cast My Ability
```

Right now it would result in;  
- equipping a weapon and
- casting an ability  at the same time

`/cast My Ability` is ignoring the GCD that happens when you switch weapons in fight.

Sources:
http://www.wowhead.com/forums&topic=35644/can-you-switch-weapons-while-in-combat
http://wow.allakhazam.com/forum.html?forum=243&mid=118828531159959080