### PR TITLE
Implement EVENT_T_FACING_TARGET

### DIFF
--- a/doc/EventAI.txt
+++ b/doc/EventAI.txt
@@ -95,6 +95,7 @@ Some events such as EVENT_T_AGGRO, EVENT_T_DEATH, EVENT_T_SPAWNED, and EVENT_T_E
 30   EVENT_T_RECEIVE_AI_EVENT        AIEventType, Sender-Entry, unused, unused               Expires when the creature receives an AIEvent of type (Param1), sent by creature (Param2 != 0). If (Param2 = 0) then sent by any creature
 31   EVENT_T_ENERGY                  EnergyMax%, EnergyMin%, RepeatMin, RepeatMax            Expires when the NPC's Energy% is between (Param1) and (Param2). Will repeat between every (Param3) and (Param4) If Event Conditions Are Still Met.
 32   EVENT_T_SELECT_ATTACKING_TARGET MinRange, MaxRange, RepeatMin, RepeatMax                Expires when the NPC has a target in threat table further than Param1 and closer than Param2. First time happens after and will repeat after Param3 and Param4.
+33   EVENT_T_FACING_TARGET           BackOrFront, unused, RepeatMin, RepeatMax               Expires when the NPC is in back (Param1=0) or in front (Param1=1) of its current target. Will repeat after Param3 and Param4.
 
 =========================================
 Action Types
@@ -493,6 +494,17 @@ Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Event Expi
 
 COMBAT ONLY - Expires when a random hostile target is found in a distance greater than (Param1) and less than (Param2). Will repeat every (Param3) and (Param4).
 Note: this event will fill TARGET_T_EVENT_SPECIFIC with the target found
+
+---------------------------
+33 = EVENT_T_FACING_TARGET:
+---------------------------
+Parameter 1: BackOrFront - Define is the NPC must be in back (Parameter 1=0) or in front (Parameter 1=1) or its current target.
+Parameter 2: Unused
+Parameter 3: RepeatMin - Minimum Time used to calculate Random Repeat Event Expire
+Parameter 4: RepeatMax - Maximum Time used to calculate Random Repeat Event Expire
+
+COMBAT ONLY - Expires when the NPC is facing the back (or front) of its current target. Will repeat every (Param3) and (Param4).
+This is commonly used for events where a NPC needs to use abilities available only when facing its target's back/front (Such as rogues' backstab ability).
 
 =========================================
 Action Types

--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -153,6 +153,7 @@ bool CreatureEventAI::IsTimerBasedEvent(EventAI_Type type) const
         case EVENT_T_RANGE:
         case EVENT_T_ENERGY:
         case EVENT_T_SELECT_ATTACKING_TARGET:
+        case EVENT_T_FACING_TARGET:
             return true;
         default:
             return false;
@@ -455,6 +456,23 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& pHolder, Unit* pAction
             LOG_PROCESS_EVENT;
             // Repeat Timers
             pHolder.UpdateRepeatTimer(m_creature, event.percent_range.repeatMin, event.percent_range.repeatMax);
+            break;
+        }
+        case EVENT_T_FACING_TARGET:
+        {
+            if (!m_creature->isInCombat() || !m_creature->getVictim())
+                return false;
+
+            // Creature expected in back of target (melee range)
+            if (event.facingTarget.backOrFront == 0 && !m_creature->getVictim()->isInBackInMap(m_creature, 5.0f))
+                return false;
+            // Creature expected in front of target (melee range)
+            else if (event.facingTarget.backOrFront == 1 && !m_creature->getVictim()->isInFrontInMap(m_creature, 5.0f))
+                return false;
+
+            LOG_PROCESS_EVENT;
+            // Repeat Timers
+            pHolder.UpdateRepeatTimer(m_creature, event.facingTarget.repeatMin, event.facingTarget.repeatMax);
             break;
         }
         default:

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -70,6 +70,7 @@ enum EventAI_Type
     EVENT_T_RECEIVE_AI_EVENT        = 30,                   // AIEventType, Sender-Entry, unused, unused
     EVENT_T_ENERGY                  = 31,                   // EnergyMax%, EnergyMin%, RepeatMin, RepeatMax
     EVENT_T_SELECT_ATTACKING_TARGET = 32,                   // MinRange, MaxRange, RepeatMin, RepeatMax
+    EVENT_T_FACING_TARGET           = 33,                   // Position, unused, RepeatMin, RepeatMax
 
     EVENT_T_END,
 };
@@ -446,7 +447,7 @@ struct CreatureEventAI_Action
             uint32 unused2;
         } dynamicMovement;
         // ACTION_T_SET_REACT_STATE                         = 50
-        struct  
+        struct
         {
             uint32 reactState;
             uint32 unused1;
@@ -660,6 +661,14 @@ struct CreatureEventAI_Event
             uint32 repeatMin;
             uint32 repeatMax;
         } selectTarget;
+        // EVENT_T_FACING_TARGET                            = 33
+        struct
+        {
+            uint32 backOrFront;
+            uint32 unused;
+            uint32 repeatMin;
+            uint32 repeatMax;
+        } facingTarget;
         // RAW
         struct
         {

--- a/src/game/AI/EventAI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/EventAI/CreatureEventAIMgr.cpp
@@ -530,6 +530,25 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                     }
                     break;
                 }
+                case EVENT_T_FACING_TARGET:
+                {
+                    // Position is invalid (0:in back, 1:in front)
+                    if (temp.facingTarget.backOrFront && temp.facingTarget.backOrFront != 1)
+                    {
+                        sLog.outErrorEventAI("Event %u has unfitting value (%u) for param1 in event EVENT_T_FACING_TARGET (must be 0 or 1), skipping.", i, temp.facingTarget.backOrFront);
+                        continue;
+                    }
+                    // Event has repeatable flag but no timer
+                    if (temp.event_flags & EFLAG_REPEATABLE && !temp.facingTarget.repeatMin && !temp.facingTarget.repeatMax)
+                    {
+                        sLog.outErrorEventAI("Creature %u has param3 and param4=0 (RepeatMin/RepeatMax) but cannot be repeatable without timers. Removing EFLAG_REPEATABLE for event %u.", temp.creature_id, i);
+                        temp.event_flags &= ~EFLAG_REPEATABLE;
+                    }
+                    // Event has repeatable flag but timer is invalid
+                    if (temp.event_flags & EFLAG_REPEATABLE && temp.facingTarget.repeatMax < temp.facingTarget.repeatMin)
+                        sLog.outErrorEventAI("Creature %u is using repeatable event(%u) with param4 < param3 (RepeatMax < RepeatMin). Event will never repeat.", temp.creature_id, i);
+                    break;
+                }
                 default:
                     sLog.outErrorEventAI("Creature %u using not checked at load event (%u) in event %u. Need check code update?", temp.creature_id, temp.event_id, i);
                     break;


### PR DESCRIPTION
Allows NPCs to perform action only when facing the back or the front of their target in EventAI. This is typically useful for rogue-like NPCs.