### PR TITLE
Get creature melee attack power from creature_template_classlevelstats

### DIFF
--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -1261,7 +1261,7 @@ void Creature::SelectLevel(uint32 forcedLevel /*= USE_DEFAULT_DATABASE_LEVEL*/)
     SetFloatValue(UNIT_FIELD_MINRANGEDDAMAGE, cinfo->MinRangedDmg * damagemod);
     SetFloatValue(UNIT_FIELD_MAXRANGEDDAMAGE, cinfo->MaxRangedDmg * damagemod);
 
-    SetModifierValue(UNIT_MOD_ATTACK_POWER, BASE_VALUE, cinfo->MeleeAttackPower * damagemod);
+    SetModifierValue(UNIT_MOD_ATTACK_POWER, BASE_VALUE, cCLS->BaseMeleeAttackPower * damagemod);
 }
 
 float Creature::_GetHealthMod(int32 Rank)


### PR DESCRIPTION
* According to the wiki creature melee attack power is supposed to be
calculated from this value rather than the value 'MeleeAttackPower' on
each entry in creature_template.
* Source: https://github.com/cmangos/issues/wiki/Creature_template#meleeattackpower