### PR TITLE
Remove faction duplicate

### DIFF
--- a/sql/base/mangos.sql
+++ b/sql/base/mangos.sql
@@ -23,7 +23,7 @@ DROP TABLE IF EXISTS `db_version`;
 CREATE TABLE `db_version` (
   `version` varchar(120) DEFAULT NULL,
   `creature_ai_version` varchar(120) DEFAULT NULL,
-  `required_z2718_01_mangos_spell_affect` bit(1) DEFAULT NULL
+  `required_z2719_01_mangos_creature_template_fixup` bit(1) DEFAULT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Used DB version notes';
 
 --
@@ -1149,8 +1149,7 @@ CREATE TABLE `creature_template` (
   `ModelId2` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `ModelId3` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `ModelId4` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `FactionAlliance` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `FactionHorde` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `Faction` smallint(5) unsigned NOT NULL DEFAULT '0',
   `Scale` float NOT NULL DEFAULT '1',
   `Family` tinyint(4) NOT NULL DEFAULT '0',
   `CreatureType` tinyint(3) unsigned NOT NULL DEFAULT '0',

--- a/sql/updates/mangos/z2719_01_mangos_creature_template_fixup.sql
+++ b/sql/updates/mangos/z2719_01_mangos_creature_template_fixup.sql
@@ -1,0 +1,4 @@
+ALTER TABLE db_version CHANGE COLUMN required_z2718_01_mangos_spell_affect required_z2719_01_mangos_creature_template_fixup bit;
+
+ALTER TABLE `creature_template` CHANGE COLUMN FactionAlliance Faction smallint(5) unsigned NOT NULL DEFAULT '0';
+ALTER TABLE `creature_template` DROP COLUMN FactionHorde;

--- a/src/game/AI/BaseAI/CreatureAI.cpp
+++ b/src/game/AI/BaseAI/CreatureAI.cpp
@@ -317,8 +317,7 @@ void CreatureAI::CheckForHelp(Unit* who, Creature* me, float distance)
                 else // In non-instanceable creature must belong to same family and faction to attack player.
                 {
                     if (me->GetCreatureInfo()->Family == ((Creature*)who)->GetCreatureInfo()->Family &&
-                            me->GetCreatureInfo()->FactionAlliance == ((Creature*)who)->GetCreatureInfo()->FactionAlliance &&
-                            me->GetCreatureInfo()->FactionHorde == ((Creature*)who)->GetCreatureInfo()->FactionHorde)
+                            me->GetCreatureInfo()->Faction == ((Creature*)who)->GetCreatureInfo()->Faction)
                         AttackStart(victim);
                 }
             }

--- a/src/game/Chat/Level2.cpp
+++ b/src/game/Chat/Level2.cpp
@@ -1868,13 +1868,10 @@ bool ChatHandler::HandleNpcFactionIdCommand(char* args)
 
     // update in memory
     if (CreatureInfo const* cinfo = pCreature->GetCreatureInfo())
-    {
-        const_cast<CreatureInfo*>(cinfo)->FactionAlliance = factionId;
-        const_cast<CreatureInfo*>(cinfo)->FactionHorde = factionId;
-    }
+        const_cast<CreatureInfo*>(cinfo)->Faction = factionId;
 
     // and DB
