### PR TITLE
[z2703] Remove duplicate info from creature_template

### DIFF
--- a/sql/base/mangos.sql
+++ b/sql/base/mangos.sql
@@ -23,7 +23,7 @@ DROP TABLE IF EXISTS `db_version`;
 CREATE TABLE `db_version` (
   `version` varchar(120) DEFAULT NULL,
   `creature_ai_version` varchar(120) DEFAULT NULL,
-  `required_z2702_01_mangos_spell_chain_totems_typos` bit(1) DEFAULT NULL
+  `required_z2703_01_mangos_creature_template_fixup` bit(1) DEFAULT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Used DB version notes';
 
 --
@@ -1162,8 +1162,7 @@ CREATE TABLE `creature_template` (
   `ModelId2` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `ModelId3` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `ModelId4` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `FactionAlliance` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `FactionHorde` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `Faction` smallint(5) unsigned NOT NULL DEFAULT '0',
   `Scale` float NOT NULL DEFAULT '1',
   `Family` tinyint(4) NOT NULL DEFAULT '0',
   `CreatureType` tinyint(3) unsigned NOT NULL DEFAULT '0',
@@ -1189,15 +1188,11 @@ CREATE TABLE `creature_template` (
   `MaxLevelHealth` int(10) unsigned NOT NULL DEFAULT '0',
   `MinLevelMana` int(10) unsigned NOT NULL DEFAULT '0',
   `MaxLevelMana` int(10) unsigned NOT NULL DEFAULT '0',
-  `MinMeleeDmg` float NOT NULL DEFAULT '0',
-  `MaxMeleeDmg` float NOT NULL DEFAULT '0',
-  `MinRangedDmg` float NOT NULL DEFAULT '0',
-  `MaxRangedDmg` float NOT NULL DEFAULT '0',
+  `MinDmg` float NOT NULL DEFAULT '0',
+  `MaxDmg` float NOT NULL DEFAULT '0',
   `Armor` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `MeleeAttackPower` int(10) unsigned NOT NULL DEFAULT '0',
-  `RangedAttackPower` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `MeleeBaseAttackTime` int(10) unsigned NOT NULL DEFAULT '2000',
-  `RangedBaseAttackTime` int(10) unsigned NOT NULL DEFAULT '2000',
+  `AttackPower` int(10) unsigned NOT NULL DEFAULT '0',
+  `BaseAttackTime` int(10) unsigned NOT NULL DEFAULT '2000',
   `DamageSchool` tinyint(4) NOT NULL DEFAULT '0',
   `MinLootGold` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `MaxLootGold` mediumint(8) unsigned NOT NULL DEFAULT '0',

--- a/sql/updates/mangos/z2703_01_mangos_creature_template_fixup.sql
+++ b/sql/updates/mangos/z2703_01_mangos_creature_template_fixup.sql
@@ -1,0 +1,20 @@
+ALTER TABLE db_version CHANGE COLUMN required_z2702_01_mangos_spell_chain_totems_typos required_z2703_01_mangos_creature_template_fixup bit;
+
+ALTER TABLE `creature_template` CHANGE COLUMN MinMeleeDmg MinDmg float NOT NULL DEFAULT '0';
+ALTER TABLE `creature_template` DROP COLUMN MinRangedDmg;
+
+ALTER TABLE `creature_template` CHANGE COLUMN MaxMeleeDmg MaxDmg float NOT NULL DEFAULT '0';
+ALTER TABLE `creature_template` DROP COLUMN MaxRangedDmg;
+
+ALTER TABLE `creature_template` CHANGE COLUMN MeleeAttackPower AttackPower unsigned NOT NULL DEFAULT '0';
+ALTER TABLE `creature_template` DROP COLUMN RangedAttackPower;
+
+ALTER TABLE `creature_template` CHANGE COLUMN MeleeBaseAttackTime BaseAttackTime int(10) unsigned NOT NULL DEFAULT '2000';
+ALTER TABLE `creature_template` DROP COLUMN RangedBaseAttackTime;
+
+ALTER TABLE `creature_template` CHANGE COLUMN FactionAlliance Faction smallint(5) unsigned NOT NULL DEFAULT '0';
+ALTER TABLE `creature_template` DROP COLUMN FactionHorde;
+
+-- For some reason creature_template_classlevelstats is NOT in the base file?
+ALTER TABLE `creature_template_classlevelstats` CHANGE COLUMN BaseMeleeAttackPower BaseAttackPower float NOT NULL DEFAULT '0';
+ALTER TABLE `creature_template_classlevelstats` DROP COLUMN BaseRangedAttackPower;

--- a/src/game/Chat/Level2.cpp
+++ b/src/game/Chat/Level2.cpp
@@ -1867,13 +1867,10 @@ bool ChatHandler::HandleNpcFactionIdCommand(char* args)
 
     // update in memory
     if (CreatureInfo const* cinfo = pCreature->GetCreatureInfo())
-    {
-        const_cast<CreatureInfo*>(cinfo)->FactionAlliance = factionId;
-        const_cast<CreatureInfo*>(cinfo)->FactionHorde = factionId;
-    }
+        const_cast<CreatureInfo*>(cinfo)->Faction = factionId;
 
     // and DB
-    WorldDatabase.PExecuteLog("UPDATE creature_template SET FactionAlliance = '%u', FactionHorde = '%u' WHERE entry = '%u'", factionId, factionId, pCreature->GetEntry());
+    WorldDatabase.PExecuteLog("UPDATE creature_template SET Faction = '%u' WHERE entry = '%u'", factionId, pCreature->GetEntry());
 
     return true;
 }

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -374,18 +374,15 @@ bool Creature::UpdateEntry(uint32 Entry, Team team, const CreatureData* data /*=
     else
         SelectLevel();
 
-    if (team == HORDE)
-        setFaction(GetCreatureInfo()->FactionHorde);
-    else
-        setFaction(GetCreatureInfo()->FactionAlliance);
+    setFaction(GetCreatureInfo()->Faction);
 
     SetUInt32Value(UNIT_NPC_FLAGS, GetCreatureInfo()->NpcFlags);
 
-    uint32 attackTimer = GetCreatureInfo()->MeleeBaseAttackTime;
+    uint32 attackTimer = GetCreatureInfo()->BaseAttackTime;
 
     SetAttackTime(BASE_ATTACK,  attackTimer);
     SetAttackTime(OFF_ATTACK,   attackTimer - attackTimer / 4);
-    SetAttackTime(RANGED_ATTACK, GetCreatureInfo()->RangedBaseAttackTime);
+    SetAttackTime(RANGED_ATTACK, attackTimer);
 
     uint32 unitFlags = GetCreatureInfo()->UnitFlags;
 
@@ -416,7 +413,7 @@ bool Creature::UpdateEntry(uint32 Entry, Team team, const CreatureData* data /*=
     UpdateAllStats();
 
     // checked and error show at loading templates
-    if (FactionTemplateEntry const* factionTemplate = sFactionTemplateStore.LookupEntry(GetCreatureInfo()->FactionAlliance))
+    if (FactionTemplateEntry const* factionTemplate = sFactionTemplateStore.LookupEntry(GetCreatureInfo()->Faction))
     {
         if (factionTemplate->factionFlags & FACTION_TEMPLATE_FLAG_PVP)
             SetPvP(true);
@@ -1230,16 +1227,13 @@ void Creature::SelectLevel(uint32 forcedLevel /*= USE_DEFAULT_DATABASE_LEVEL*/)
     // damage
     float damagemod = _GetDamageMod(rank);
 
-    SetBaseWeaponDamage(BASE_ATTACK, MINDAMAGE, cinfo->MinMeleeDmg * damagemod);
-    SetBaseWeaponDamage(BASE_ATTACK, MAXDAMAGE, cinfo->MaxMeleeDmg * damagemod);
+    SetBaseWeaponDamage(BASE_ATTACK, MINDAMAGE, cinfo->MinDmg * damagemod);
+    SetBaseWeaponDamage(BASE_ATTACK, MAXDAMAGE, cinfo->MaxDmg * damagemod);
 
-    SetBaseWeaponDamage(OFF_ATTACK, MINDAMAGE, cinfo->MinMeleeDmg * damagemod);
-    SetBaseWeaponDamage(OFF_ATTACK, MAXDAMAGE, cinfo->MaxMeleeDmg * damagemod);
+    SetBaseWeaponDamage(OFF_ATTACK, MINDAMAGE, cinfo->MinDmg * damagemod);
+    SetBaseWeaponDamage(OFF_ATTACK, MAXDAMAGE, cinfo->MaxDmg * damagemod);
 
-    SetFloatValue(UNIT_FIELD_MINRANGEDDAMAGE, cinfo->MinRangedDmg * damagemod);
-    SetFloatValue(UNIT_FIELD_MAXRANGEDDAMAGE, cinfo->MaxRangedDmg * damagemod);
-
-    SetModifierValue(UNIT_MOD_ATTACK_POWER, BASE_VALUE, cinfo->MeleeAttackPower * damagemod);
+    SetModifierValue(UNIT_MOD_ATTACK_POWER, BASE_VALUE, cinfo->AttackPower * damagemod);
 }
 
 float Creature::_GetHealthMod(int32 Rank)
@@ -2451,7 +2445,7 @@ void Creature::ClearTemporaryFaction()
         return;
 
     // Reset to original faction
-    setFaction(GetCreatureInfo()->FactionAlliance);
+    setFaction(GetCreatureInfo()->Faction);
 
     ForceHealthAndPowerUpdate();                            // update health and power for client needed to hide enemy real value
 

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -81,8 +81,7 @@ struct CreatureInfo
     uint32  MinLevel;
     uint32  MaxLevel;
     uint32  ModelId[MAX_CREATURE_MODEL];
-    uint32  FactionAlliance;
-    uint32  FactionHorde;
+    uint32  Faction;
     float   Scale;
     uint32  Family;                                         // enum CreatureFamily values (optional)
     uint32  CreatureType;                                   // enum CreatureType values
@@ -108,15 +107,11 @@ struct CreatureInfo
     uint32  MaxLevelHealth;
     uint32  MinLevelMana;
     uint32  MaxLevelMana;
-    float   MinMeleeDmg;
-    float   MaxMeleeDmg;
-    float   MinRangedDmg;
-    float   MaxRangedDmg;
+    float   MinDmg;
+    float   MaxDmg;
     uint32  Armor;
-    uint32  MeleeAttackPower;
-    uint32  RangedAttackPower;
-    uint32  MeleeBaseAttackTime;
-    uint32  RangedBaseAttackTime;
+    uint32  AttackPower;
+    uint32  BaseAttackTime;
     uint32  DamageSchool;
     uint32  MinLootGold;
     uint32  MaxLootGold;
@@ -241,8 +236,7 @@ struct CreatureClassLvlStats
     uint32  BaseHealth;
     uint32  BaseMana;
     float   BaseDamage;
-    float   BaseMeleeAttackPower;
-    float   BaseRangedAttackPower;
+    float   BaseAttackPower;
     uint32  BaseArmor;
 };
 

