### PR TITLE
Fixed incorrect UpdateField.h value BANKBAG_SLOT_LAST

### DIFF
--- a/src/game/Entities/UpdateFields.h
+++ b/src/game/Entities/UpdateFields.h
@@ -204,7 +204,7 @@ enum EUnitFields
     PLAYER_FIELD_BANK_SLOT_1                   = 0x178 + UNIT_END, // Size:48
     PLAYER_FIELD_BANK_SLOT_LAST                = 0x1a6 + UNIT_END,
     PLAYER_FIELD_BANKBAG_SLOT_1                = 0x1a8 + UNIT_END, // Size:12
-    PLAYER_FIELD_BANKBAG_SLOT_LAST             = 0xab2 + UNIT_END,
+    PLAYER_FIELD_BANKBAG_SLOT_LAST             = 0x1b3 + UNIT_END,
     PLAYER_FIELD_VENDORBUYBACK_SLOT_1          = 0x1b4 + UNIT_END, // Size:24
     PLAYER_FIELD_VENDORBUYBACK_SLOT_LAST       = 0x1ca + UNIT_END,
     PLAYER_FIELD_KEYRING_SLOT_1                = 0x1cc + UNIT_END, // Size:64

--- a/src/game/Entities/UpdateFields.h
+++ b/src/game/Entities/UpdateFields.h
@@ -204,7 +204,7 @@ enum EUnitFields
     PLAYER_FIELD_BANK_SLOT_1                   = 0x178 + UNIT_END, // Size:48
     PLAYER_FIELD_BANK_SLOT_LAST                = 0x1a6 + UNIT_END,
     PLAYER_FIELD_BANKBAG_SLOT_1                = 0x1a8 + UNIT_END, // Size:12
-    PLAYER_FIELD_BANKBAG_SLOT_LAST             = 0x1b3 + UNIT_END,
+    PLAYER_FIELD_BANKBAG_SLOT_LAST             = 0x1b2 + UNIT_END,
     PLAYER_FIELD_VENDORBUYBACK_SLOT_1          = 0x1b4 + UNIT_END, // Size:24
     PLAYER_FIELD_VENDORBUYBACK_SLOT_LAST       = 0x1ca + UNIT_END,
     PLAYER_FIELD_KEYRING_SLOT_1                = 0x1cc + UNIT_END, // Size:64


### PR DESCRIPTION
I think this value is wrong? 

PLAYER_FIELD_BANKBAG_SLOT_1 = 0x1a8 + UNIT_END, // Size:12
PLAYER_FIELD_BANKBAG_SLOT_LAST= 0xab2 + UNIT_END,

I think the new value is correct. There are no references to this value in Cmangos though so it's just a latent fault. Not an active one thankfully.