### PR TITLE
Fix always true if statement

### DIFF
--- a/contrib/vmap_extractor/vmapextract/vmapexport.cpp
+++ b/contrib/vmap_extractor/vmapextract/vmapexport.cpp
@@ -358,7 +358,7 @@ bool processArgv(int argc, char** argv)
             {
                 hasInputPathParam = true;
                 strcpy(input_path, argv[i + 1]);
-                if (input_path[strlen(input_path) - 1] != '\\' || input_path[strlen(input_path) - 1] != '/')
+                if (input_path[strlen(input_path) - 1] != '\\' && input_path[strlen(input_path) - 1] != '/')
                     strcat(input_path, "/");
                 ++i;
             }


### PR DESCRIPTION
This statement would always be true.

This puts it in line and smiliar functionality with the statements already fixed at line 125 and 231 in MapTree.cpp

Ref: https://medium.com/@Coder_HarryLee/checking-the-world-of-warcraft-cmangos-open-source-server-5405f364fb32

the re-extracted resources are made temporarily available [here](https://www.dropbox.com/s/6hcxi94n5l6yovp/fixifResources.rar?dl=0)