### PR TITLE
Fix civilian checks in Classic

### DIFF
--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -1847,7 +1847,7 @@ bool Creature::CanAssistTo(const Unit* u, const Unit* enemy, bool checkfaction /
         return false;
 
     // we don't need help from non-combatant ;)
-    if (GetCreatureInfo()->ExtraFlags & CREATURE_EXTRA_FLAG_NO_AGGRO)
+    if (IsCivilian())
         return false;
 
     if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_IMMUNE_TO_NPC))

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -576,7 +576,8 @@ class Creature : public Unit
         void ReduceCorpseDecayTimer();
         uint32 GetCorpseDecayTimer() const { return m_corpseDecayTimer; }
         bool IsRacialLeader() const { return GetCreatureInfo()->RacialLeader; }
-        bool IsCivilian() const { return !!GetCreatureInfo()->civilian; }
+        bool IsCivilian() const { return !!(GetCreatureInfo()->ExtraFlags & CREATURE_EXTRA_FLAG_NO_AGGRO); }
+        bool IsPvPCivilian() const { return !!GetCreatureInfo()->civilian; }
         bool IsGuard() const { return !!(GetCreatureInfo()->ExtraFlags & CREATURE_EXTRA_FLAG_GUARD); }
 
         bool CanWalk() const { return !!(GetCreatureInfo()->InhabitType & INHABIT_GROUND); }
@@ -784,7 +785,7 @@ class Creature : public Unit
         void SendAreaSpiritHealerQueryOpcode(Player* pl);
 
         void SetVirtualItem(VirtualItemSlot slot, uint32 item_id);
-        
+
         void OnEventHappened(uint16 eventId, bool activate, bool resume) override { return AI()->OnEventHappened(eventId, activate, resume); }
 
         uint32 GetDetectionRange() const override { return m_creatureInfo->Detection; }

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -6153,7 +6153,7 @@ bool Player::RewardHonor(Unit* uVictim, uint32 groupsize)
     if (uVictim->GetTypeId() == TYPEID_UNIT)
     {
         Creature* cVictim = (Creature*)uVictim;
-        if (cVictim->IsCivilian())
+        if (cVictim->IsPvPCivilian())
         {
             AddHonorCP(MaNGOS::Honor::DishonorableKillPoints(getLevel()), DISHONORABLE, cVictim);
             return true;


### PR DESCRIPTION
- Make use of CREATURE_EXTRA_FLAG_NO_AGGRO to match TBC/WotLK cores behaviour with similar flag CREATURE_EXTRA_FLAG_CIVILIAN
- Add separate function for PvP civilian check that is a Classic specific behaviour related to Honor System at the time