### PR TITLE
Update/fix xp gain calculations

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -18311,11 +18311,10 @@ void Player::RewardSinglePlayerAtKill(Unit* pVictim)
     {
         Creature* creatureVictim = static_cast<Creature*>(pVictim);
         RewardReputation(creatureVictim, 1);
-        uint32 xp = MaNGOS::XP::Gain(this, creatureVictim);
-        GiveXP(xp, creatureVictim);
+        GiveXP(MaNGOS::XP::Gain(this, creatureVictim), creatureVictim);
 
         if (Pet* pet = GetPet())
-            pet->GivePetXP(xp);
+            pet->GivePetXP(MaNGOS::XP::Gain(pet, creatureVictim));
 
         // normal creature (not pet/etc) can be only in !PvP case
         if (CreatureInfo const* normalInfo = creatureVictim->GetCreatureInfo())

--- a/src/game/Tools/Formulas.h
+++ b/src/game/Tools/Formulas.h
@@ -352,7 +352,7 @@ namespace MaNGOS
 
             xp_gain *= target->GetCreatureInfo()->ExperienceMultiplier;
 
-            return (uint32)(std::round(xp_gain * sWorld.getConfig(CONFIG_FLOAT_RATE_XP_KILL)));
+            return (uint32)(std::nearbyint(xp_gain * sWorld.getConfig(CONFIG_FLOAT_RATE_XP_KILL)));
         }
 
         inline float xp_in_group_rate(uint32 count, bool isRaid)

--- a/src/game/Tools/Formulas.h
+++ b/src/game/Tools/Formulas.h
@@ -297,61 +297,62 @@ namespace MaNGOS
             return GRAY;
         }
 
-        inline uint32 GetZeroDifference(uint32 pl_level)
+        inline uint32 GetZeroDifference(uint32 unit_level)
         {
-            if (pl_level < 8)  return 5;
-            if (pl_level < 10) return 6;
-            if (pl_level < 12) return 7;
-            if (pl_level < 16) return 8;
-            if (pl_level < 20) return 9;
-            if (pl_level < 30) return 11;
-            if (pl_level < 40) return 12;
-            if (pl_level < 45) return 13;
-            if (pl_level < 50) return 14;
-            if (pl_level < 55) return 15;
-            if (pl_level < 60) return 16;
+            if (unit_level < 8)  return 5;
+            if (unit_level < 10) return 6;
+            if (unit_level < 12) return 7;
+            if (unit_level < 16) return 8;
+            if (unit_level < 20) return 9;
+            if (unit_level < 30) return 11;
+            if (unit_level < 40) return 12;
+            if (unit_level < 45) return 13;
+            if (unit_level < 50) return 14;
+            if (unit_level < 55) return 15;
+            if (unit_level < 60) return 16;
             return 17;
         }
 
-        inline uint32 BaseGain(uint32 pl_level, uint32 mob_level)
+        inline float BaseGain(uint32 unit_level, uint32 mob_level)
         {
-            const uint32 nBaseExp = 45;
-            if (mob_level >= pl_level)
+            const uint32 nBaseExp = unit_level * 5 + 45;
+            if (mob_level >= unit_level)
             {
-                uint32 nLevelDiff = mob_level - pl_level;
+                uint32 nLevelDiff = mob_level - unit_level;
                 if (nLevelDiff > 4)
                     nLevelDiff = 4;
-                return ((pl_level * 5 + nBaseExp) * (20 + nLevelDiff) / 10 + 1) / 2;
+                return nBaseExp * (1.0f + (0.05f * nLevelDiff));
             }
-            uint32 gray_level = GetGrayLevel(pl_level);
+            uint32 gray_level = GetGrayLevel(unit_level);
             if (mob_level > gray_level)
             {
-                uint32 ZD = GetZeroDifference(pl_level);
-                return (pl_level * 5 + nBaseExp) * (ZD + mob_level - pl_level) / ZD;
+                uint32 ZD = GetZeroDifference(unit_level);
+                uint32 nLevelDiff = unit_level - mob_level;
+                return nBaseExp * (1.0f - (float(nLevelDiff) / ZD));
             }
             return 0;
         }
 
-        inline uint32 Gain(Player* player, Creature* target)
+        inline uint32 Gain(Unit const* unit, Creature* target)
         {
             if (target->IsTotem() || target->IsPet() || target->IsNoXp() || target->IsCritter())
                 return 0;
 
-            uint32 xp_gain = BaseGain(player->getLevel(), target->getLevel());
-            if (xp_gain == 0)
+            float xp_gain = BaseGain(unit->getLevel(), target->getLevel());
+            if (xp_gain == 0.0f)
                 return 0;
 
             if (target->IsElite())
             {
                 if (target->GetMap()->IsNoRaid())
-                    xp_gain *= 2.5;
+                    xp_gain *= 2.5f;
                 else
-                    xp_gain *= 2;
+                    xp_gain *= 2.0f;
             }
 
             xp_gain *= target->GetCreatureInfo()->ExperienceMultiplier;
 
-            return (uint32)(xp_gain * sWorld.getConfig(CONFIG_FLOAT_RATE_XP_KILL));
+            return (uint32)(std::round(xp_gain * sWorld.getConfig(CONFIG_FLOAT_RATE_XP_KILL)));
         }
 
         inline float xp_in_group_rate(uint32 count, bool isRaid)


### PR DESCRIPTION
Update xp formulas and rewrite to be based off of
https://wowwiki.fandom.com/wiki/Formulas:Mob_XP?oldid=228414
which is based off of
https://web.archive.org/web/20060722002320/http://mosa.unity.ncsu.edu/WoW/library/xpgrid.html

Rewrite xp formulas to support units and not just players (in support of pets)

Don't factor in any group rate when giving out reputation as there is no group rate bonus for that, it's equally divided by all the members regardless of level or anything else

Calculate in level difference between the pet and the killed target for xp gain instead of the pet's owner and killed target

convert interger types to float before using them in point decimal calculations. Also round up when giving xp so use std::round before converting back to uint32

Contributes to https://github.com/cmangos/issues/issues/931
> Pet does not gain exp as it should; it gains exp based on the level difference between its owner and the kill, not itself and the kill as it should.