### PR TITLE
minor update to BindIP description in sample configs

### DIFF
--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -52,7 +52,7 @@ ConfVersion=2015090801
 #        Port on which the server will listen
 #
 #    BindIP
-#        Bind World Server to IP/hostname
+#        Bind World Server to specific IP address
 #        This option is useful for running multiple worldd/realmd instances
 #        on different IP addresses using default ports.
 #        DO NOT CHANGE THIS UNLESS YOU _REALLY_ KNOW WHAT YOU'RE DOING

--- a/src/realmd/realmd.conf.dist.in
+++ b/src/realmd/realmd.conf.dist.in
@@ -29,7 +29,7 @@ ConfVersion=2010062001
 #         Port on which the server will listen
 #
 #    BindIP
-#         Bind Realm Server to IP/hostname
+#         Bind Realm Server to specific IP address
 #         This option is useful for running multiple worldd/realmd instances
 #         on different IP addresses using default ports.
 #         DO NOT CHANGE THIS UNLESS YOU _REALLY_ KNOW WHAT YOU'RE DOING


### PR DESCRIPTION
No name resolution is being performed for name or string entered into the BindIP field.  Previous to this commit https://github.com/cmangos/mangos-classic/commit/ab2f3f6725a5ad979c4641a9a8268da9bc537227 BindIP was ignored.  Realmd and Mangosd would just bind to 0.0.0.0

This PR just updates the description of BindIP within the sample configs.