### PR TITLE
Fix creature's pets despawning on master death

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -1346,6 +1346,9 @@ void Player::SetDeathState(DeathState s)
         // FIXME: is pet dismissed at dying or releasing spirit? if second, add SetDeathState(DEAD) to HandleRepopRequestOpcode and define pet unsummon here with (s == DEAD)
         RemovePet(PET_SAVE_REAGENTS);
 
+        // Remove guardians (only players are supposed to have pets/guardians removed on death)
+        RemoveGuardians();
+
         // save value before aura remove in Unit::SetDeathState
         ressSpellId = GetUInt32Value(PLAYER_SELF_RES_SPELL);
 

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -7879,7 +7879,6 @@ void Unit::SetDeathState(DeathState s)
         RemoveAllAurasOnDeath();
         BreakCharmOutgoing();
         BreakCharmIncoming();
-        RemoveGuardians();
         RemoveMiniPet();
         UnsummonAllTotems();
 


### PR DESCRIPTION
Most assuredly guardians shouldn't be removed on creature death, so move that to player.

Do creatures even have minipets? they are only created through spelleffect EffectSummonCritter as far as I'm aware and are there any creature's which has a spell using that effect? I'm not so sure. 

Should creature's totems get removed on owner's death when pets shouldn't? I'd think not but really need a bit more research on that before moving it along with the others..

Solves cmangos/issues#1063 , also their AI persists through death, meaning they will keep using their abilities if set in eventai, which is awesome, they will however not really despawn as they just go back to 'following' their master's corpse, while they should despawn upon JustReachedHome() - they never do go home, though. Looking into that right now, but PR'ing this for now.