### PR TITLE
Readjust reputation gain on lower level mobs/quests

### DIFF
--- a/src/game/World/World.cpp
+++ b/src/game/World/World.cpp
@@ -391,8 +391,8 @@ void World::LoadConfigSettings(bool reload)
     setConfigPos(CONFIG_FLOAT_RATE_XP_QUEST,                             "Rate.XP.Quest",                             1.0f);
     setConfigPos(CONFIG_FLOAT_RATE_XP_EXPLORE,                           "Rate.XP.Explore",                           1.0f);
     setConfigPos(CONFIG_FLOAT_RATE_REPUTATION_GAIN,                      "Rate.Reputation.Gain",                      1.0f);
-    setConfigPos(CONFIG_FLOAT_RATE_REPUTATION_LOWLEVEL_KILL,             "Rate.Reputation.LowLevel.Kill",             1.0f);
-    setConfigPos(CONFIG_FLOAT_RATE_REPUTATION_LOWLEVEL_QUEST,            "Rate.Reputation.LowLevel.Quest",            1.0f);
+    setConfigPos(CONFIG_FLOAT_RATE_REPUTATION_LOWLEVEL_KILL,             "Rate.Reputation.LowLevel.Kill",             0.2f);
+    setConfigPos(CONFIG_FLOAT_RATE_REPUTATION_LOWLEVEL_QUEST,            "Rate.Reputation.LowLevel.Quest",            0.2f);
     setConfigPos(CONFIG_FLOAT_RATE_CREATURE_NORMAL_DAMAGE,               "Rate.Creature.Normal.Damage",               1.0f);
     setConfigPos(CONFIG_FLOAT_RATE_CREATURE_ELITE_ELITE_DAMAGE,          "Rate.Creature.Elite.Elite.Damage",          1.0f);
     setConfigPos(CONFIG_FLOAT_RATE_CREATURE_ELITE_RAREELITE_DAMAGE,      "Rate.Creature.Elite.RAREELITE.Damage",      1.0f);

--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -3,7 +3,7 @@
 #####################################
 
 [MangosdConf]
-ConfVersion=2019020501
+ConfVersion=2019020502
 
 ###################################################################################################################
 # CONNECTIONS AND DIRECTORIES
@@ -1279,12 +1279,12 @@ Visibility.AIRelocationNotifyDelay = 1000
 #         Default: 1
 #
 #    Rate.Reputation.LowLevel.Kill
-#         Reputation Gain form low level kill (grey creture)
+#         Lowest Reputation Gain rate from low level kill
 #         Default: 0.2
 #
 #    Rate.Reputation.LowLevel.Quest
-#         Reputation Gain rate
-#         Default: 1
+#         Lowest Reputation Gain rate from low level quest
+#         Default: 0.2
 #
 #    Rate.InstanceResetTime
 #        Multiplier for the number of days in between global raid/heroic instance resets.
@@ -1402,7 +1402,7 @@ Rate.Mining.Next   = 1
 Rate.Talent = 1
 Rate.Reputation.Gain = 1
 Rate.Reputation.LowLevel.Kill    = 0.2
-Rate.Reputation.LowLevel.Quest   = 1
+Rate.Reputation.LowLevel.Quest   = 0.2
 Rate.InstanceResetTime = 1
 SkillGain.Crafting = 1
 SkillGain.Defense = 1

--- a/src/shared/SystemConfig.h
+++ b/src/shared/SystemConfig.h
@@ -37,7 +37,7 @@
 // Format is YYYYMMDDRR where RR is the change in the conf file
 // for that day.
 #ifndef _MANGOSDCONFVERSION
-# define _MANGOSDCONFVERSION 2019020501
+# define _MANGOSDCONFVERSION 2019020502
 #endif
 #ifndef _REALMDCONFVERSION
 # define _REALMDCONFVERSION 2010062001


### PR DESCRIPTION
The reputation system rate on lower level quests and mobs is more complex than simply having 1 config value for gray levels, which doesn't make much sense.

> Just like XP, if the mob or quest level is 6 or more levels below you, the reputation gained will be lowered by 20% for each level (however it can't be lower than 20%). Completing quests or killing mobs whose level is higher than yours won't give you more reputation.
> 
> For example, completing a level 10 quest that normally gives 25 points will give: 
> 
> Level | Points
> 1 | 25 (100%)
> 10 | 25 (100%)
> 15 | 25 (100%)
> 16 | 20 (80%)
> 17 | 15 (60%)
> 18 | 10 (40%)
> 19 | 5 (20%)
> 60 | 5 (20%)

https://wowwiki.fandom.com/wiki/Reputation?oldid=346091#Gaining_and_Losing_reputation

This was changed in wotlk to not have any penalty to reputation gains from lower level mobs/quests;

>Full reputation is still gained by questing at a higher level. For example, completing low level quests with a level 80 character now gives full reputation. This makes it easier to get to exalted and buy another faction's mount.
>
>Grey mobs used to give 20% of the normal reputation until the release of Patch 3.0.8. Now any mob will give full reputation. See the mob difficulty colors chart for when mobs transition from green to grey.

https://wowwiki.fandom.com/wiki/Reputation#Gaining_and_losing_reputation