### PR TITLE
fix hang exiting mangosd on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ autom4te.cache
 *.orig
 *.patch
 callgrind.out.*
+nbproject/
 
 #
 # Git stuff

--- a/src/mangosd/CliRunnable.cpp
+++ b/src/mangosd/CliRunnable.cpp
@@ -602,6 +602,14 @@ void CliRunnable::run()
     // later it will be printed after command queue updates
     printf("mangos>");
 
+#ifdef __linux__
+    //Set stdin IO to nonblocking - prevent Server from hanging in shutdown process till enter is pressed
+    int fd = fileno(stdin);  
+    int flags = fcntl(fd, F_GETFL, 0); 
+    flags |= O_NONBLOCK; 
+    fcntl(fd, F_SETFL, flags);
+#endif
+
     ///- As long as the World is running (no World::m_stopEvent), get the command line and handle it
     while (!World::IsStopped())
     {


### PR DESCRIPTION
this fixes the hang until a keypress with 'Halting process...' when quitting mangosd (tested on ubuntu 16)