### PR TITLE
Improve handle of SPELL_EFFECT_OPEN_LOCK for GAMEOBJECT_TYPE_TRAP

### DIFF
--- a/src/game/Entities/GameObject.cpp
+++ b/src/game/Entities/GameObject.cpp
@@ -66,6 +66,7 @@ GameObject::GameObject() : WorldObject(),
 
     m_isInUse = false;
     m_reStockTimer = 0;
+    m_rearmTimer = 0;
     m_despawnTimer = 0;
 }
 
@@ -409,6 +410,20 @@ void GameObject::Update(uint32 update_diff, uint32 p_time)
 
                         loot->Update();
                     }
+                    break;
+                case GAMEOBJECT_TYPE_TRAP:
+                    if (m_rearmTimer == 0)
+                    {
+                        m_rearmTimer = time(nullptr) + GetRespawnDelay();
+                        SetGoState(GO_STATE_ACTIVE_ALTERNATIVE);
+                    }
+
+                    if (m_rearmTimer < time(nullptr))
+                    {
+                        SetGoState(GO_STATE_READY);
+                        m_lootState = GO_READY;
+                        m_rearmTimer = 0;
+                    };
                     break;
                 case GAMEOBJECT_TYPE_GOOBER:
                     if (m_cooldownTime < time(nullptr))

--- a/src/game/Entities/GameObject.h
+++ b/src/game/Entities/GameObject.h
@@ -748,6 +748,9 @@ class GameObject : public WorldObject
         ObjectGuid m_lootRecipientGuid;                     // player who will have rights for looting if m_lootGroupRecipient==0 or group disbanded
         uint32 m_lootGroupRecipientId;                      // group who will have rights for looting if set and exist
 
+        // Used for trap type
+        time_t m_rearmTimer;                                // timer to rearm the trap once disarmed
+
         // Used for chest type
         bool m_isInUse;                                     // only one player at time are allowed to open chest
         time_t m_reStockTimer;                              // timer to refill the chest

--- a/src/game/Globals/SharedDefines.h
+++ b/src/game/Globals/SharedDefines.h
@@ -372,7 +372,7 @@ enum SpellAttributesEx3
     SPELL_ATTR_EX3_UNK15                       = 0x00008000,// 15 Auto Shoot, Shoot, Throw,  - this is autoshot flag
     SPELL_ATTR_EX3_CANT_TRIGGER_PROC           = 0x00010000,// 16 confirmed by patchnotes
     SPELL_ATTR_EX3_NO_INITIAL_AGGRO            = 0x00020000,// 17 Causes no aggro if not missed
-    SPELL_ATTR_EX3_CANT_MISS                   = 0x00040000,// 18 Spell should always hit its target 
+    SPELL_ATTR_EX3_CANT_MISS                   = 0x00040000,// 18 Spell should always hit its target
     SPELL_ATTR_EX3_UNK19                       = 0x00080000,// 19
     SPELL_ATTR_EX3_DEATH_PERSISTENT            = 0x00100000,// 20 Death persistent spells
     SPELL_ATTR_EX3_UNK21                       = 0x00200000,// 21
@@ -1613,6 +1613,7 @@ enum LockKeyType
 
 enum LockType
 {
+    LOCKTYPE_NONE                  = 0,
     LOCKTYPE_PICKLOCK              = 1,
     LOCKTYPE_HERBALISM             = 2,
     LOCKTYPE_MINING                = 3,

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -1986,9 +1986,9 @@ void Spell::SendLoot(ObjectGuid guid, LootType loottype, LockType lockType)
                         break;
 
                     case GAMEOBJECT_TYPE_TRAP:
-                        if (lockType == LOCKTYPE_DISARM_TRAP)
+                        if (lockType == LOCKTYPE_DISARM_TRAP || lockType == LOCKTYPE_NONE)
                         {
-                            gameObjTarget->SetLootState(GO_JUST_DEACTIVATED);
+                            gameObjTarget->SetLootState(GO_ACTIVATED);
                             return;
                         }
                         sLog.outError("Spell::SendLoot unhandled locktype %u for GameObject trap (entry %u) for spell %u.", lockType, gameObjTarget->GetEntry(), m_spellInfo->Id);
@@ -4111,7 +4111,7 @@ void Spell::EffectStuck(SpellEffectIndex /*eff_idx*/)
     }
     else
     {
-        // If the player is alive, but their hearthstone is either not in their inventory (e.g. in the bank) or 
+        // If the player is alive, but their hearthstone is either not in their inventory (e.g. in the bank) or
         // their hearthstone is on cooldown, then the game will try to "nudge" the player in a seemingly random direction.
         // @todo This check could possibly more accurately find a safe position to port to, has the potential for porting underground.
         float x, y, z;


### PR DESCRIPTION
Improve the way traps are handled when targetted by SPELL_EFFECT_OPEN_LOCK (like disarm trap spell). Instead of being desactivated and despawning, they change state and use an alternate visual for the duration of the open lock (which is equal to the GO respawn time). They are then rearmed (back to GO_STATE_READY)

This should fix:
- the disarming of Suppression Device traps in BWL that were despawning instead of being disarmed
- quests 4734 and 4735 in UBRS where egg traps were still triggering instead of temporary changing state as expected