### PR TITLE
Allow linking graveyards by area id.

### DIFF
--- a/sql/updates/mangos/z27xx_01_mangos_graveyard_map_links.sql
+++ b/sql/updates/mangos/z27xx_01_mangos_graveyard_map_links.sql
@@ -1,0 +1,12 @@
+-- Rename ghost_zone to ghost_loc because ghost_loc can now also refer to a map, not just an area
+-- Add link_kind to indicate what `ghost_loc` refers to.
+-- There are two
+-- kinds:
+--   0 --> `ghost_loc` refers to an area
+--   1 --> `ghost_loc` refers to a map
+
+ALTER TABLE `game_graveyard_zone`
+    CHANGE `ghost_zone` `ghost_loc` MEDIUMINT UNSIGNED NOT NULL,
+    ADD COLUMN `link_kind` TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `ghost_loc`,
+    DROP PRIMARY KEY,
+    ADD PRIMARY KEY(`id`, `ghost_loc`, `link_kind`);

--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -3710,7 +3710,7 @@ bool ChatHandler::HandleLinkGraveCommand(char* args)
         return false;
     }
 
-    if (sObjectMgr.AddGraveYardLink(g_id, zoneId, g_team))
+    if (sObjectMgr.AddGraveYardLink(g_id, zoneId, GRAVEYARD_AREALINK, g_team))
         PSendSysMessage(LANG_COMMAND_GRAVEYARDLINKED, g_id, zoneId);
     else
         PSendSysMessage(LANG_COMMAND_GRAVEYARDALRLINKED, g_id, zoneId);

--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -3735,6 +3735,7 @@ bool ChatHandler::HandleNearGraveCommand(char* args)
 
     Player* player = m_session->GetPlayer();
     uint32 zone_id = player->GetZoneId();
+    uint32 area_id = player->GetAreaId();
 
     WorldSafeLocsEntry const* graveyard = sObjectMgr.GetClosestGraveYard(player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(), player->GetMapId(), g_team);
 
