### PR TITLE
Move logic to reset attack timer from Spell::finish to Spell::cast

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -3113,6 +3113,13 @@ void Spell::cast(bool skipCheck)
     // CAST SPELL
     SendSpellCooldown();
 
+    if (IsMeleeAttackResetSpell())
+    {
+        m_caster->resetAttackTimer(BASE_ATTACK);
+        if (m_caster->haveOffhandWeapon())
+            m_caster->resetAttackTimer(OFF_ATTACK);
+    }
+
     TakePower();
     TakeReagents();                                         // we must remove reagents before HandleEffects to allow place crafted item in same slot
     TakeAmmo();
@@ -3486,13 +3493,6 @@ void Spell::finish(bool ok)
     // Heal caster for all health leech from all targets
     if (m_healthLeech)
         m_caster->DealHeal(m_caster, uint32(m_healthLeech), m_spellInfo);
-
-    if (IsMeleeAttackResetSpell())
-    {
-        m_caster->resetAttackTimer(BASE_ATTACK);
-        if (m_caster->haveOffhandWeapon())
-            m_caster->resetAttackTimer(OFF_ATTACK);
-    }
 
     if (m_spellInfo->AttributesEx & SPELL_ATTR_EX_REFUND_POWER)
     {


### PR DESCRIPTION
Previously creatures that cast "delayed" spells (spells that take time to reach their target, e.g. Fireball) would be able to sneak in an extra melee attack between spell casts.

This behavior was due to the AI melee attack logic only checking for spells that are actively being cast, not spells that are in the process of travelling to the target. As soon as the spell was done being cast, the creature would perform a melee attack, but the logic to reset their attack timer wouldn't be executed until the spell actually reached the target several update ticks later.

This patches moves the attack timer reset logic to `Spell::cast` so that it is executed as soon as the spell is done being cast.

See https://gist.github.com/Patman64/e5747cc3cdcf16fa69b6fb04e38d8d48 for an example of combat *without* this patch. Note that `Unit::DealDamage` is executed as soon as `m_creature->IsNonMeleeSpellCasted(false)` returns `false`, but `Spell::finish` is not executed for another 6 update ticks and by that point the attack timer had just been reset 6 ticks prior.

See https://gist.github.com/Patman64/8572687c51e211306edf892249e3a0d8 for an example of combat *with* this patch. Note that `Unit::DealDamage` is never executed. The attack timer is reset from 0 to 2600 as soon as spell has been cast.