### PR TITLE
Remove reference to prospecting_loot_template

### DIFF
--- a/sql/updates/mangos/z2709_01_mangos_comments.sql
+++ b/sql/updates/mangos/z2709_01_mangos_comments.sql
@@ -14,7 +14,6 @@ ALTER TABLE reference_loot_template ADD comments VARCHAR(300) DEFAULT '' AFTER c
 ALTER TABLE disenchant_loot_template ADD comments VARCHAR(300) DEFAULT '' AFTER condition_id;
 ALTER TABLE fishing_loot_template ADD comments VARCHAR(300) DEFAULT '' AFTER condition_id;
 ALTER TABLE item_loot_template ADD comments VARCHAR(300) DEFAULT '' AFTER condition_id;
-ALTER TABLE prospecting_loot_template ADD comments VARCHAR(300) DEFAULT '' AFTER condition_id;
 ALTER TABLE skinning_loot_template ADD comments VARCHAR(300) DEFAULT '' AFTER condition_id;
 
 


### PR DESCRIPTION
Table doesn't exist in mangos-classic DB and causes errors when `z2709_01_mangos_comments.sql` is executed.