--- a/src/game/Entities/Pet.cpp
+++ b/src/game/Entities/Pet.cpp
@@ -1143,9 +1143,8 @@ void Pet::InitStatsForLevel(uint32 petlevel)
 
     int32 createResistance[MAX_SPELL_SCHOOL] = {0, 0, 0, 0, 0, 0, 0};
 
-    SetAttackTime(BASE_ATTACK, cInfo->MeleeBaseAttackTime);
-    SetAttackTime(OFF_ATTACK, cInfo->MeleeBaseAttackTime);
-    SetAttackTime(RANGED_ATTACK, cInfo->RangedBaseAttackTime);
+    SetAttackTime(BASE_ATTACK, cInfo->BaseAttackTime);
+    SetAttackTime(OFF_ATTACK, cInfo->BaseAttackTime);
 
     if (getPetType() == HUNTER_PET)
         SetMeleeDamageSchool(SpellSchools(SPELL_SCHOOL_NORMAL));
@@ -1249,7 +1248,7 @@ void Pet::InitStatsForLevel(uint32 petlevel)
 				CreatureClassLvlStats const* cCLS = sObjectMgr.GetCreatureClassLvlStats(petlevel, cInfo->UnitClass);
                 if (cInfo->ArmorMultiplier && cCLS) // Info found in ClassLevelStats
                 {
-                    minDmg = (cCLS->BaseDamage * cInfo->DamageVariance + (cCLS->BaseMeleeAttackPower / 14) * (cInfo->MeleeBaseAttackTime/1000)) * cInfo->DamageMultiplier;
+                    minDmg = (cCLS->BaseDamage * cInfo->DamageVariance + (cCLS->BaseAttackPower / 14) * (cInfo->BaseAttackTime/1000)) * cInfo->DamageMultiplier;
 
                     // Apply custom damage setting (from config)
                     minDmg *= _GetDamageMod(cInfo->Rank);
@@ -1261,8 +1260,8 @@ void Pet::InitStatsForLevel(uint32 petlevel)
                 {
                     sLog.outErrorDb("SUMMON_PET creature_template not finished on creature %s! (entry: %u)", GetGuidStr().c_str(), cInfo->Entry);
 
-                    float dMinLevel = cInfo->MinMeleeDmg / cInfo->MinLevel;
-                    float dMaxLevel = cInfo->MaxMeleeDmg / cInfo->MaxLevel;
+                    float dMinLevel = cInfo->MinDmg / cInfo->MinLevel;
+                    float dMaxLevel = cInfo->MaxDmg / cInfo->MaxLevel;
                     float mDmg = (dMaxLevel - ((dMaxLevel - dMinLevel) / 2)) * petlevel;
                     
                     // Set damage
@@ -1299,7 +1298,7 @@ void Pet::InitStatsForLevel(uint32 petlevel)
                 armor = cCLS->BaseArmor;
 
                 // Melee
-                minDmg = (cCLS->BaseDamage * cInfo->DamageVariance + (cCLS->BaseMeleeAttackPower / 14) * (cInfo->MeleeBaseAttackTime/1000)) * cInfo->DamageMultiplier;
+                minDmg = (cCLS->BaseDamage * cInfo->DamageVariance + (cCLS->BaseAttackPower / 14) * (cInfo->BaseAttackTime/1000)) * cInfo->DamageMultiplier;
 
                 // Get custom setting
                 minDmg *= _GetDamageMod(cInfo->Rank);
@@ -1307,15 +1306,6 @@ void Pet::InitStatsForLevel(uint32 petlevel)
                 // If the damage value is not passed on as float it will result in damage = 1; but only for guardian type pets, though...
                 SetBaseWeaponDamage(BASE_ATTACK, MINDAMAGE, float(minDmg));
                 SetBaseWeaponDamage(BASE_ATTACK, MAXDAMAGE, float(minDmg * 1.5));
-
-                // Ranged
-                minDmg = (cCLS->BaseDamage * cInfo->DamageVariance + (cCLS->BaseRangedAttackPower / 14) * (cInfo->RangedBaseAttackTime/1000)) * cInfo->DamageMultiplier;
-
-                // Get custom setting
-                minDmg *= _GetDamageMod(cInfo->Rank);
-
-                SetBaseWeaponDamage(RANGED_ATTACK, MINDAMAGE, float(minDmg));
-                SetBaseWeaponDamage(RANGED_ATTACK, MAXDAMAGE, float(minDmg * 1.5));
             }
             else // TODO: Remove fallback to creature_template data when DB is ready
             {
@@ -1342,11 +1332,8 @@ void Pet::InitStatsForLevel(uint32 petlevel)
 
                 sLog.outErrorDb("Pet::InitStatsForLevel> Error trying to set stats for creature %s (entry: %u) using ClassLevelStats; not enough data to do it!", GetGuidStr().c_str(), cInfo->Entry);
 
-                SetBaseWeaponDamage(BASE_ATTACK, MINDAMAGE, float(cInfo->MinMeleeDmg));
-                SetBaseWeaponDamage(BASE_ATTACK, MAXDAMAGE, float(cInfo->MaxMeleeDmg));
-
-                SetBaseWeaponDamage(RANGED_ATTACK, MINDAMAGE, float(cInfo->MinRangedDmg));
-                SetBaseWeaponDamage(RANGED_ATTACK, MAXDAMAGE, float(cInfo->MaxRangedDmg));
+                SetBaseWeaponDamage(BASE_ATTACK, MINDAMAGE, float(cInfo->MinDmg));
+                SetBaseWeaponDamage(BASE_ATTACK, MAXDAMAGE, float(cInfo->MaxDmg));
             }
 
             break;

--- a/src/game/Entities/StatSystem.cpp
+++ b/src/game/Entities/StatSystem.cpp
@@ -662,7 +662,7 @@ void Creature::UpdateDamagePhysical(WeaponAttackType attType)
     UnitMods unitMod = (attType == BASE_ATTACK ? UNIT_MOD_DAMAGE_MAINHAND : UNIT_MOD_DAMAGE_OFFHAND);
 
     /* difference in AP between current attack power and base value from DB */
-    float att_pwr_change = GetTotalAttackPowerValue(attType) - GetCreatureInfo()->MeleeAttackPower;
+    float att_pwr_change = GetTotalAttackPowerValue(attType) - GetCreatureInfo()->AttackPower;
     float base_value  = GetModifierValue(unitMod, BASE_VALUE) + (att_pwr_change * GetAPMultiplier(attType, false) / 14.0f);
     float base_pct    = GetModifierValue(unitMod, BASE_PCT);
     float total_value = GetModifierValue(unitMod, TOTAL_VALUE);

--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -402,13 +402,9 @@ void ObjectMgr::LoadCreatureTemplates()
         if (!cInfo)
             continue;
 
-        FactionTemplateEntry const* factionTemplate = sFactionTemplateStore.LookupEntry(cInfo->FactionAlliance);
+        FactionTemplateEntry const* factionTemplate = sFactionTemplateStore.LookupEntry(cInfo->Faction);
         if (!factionTemplate)
-            sLog.outErrorDb("Creature (Entry: %u) has nonexistent faction_A template (%u)", cInfo->Entry, cInfo->FactionAlliance);
-
-        factionTemplate = sFactionTemplateStore.LookupEntry(cInfo->FactionHorde);
-        if (!factionTemplate)
-            sLog.outErrorDb("Creature (Entry: %u) has nonexistent faction_H template (%u)", cInfo->Entry, cInfo->FactionHorde);
+            sLog.outErrorDb("Creature (Entry: %u) has nonexistent faction template (%u)", cInfo->Entry, cInfo->Faction);
 
         for (int k = 0; k < MAX_KILL_CREDIT; ++k)
         {
@@ -493,11 +489,8 @@ void ObjectMgr::LoadCreatureTemplates()
             const_cast<CreatureInfo*>(cInfo)->DamageSchool = SPELL_SCHOOL_NORMAL;
         }
 
-        if (cInfo->MeleeBaseAttackTime == 0)
-            const_cast<CreatureInfo*>(cInfo)->MeleeBaseAttackTime  = BASE_ATTACK_TIME;
-
-        if (cInfo->RangedBaseAttackTime == 0)
-            const_cast<CreatureInfo*>(cInfo)->RangedBaseAttackTime = BASE_ATTACK_TIME;
+        if (cInfo->BaseAttackTime == 0)
+            const_cast<CreatureInfo*>(cInfo)->BaseAttackTime = BASE_ATTACK_TIME;
 
         if ((cInfo->NpcFlags & UNIT_NPC_FLAG_TRAINER) && cInfo->TrainerType >= MAX_TRAINER_TYPE)
             sLog.outErrorDb("Creature (Entry: %u) has wrong trainer type %u", cInfo->Entry, cInfo->TrainerType);
@@ -696,7 +689,7 @@ void ObjectMgr::LoadCreatureClassLvlStats()
     // initialize data array
     memset(&m_creatureClassLvlStats, 0, sizeof(m_creatureClassLvlStats));
 
-    std::string queryStr = "SELECT Class, Level, BaseMana, BaseMeleeAttackPower, BaseRangedAttackPower, BaseArmor, BaseHealthExp0, BaseDamageExp0 "
+    std::string queryStr = "SELECT Class, Level, BaseMana, BaseAttackPower, BaseArmor, BaseHealthExp0, BaseDamageExp0 "
                            "FROM creature_template_classlevelstats ORDER BY Class, Level";
 
     QueryResult* result = WorldDatabase.Query(queryStr.c_str());
@@ -736,11 +729,10 @@ void ObjectMgr::LoadCreatureClassLvlStats()
         CreatureClassLvlStats& cCLS = m_creatureClassLvlStats[creatureLevel][classToIndex[creatureClass]];
 
         cCLS.BaseMana               = fields[2].GetUInt32();
-        cCLS.BaseMeleeAttackPower   = fields[3].GetFloat();
-        cCLS.BaseRangedAttackPower  = fields[4].GetFloat();
-        cCLS.BaseArmor              = fields[5].GetUInt32();
-        cCLS.BaseHealth             = fields[6].GetUInt32();
-        cCLS.BaseDamage             = fields[7].GetFloat();
+        cCLS.BaseAttackPower        = fields[3].GetFloat();
+        cCLS.BaseArmor              = fields[4].GetUInt32();
+        cCLS.BaseHealth             = fields[5].GetUInt32();
+        cCLS.BaseDamage             = fields[6].GetFloat();
 
         ++storedRow;
     }

--- a/src/shared/revision_sql.h
+++ b/src/shared/revision_sql.h
@@ -2,5 +2,5 @@
 #define __REVISION_SQL_H__
  #define REVISION_DB_REALMD "required_z2678_01_realmd"
  #define REVISION_DB_CHARACTERS "required_z2698_01_characters_playerbot_saved_data"
- #define REVISION_DB_MANGOS "required_z2702_01_mangos_spell_chain_totems_typos"
+ #define REVISION_DB_MANGOS "required_z2703_01_mangos_creature_template_fixup"
 #endif // __REVISION_SQL_H__


### PR DESCRIPTION
creature_template contains a lot of duplicate info.

This removes Most things to do with ranged and streamlines faction for both ally and horde.

@Cyberium @cala @Tobschinski @killerwife @Grz3s