### PR TITLE
Add support for 36 slot bags

### DIFF
--- a/src/game/Entities/Bag.h
+++ b/src/game/Entities/Bag.h
@@ -22,8 +22,8 @@
 #include "Common.h"
 #include "Entities/Item.h"
 
-// Maximum 28 Slots ( (CONTAINER_END - CONTAINER_FIELD_SLOT_1)/2
-#define MAX_BAG_SIZE 28                                     // 1.12
+// Maximum 36 Slots ( (CONTAINER_END - CONTAINER_FIELD_SLOT_1)/2
+#define MAX_BAG_SIZE 36
 
 enum InventorySlot
 {

--- a/src/game/Entities/UpdateFields.h
+++ b/src/game/Entities/UpdateFields.h
@@ -58,9 +58,9 @@ enum EContainerFields
 {
     CONTAINER_FIELD_NUM_SLOTS                  = ITEM_END + 0x00, // Size:1
     CONTAINER_ALIGN_PAD                        = ITEM_END + 0x01, // Size:1
-    CONTAINER_FIELD_SLOT_1                     = ITEM_END + 0x02, // count=56
-    CONTAINER_FIELD_SLOT_LAST                  = ITEM_END + 0x38,
-    CONTAINER_END                              = ITEM_END + 0x3A,
+    CONTAINER_FIELD_SLOT_1                     = ITEM_END + 0x02, // count=72
+    CONTAINER_FIELD_SLOT_LAST                  = ITEM_END + 0x48,
+    CONTAINER_END                              = ITEM_END + 0x4A,
 };
 
 enum EUnitFields


### PR DESCRIPTION
Described in this issue: https://github.com/cmangos/issues/issues/1777, this PR adds support for 36 slot bags. 

As there are no 36 slot bags in Classic, you will need to add a custom bag item with 36 slots to test.