### PR TITLE
Improve EAI ranged mode behavior for main spells with min range

### DIFF
--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -148,6 +148,7 @@ void CreatureEventAI::InitAI()
                                 m_mainSpellId = i.action[actionIdx].cast.spellId;
                                 SpellEntry const* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(m_mainSpellId);
                                 m_mainSpellCost = Spell::CalculatePowerCost(spellInfo, m_creature, nullptr, nullptr);
+                                m_mainSpellMinRange = GetSpellMinRange(sSpellRangeStore.LookupEntry(spellInfo->rangeIndex));
                                 m_mainSpells.insert(i.action[actionIdx].cast.spellId);
                             }
 
@@ -779,6 +780,7 @@ bool CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                         {
                             case CAST_FAIL_COOLDOWN:
                             case CAST_FAIL_POWER:
+                            case CAST_FAIL_TOO_CLOSE:
                                 SetCurrentRangedMode(false);
                                 break;
                             case CAST_OK:
@@ -2013,7 +2015,8 @@ void CreatureEventAI::DistanceYourself()
         SetCurrentRangedMode(true);
 
     float x, y, z;
-    victim->GetNearPoint(m_creature, x, y, z, m_creature->GetObjectBoundingRadius(), DISTANCING_CONSTANT + m_creature->GetCombinedCombatReach(victim) * 1.5f, victim->GetAngle(m_creature));
+    float distance = DISTANCING_CONSTANT + std::max(m_creature->GetCombinedCombatReach(victim) * 1.5f, m_creature->GetCombinedCombatReach(victim) + m_mainSpellMinRange);
+    victim->GetNearPoint(m_creature, x, y, z, m_creature->GetObjectBoundingRadius(), distance, victim->GetAngle(m_creature));
     m_creature->GetMotionMaster()->MovePoint(POINT_MOVE_DISTANCE, x, y, z);
 }
 

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -861,6 +861,7 @@ class CreatureEventAI : public CreatureAI
         std::unordered_set<uint32> m_distanceSpells;
         uint32 m_mainSpellId;
         uint32 m_mainSpellCost;
+        float m_mainSpellMinRange;
 };
 
 #endif


### PR DESCRIPTION
This drastically improves the AI behavior for creatures that use ranged
mode and ranged weapons. Previously they had a "dead zone" where they
would be unable to cast their shoot spell (due to the spell's minimum
range) but would fail to switch back to melee mode.

Additionally, if they used a crowd control spell (e.g. Net), they would
fail to move far enough back and would end up stuck in the dead zone.

This changes `ACTION_T_CAST` logic to properly handle `CAST_FAIL_TOO_CLOSE` to
switch back to melee mode.

This also changes `CreatureEventAI::DistanceYourself` to add additional
distance if the main spell has a minimum range.

Demo script: https://gist.github.com/Patman64/6799a59be9d2951e37dd6ee9680cd3ca
Video of AI *without* patch: https://mega.nz/#!DqoQ1KIY!r-Eqc5fNwgNa6JbQZc2xOxPATwxwLyryTt-RY2bk32A
Video of AI *with* patch: https://mega.nz/#!Tig2UAxJ!qnbetji5k3cvN5rn_1NcVwI8ecY0cQ-R3bhg30acC0Q