### PR TITLE
Don't set attack timer on both weapons

### DIFF
--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -501,15 +501,21 @@ bool Unit::UpdateMeleeAttackingState()
     uint8 swingError = 0;
     if (!CanReachWithMeleeAttack(victim))
     {
-        setAttackTimer(BASE_ATTACK, 100);
-        setAttackTimer(OFF_ATTACK, 100);
+        if (isAttackReady(BASE_ATTACK))
+            setAttackTimer(BASE_ATTACK, 100);
+        if (haveOffhandWeapon() && isAttackReady(OFF_ATTACK))
+            setAttackTimer(OFF_ATTACK, 100);
+
         swingError = 1;
     }
     // 120 degrees of radiant range
     else if (!HasInArc(2 * M_PI_F / 3, victim))
     {
-        setAttackTimer(BASE_ATTACK, 100);
-        setAttackTimer(OFF_ATTACK, 100);
+        if (isAttackReady(BASE_ATTACK))
+            setAttackTimer(BASE_ATTACK, 100);
+        if (haveOffhandWeapon() && isAttackReady(OFF_ATTACK))
+            setAttackTimer(OFF_ATTACK, 100);
+
         swingError = 2;
     }
     else


### PR DESCRIPTION
The current situation of setting both weapons to 100 ms when out of
range / don't have target in front can be abused (every time you get a hit in
with your slow main hand, run out of range or turn around and wait for
the error to display, triggered by your fast offhander; now both your
weapons are ready again since attack timers are set to 100ms on both...

Ref; https://github.com/elysium-project/server/issues/2655