### PR TITLE
Make spell proc cooldowns apply to creatures

### DIFF
--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -426,9 +426,8 @@ void Unit::ProcDamageAndSpellFor(ProcSystemArguments& argData, bool isVictim)
         bool procSuccess = true;
         bool anyAuraProc = false;
 
-        // For players set spell cooldown if need
         execData.cooldown = 0;
-        if (GetTypeId() == TYPEID_PLAYER && spellProcEvent && spellProcEvent->cooldown)
+        if (spellProcEvent && spellProcEvent->cooldown)
             execData.cooldown = spellProcEvent->cooldown;
 
         for (int32 i = 0; i < MAX_EFFECT_INDEX; ++i)


### PR DESCRIPTION
This prevents spells from proc'ing at extreme rates for certain NPCs.
For example, creatures that with Lightning Shield will shed a charge on
*every single hit*, which is particularly bad against players with high
hit rate (e.g. rogues).