### PR TITLE
Update what is considered CC by EventAI

### DIFF
--- a/src/game/Grids/GridNotifiers.h
+++ b/src/game/Grids/GridNotifiers.h
@@ -709,7 +709,8 @@ namespace MaNGOS
             bool operator()(Unit* u)
             {
                 if (u->isAlive() && u->isInCombat() && !i_obj->IsHostileTo(u) && i_obj->IsWithinDistInMap(u, i_range) &&
-                        (u->isCharmed() || u->isFrozen() || u->hasUnitState(UNIT_STAT_CAN_NOT_REACT)))
+                        (u->IsImmobilized() || u->GetMaxNegativeAuraModifier(SPELL_AURA_MOD_DECREASE_SPEED) || u->isFeared() ||
+                         u->IsPolymorphed() || u->isFrozen() || u->hasUnitState(UNIT_STAT_CAN_NOT_REACT)))
                 {
                     return true;
                 }


### PR DESCRIPTION
Not enough things were considered CCs, and considering isCharmed a CC is
useless since we check if the mob is hostile to us first, which it will be if it's charmed, so we would never even get to this check.