### PR TITLE
port of olion17/server@b9628e to improve packet structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ autom4te.cache
 *.orig
 *.patch
 callgrind.out.*
+nbproject/
 
 #
 # Git stuff

--- a/src/game/Entities/GossipDef.cpp
+++ b/src/game/Entities/GossipDef.cpp
@@ -451,9 +451,10 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* pQuest, ObjectGuid guid
     {
         ItemPrototype const* IProto;
 
-        data << uint32(pQuest->GetRewChoiceItemsCount());
+        uint32 count = pQuest->GetRewChoiceItemsCount();
+        data << uint32(count);
 
-        for (uint32 i = 0; i < QUEST_REWARD_CHOICES_COUNT; ++i)
+        for (uint32 i = 0; i < count; ++i)
         {
             data << uint32(pQuest->RewChoiceItemId[i]);
             data << uint32(pQuest->RewChoiceItemCount[i]);
@@ -466,9 +467,10 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* pQuest, ObjectGuid guid
                 data << uint32(0x00);
         }
 
-        data << uint32(pQuest->GetRewItemsCount());
+        count = pQuest->GetRewItemsCount();
+        data << uint32(count);
 
-        for (uint32 i = 0; i < QUEST_REWARDS_COUNT; ++i)
+        for (uint32 i = 0; i < count; ++i)
         {
             data << uint32(pQuest->RewItemId[i]);
             data << uint32(pQuest->RewItemCount[i]);
@@ -484,34 +486,16 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* pQuest, ObjectGuid guid
         data << uint32(pQuest->GetRewOrReqMoney());
     }
 
-    data << pQuest->GetReqItemsCount();
-    for (uint32 i = 0; i <  QUEST_OBJECTIVES_COUNT; i++)
-    {
-        data << pQuest->ReqItemId[i];
-        data << pQuest->ReqItemCount[i];
-    }
+    data << uint32(pQuest->GetRewSpell());
 
-
-    data << pQuest->GetReqCreatureOrGOcount();
-    for (uint32 i = 0; i < QUEST_OBJECTIVES_COUNT; i++)
-    {
-        data << uint32(pQuest->ReqCreatureOrGOId[i]);
-        data << pQuest->ReqCreatureOrGOCount[i];
-    }
-
-    /*[-ZERO]
-    // rewarded honor points. Multiply with 10 to satisfy client
-    data << uint32(pQuest->GetRewSpell());                  // reward spell, this spell will display (icon) (casted if RewSpellCast==0)
-    data << uint32(pQuest->GetRewSpellCast());              // casted spell
-
-    data << uint32(QUEST_EMOTE_COUNT);
-
-    for (uint32 i = 0; i < QUEST_EMOTE_COUNT; ++i)
+    uint32 count = pQuest->GetDetailsEmoteCount();
+    data << uint32(count);
+    for (uint32 i = 0; i < count; ++i)
     {
         data << uint32(pQuest->DetailsEmote[i]);
-        data << uint32(pQuest->DetailsEmoteDelay[i]);       // DetailsEmoteDelay (in ms)
+        data << uint32(pQuest->DetailsEmoteDelay[i]); // delay between emotes in ms
     }
-    */
+
     GetMenuSession()->SendPacket(data);
 
     DEBUG_LOG("WORLD: Sent SMSG_QUESTGIVER_QUEST_DETAILS - for %s of %s, questid = %u", GetMenuSession()->GetPlayer()->GetGuidStr().c_str(), guid.GetString().c_str(), pQuest->GetQuestId());

--- a/src/game/Quests/QuestDef.cpp
+++ b/src/game/Quests/QuestDef.cpp
@@ -109,8 +109,13 @@ Quest::Quest(Field* questRecord)
     PointY = questRecord[103].GetFloat();
     PointOpt = questRecord[104].GetUInt32();
 
+    m_detailsemotecount = 0;
     for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
+    {
         DetailsEmote[i] = questRecord[105 + i].GetUInt32();
+        if (DetailsEmote[i] != 0)
+            m_detailsemotecount = i + 1;
+    }
 
     for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
         DetailsEmoteDelay[i] = questRecord[109 + i].GetUInt32();

--- a/src/game/Quests/QuestDef.h
+++ b/src/game/Quests/QuestDef.h
@@ -233,6 +233,7 @@ class Quest
         uint32 GetPointOpt() const { return PointOpt; }
         uint32 GetIncompleteEmote() const { return IncompleteEmote; }
         uint32 GetCompleteEmote() const { return CompleteEmote; }
+        uint32 GetDetailsEmoteCount() const { return m_detailsemotecount; }
         uint32 GetQuestStartScript() const { return QuestStartScript; }
         uint32 GetQuestCompleteScript() const { return QuestCompleteScript; }
 
@@ -280,6 +281,7 @@ class Quest
         uint32 m_reqCreatureOrGOcount;
         uint32 m_rewchoiceitemscount;
         uint32 m_rewitemscount;
+        uint32 m_detailsemotecount; // actual allowed value 0..4
 
         bool m_isActive;
 


### PR DESCRIPTION
fixes cmangos/issues/issues/1404

per the linked issue's first example, Kaltunk currently does not emote even if you set DetailsEmote1 in the quest_template entry (4641) to 1. with this change he will emote, however obviously these depend on the db having the correct settings.

i can't say i'm super familiar with the emote system, but it looks right to me.