-    WorldDatabase.PExecuteLog("UPDATE creature_template SET FactionAlliance = '%u', FactionHorde = '%u' WHERE entry = '%u'", factionId, factionId, pCreature->GetEntry());
+    WorldDatabase.PExecuteLog("UPDATE creature_template SET Faction = '%u' WHERE entry = '%u'", factionId, pCreature->GetEntry());
 
     return true;
 }

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -378,10 +378,7 @@ bool Creature::UpdateEntry(uint32 Entry, Team team, const CreatureData* data /*=
     else
         SelectLevel();
 
-    if (team == HORDE)
-        setFaction(GetCreatureInfo()->FactionHorde);
-    else
-        setFaction(GetCreatureInfo()->FactionAlliance);
+    setFaction(GetCreatureInfo()->Faction);
 
     SetUInt32Value(UNIT_NPC_FLAGS, GetCreatureInfo()->NpcFlags);
 
@@ -419,7 +416,7 @@ bool Creature::UpdateEntry(uint32 Entry, Team team, const CreatureData* data /*=
     UpdateAllStats();
 
     // checked and error show at loading templates
-    if (FactionTemplateEntry const* factionTemplate = sFactionTemplateStore.LookupEntry(GetCreatureInfo()->FactionAlliance))
+    if (FactionTemplateEntry const* factionTemplate = sFactionTemplateStore.LookupEntry(GetCreatureInfo()->Faction))
     {
         if (factionTemplate->factionFlags & FACTION_TEMPLATE_FLAG_PVP)
             SetPvP(true);
@@ -2499,7 +2496,7 @@ void Creature::ClearTemporaryFaction()
         return;
 
     // Reset to original faction
-    setFaction(GetCreatureInfo()->FactionAlliance);
+    setFaction(GetCreatureInfo()->Faction);
 
     ForceHealthAndPowerUpdate();                            // update health and power for client needed to hide enemy real value
 

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -84,8 +84,7 @@ struct CreatureInfo
     uint32  MinLevel;
     uint32  MaxLevel;
     uint32  ModelId[MAX_CREATURE_MODEL];
-    uint32  FactionAlliance;
-    uint32  FactionHorde;
+    uint32  Faction;
     float   Scale;
     uint32  Family;                                         // enum CreatureFamily values (optional)
     uint32  CreatureType;                                   // enum CreatureType values

--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -402,13 +402,9 @@ void ObjectMgr::LoadCreatureTemplates()
         if (!cInfo)
             continue;
 
-        FactionTemplateEntry const* factionTemplate = sFactionTemplateStore.LookupEntry(cInfo->FactionAlliance);
+        FactionTemplateEntry const* factionTemplate = sFactionTemplateStore.LookupEntry(cInfo->Faction);
         if (!factionTemplate)
-            sLog.outErrorDb("Creature (Entry: %u) has nonexistent faction_A template (%u)", cInfo->Entry, cInfo->FactionAlliance);
-
-        factionTemplate = sFactionTemplateStore.LookupEntry(cInfo->FactionHorde);
-        if (!factionTemplate)
-            sLog.outErrorDb("Creature (Entry: %u) has nonexistent faction_H template (%u)", cInfo->Entry, cInfo->FactionHorde);
+            sLog.outErrorDb("Creature (Entry: %u) has nonexistent faction template (%u)", cInfo->Entry, cInfo->Faction);
 
         for (int k = 0; k < MAX_KILL_CREDIT; ++k)
         {

--- a/src/shared/revision_sql.h
+++ b/src/shared/revision_sql.h
@@ -2,5 +2,5 @@
 #define __REVISION_SQL_H__
  #define REVISION_DB_REALMD "required_z2716_01_realmd_totp"
  #define REVISION_DB_CHARACTERS "required_z2708_01_characters_account_instances_entered"
- #define REVISION_DB_MANGOS "required_z2718_01_mangos_spell_affect"
+ #define REVISION_DB_MANGOS "required_z2719_01_mangos_creature_template_fixup"
 #endif // __REVISION_SQL_H__


### PR DESCRIPTION
Remove faction duplicate from creature_template

I ran this on cmangos classic database;

`select Entry, FactionAlliance as FacA, FactionHorde as FacH from creature_template Where FactionAlliance-FactionHorde!='0';`

and got this result;

![billede](https://user-images.githubusercontent.com/1907820/36976187-f8531f9a-207c-11e8-807f-67cf738768b8.png)

This guy;

http://wowwiki.wikia.com/wiki/William_Kielar

Then I ran it against cmangos tbc-db and got the same result. Still just that one guy... 

Why he needs to be a different faction to ally and to horde is beyond me but must be able to be handled in his eventAI script, and if not, then move him to SD2 where it should be manageable.

@Tobschinski @cala 