### PR TITLE
Do not show incomplete quest text for completed quests.

### DIFF
--- a/src/game/Entities/GossipDef.cpp
+++ b/src/game/Entities/GossipDef.cpp
@@ -721,8 +721,8 @@ void PlayerMenu::SendQuestGiverRequestItems(Quest const* pQuest, ObjectGuid npcG
         }
     }
 
-    // We may wish a better check, perhaps checking the real quest requirements
-    if (RequestItemsText.empty())
+    // Only shown for incomplete quests, or ones that require items.
+    if (RequestItemsText.empty() || ((pQuest->GetReqItemsCount() == 0) && Completable))
     {
         SendQuestGiverOfferReward(pQuest, npcGUID, true);
         return;


### PR DESCRIPTION
Quests that don't require items use the RequestItemsText field to store the text that is shown when you talk to the quest giver while the quest is incomplete. Therefore the text should not be shown for them when the quest is complete. For quests that do require items, it is self explanatory.

Here is a gif to illustrate what i am talking about.
![ezgif-1-3d4a9bc9c4 gif 94004b57416de09e0893bf5b0e36d12b](https://user-images.githubusercontent.com/6519171/44044797-5d78373a-9f2f-11e8-8130-16dc9a602208.gif)
 https://youtu.be/jTSyexUNN9E?t=5m20s

You can see that on retail, it goes straight to offering the reward. You should not have to click "continue". 