### PR TITLE
Set autocast default to enabled for pets

### DIFF
--- a/src/game/Entities/Pet.cpp
+++ b/src/game/Entities/Pet.cpp
@@ -1902,7 +1902,7 @@ bool Pet::addSpell(uint32 spell_id, ActiveStates active /*= ACT_DECIDE*/, PetSpe
     if (active == ACT_DECIDE)                               // active was not used before, so we save it's autocast/passive state here
     {
         if (IsAutocastable(spellInfo))
-            newspell.active = ACT_DISABLED;
+            newspell.active = ACT_ENABLED;
         else
             newspell.active = ACT_PASSIVE;
     }

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -8964,8 +8964,8 @@ void CharmInfo::InitCharmCreateSpells()
                     onlyselfcast = false;
             }
 
-            if (onlyselfcast || !IsPositiveSpell(spellId))  // only self cast and spells versus enemies are autocastable
-                newstate = ACT_DISABLED;
+            if (IsAutocastable(spellInfo))
+                newstate = ACT_ENABLED;
             else
                 newstate = ACT_PASSIVE;
 


### PR DESCRIPTION
Autocast spells should be set to autocast by default when creatures are first summon/tamed
Touched up the same functionality for charmed units (they determined autocast spells in a really weird manner)

Proof; https://www.youtube.com/watch?v=ILsu79gPj00 (at 4:29)

Addresses the last issue remaining mentioned in https://github.com/cmangos/issues/issues/882
> the pet bar doesn't actually reflect what the default settings are properly. Waterbolt is set to autocast and Freeze is set to manual cast by default,