### PR TITLE
Make WorldSocket::SendPacket thread-safe for multithreading of sendin…

### DIFF
--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -64,6 +64,8 @@ void WorldSocket::SendPacket(const WorldPacket& pct, bool immediate)
     if (IsClosed())
         return;
 
+    std::lock_guard<std::mutex> guard(m_packetSendLock);
+
     // Dump outgoing packet.
     sLog.outWorldPacketDump(GetRemoteEndpoint().c_str(), pct.GetOpcode(), pct.GetOpcodeName(), pct, false);
 
@@ -138,7 +140,7 @@ bool WorldSocket::ProcessIncomingData()
     if ((header.size < 4) || (header.size > 0x2800) || (header.cmd >= NUM_MSG_TYPES))
     {
         sLog.outError("WorldSocket::ProcessIncomingData: client sent malformed packet size = %u , cmd = %u", header.size, header.cmd);
-    
+
         errno = EINVAL;
         return false;
     }

--- a/src/game/Server/WorldSocket.h
+++ b/src/game/Server/WorldSocket.h
@@ -101,6 +101,8 @@ class WorldSocket : public MaNGOS::Socket
         ClientPktHeader m_existingHeader;
         bool m_useExistingHeader;
 
+        std::mutex m_packetSendLock; // mutex for SendPacket
+
         /// Class used for managing encryption of the headers
         AuthCrypt m_crypt;
 


### PR DESCRIPTION
…g packets

Currently, WorldSocket::SendPacket is not thread safe, cause there're two `Socket::Write`, each would acquire a lock of `Socket::m_mutex`. These two `Socket::Write` may cause `m_outBuffer` has unordered packet head and body.