### PR TITLE
Fix hunter pet movement when enemy is targeting it

### DIFF
--- a/src/game/AI/BaseAI/PetAI.cpp
+++ b/src/game/AI/BaseAI/PetAI.cpp
@@ -144,6 +144,20 @@ void PetAI::UpdateAI(const uint32 diff)
         inCombat = false;
     }
 
+    // If hunter pet's victim is targeting the pet, do not try to get behind it.
+    if (pet && victim && inCombat && (pet->getPetType() == HUNTER_PET))
+    {
+        if (victim->getVictim() == m_unit)
+        {    
+            m_attackAngle = 0.0f;
+            AttackStart(victim);
+        } else {
+            // Pet is not the target, try to get behind it again.
+            m_attackAngle = M_PI_F;
+            AttackStart(victim);
+        }
+    }
+
     CharmInfo* charminfo = m_unit->GetCharmInfo();
     MANGOS_ASSERT(charminfo);
 

--- a/src/game/AI/BaseAI/PetAI.cpp
+++ b/src/game/AI/BaseAI/PetAI.cpp
@@ -151,7 +151,9 @@ void PetAI::UpdateAI(const uint32 diff)
         {    
             m_attackAngle = 0.0f;
             AttackStart(victim);
-        } else {
+        }
+        else
+        {
             // Pet is not the target, try to get behind it again.
             m_attackAngle = M_PI_F;
             AttackStart(victim);


### PR DESCRIPTION
This fixes an issue with hunter pet AI wherein the pet will repeatedly attempt to get behind its target, causing the target to turn around. 