@@ -3742,7 +3743,10 @@ bool ChatHandler::HandleNearGraveCommand(char* args)
     {
         uint32 g_id = graveyard->ID;
 
-        GraveYardData const* data = sObjectMgr.FindGraveYardData(g_id, zone_id);
+        GraveYardData const* data = sObjectMgr.FindGraveYardData(g_id, area_id);
+        if (!data || (g_team != TEAM_BOTH_ALLOWED && data->team != g_team && data->team != TEAM_BOTH_ALLOWED))
+            data = sObjectMgr.FindGraveYardData(g_id, zone_id);
+
         if (!data)
         {
             PSendSysMessage(LANG_COMMAND_GRAVEYARDERROR, g_id);

--- a/src/game/Globals/ObjectMgr.h
+++ b/src/game/Globals/ObjectMgr.h
@@ -285,7 +285,9 @@ struct GraveYardData
     uint32 safeLocId;
     Team team;
 };
-typedef std::multimap < uint32 /*zoneId*/, GraveYardData > GraveYardMap;
+#define GRAVEYARD_AREALINK  0
+#define GRAVEYARD_MAPLINK   1
+typedef std::multimap < uint32 /*locId*/, GraveYardData > GraveYardMap;
 typedef std::pair<GraveYardMap::const_iterator, GraveYardMap::const_iterator> GraveYardMapBounds;
 
 struct QuestgiverGreeting
@@ -599,11 +601,12 @@ class ObjectMgr
         QuestgiverGreeting const* GetQuestgiverGreetingData(uint32 entry, uint32 type) const;
         TrainerGreeting const* GetTrainerGreetingData(uint32 entry) const;
 
-        WorldSafeLocsEntry const* GetClosestGraveYard(float x, float y, float z, uint32 MapId, Team team) const;
-        bool AddGraveYardLink(uint32 id, uint32 zoneId, Team team, bool inDB = true);
-        void SetGraveYardLinkTeam(uint32 id, uint32 zoneId, Team team);
+        WorldSafeLocsEntry const* GetClosestGraveYard(float x, float y, float z, uint32 mapId, Team team) const;
+        bool AddGraveYardLink(uint32 id, uint32 locId, uint32 linkKind, Team team, bool inDB = true);
+        void SetGraveYardLinkTeam(uint32 id, uint32 linkKey, Team team);
         void LoadGraveyardZones();
         GraveYardData const* FindGraveYardData(uint32 id, uint32 zoneId) const;
+        static uint32 GraveyardLinkKey(uint32 locId, uint32 linkKind);
 
         AreaTrigger const* GetAreaTrigger(uint32 trigger) const
         {

--- a/src/game/Globals/ObjectMgr.h
+++ b/src/game/Globals/ObjectMgr.h
@@ -599,7 +599,7 @@ class ObjectMgr
         QuestgiverGreeting const* GetQuestgiverGreetingData(uint32 entry, uint32 type) const;
         TrainerGreeting const* GetTrainerGreetingData(uint32 entry) const;
 
-        WorldSafeLocsEntry const* GetClosestGraveYard(float x, float y, float z, uint32 MapId, Team team);
+        WorldSafeLocsEntry const* GetClosestGraveYard(float x, float y, float z, uint32 MapId, Team team) const;
         bool AddGraveYardLink(uint32 id, uint32 zoneId, Team team, bool inDB = true);
         void SetGraveYardLinkTeam(uint32 id, uint32 zoneId, Team team);
         void LoadGraveyardZones();
@@ -1223,6 +1223,10 @@ class ObjectMgr
 
         void LoadGossipMenu(std::set<uint32>& gossipScriptSet);
         void LoadGossipMenuItems(std::set<uint32>& gossipScriptSet);
+        
+        WorldSafeLocsEntry const* GetClosestGraveyardHelper(
+                GraveYardMapBounds bounds, float x, float y, float z,
+                uint32 mapId, Team team) const;
 
         typedef std::map<uint32, PetLevelInfo*> PetLevelInfoMap;
         // PetLevelInfoMap[creature_id][level]


### PR DESCRIPTION
After dying in frostmane hold and spawning in coldridge valley I suspected something was wrong with how a graveyard is selected. I found [this comment](https://www.wowhead.com/quest=287/frostmane-hold#comments:id=215696) on wowhead: 

>The nearest graveyard is in Kharanos, so if you die it is an annoyingly long run back.

This indicates that there is indeed something wrong with how the graveyards are selected. Even some areas more north of frostmane hold make you spawn in coldridge valley instead of Kharanos. I suspected that subzone/area id is related.

It's unlikely that frostmane hold is linked to the kharanos graveyard. Instead it's more likely that the coldridge valley graveyard is linked to coldridge valley and coldridge pass but NOT to dun morogh. I think this because north of frostmane hold there are areas that have no subzone but currently still make you respawn in coldridge valley. This makes no sense if frostmane hold itself didn't even make you respawn there (as the comment suggests).

I've implemented a patch that allows you to link graveyards to a subzone (in addition to linking to zones as it currently allows). Here's the commit log:

    Changes how `game_graveyard_zone`.`ghost_zone` is interpreted. This
    column can now also be an area id.
    
    When looking for a nearby graveyard the server will first attempt to
    spawn at graveyards linked to your current area and only if that fails
    continue to the graveyards linked to your current zone.

And here is an SQL file to test the changes:

    -- Unlink the graveyard in coldridge valley from dun morogh
    DELETE FROM `game_graveyard_zone` WHERE `id`=100;
    
    -- Link the graveyard to the subzones. TODO: alliance?
    INSERT INTO `game_graveyard_zone` (`id`, `ghost_zone`, `alliance`) VALUES
        (100, 132, 0),  -- coldridge valley
        (100, 800, 0);  -- coldridge pass

It's possible that all closed off starting zones have their own exclusive graveyard that is not linked to the wider zone, but I haven't investigated that at all. I also don't know if the graveyard should be exclusive to alliance, but it was currently available to all factions so I haven't changed that in this SQL file.

This is the first patch I've written for mangos so I'm open to any input. If something is unclear I can clear that up or if something needs to be changed I can do that too.