### PR TITLE
CMakelist alterations for git_id

### DIFF
--- a/contrib/git_id/CMakeLists.txt
+++ b/contrib/git_id/CMakeLists.txt
@@ -19,20 +19,12 @@ cmake_minimum_required(VERSION 2.8)
 include(../../cmake/common.cmake)
 include(CheckPlatform)
 
+
 add_executable(git_id git_id.cpp)
 
-if(WIN32 AND MSVC)
-  if(PLATFORM MATCHES X86) # 32-bit
-    set(FOLDER_ARCH x86)
-  else() # 64-bit
-    set(FOLDER_ARCH x64)
-  endif()
-
+if(MSVC)
   # Define OutDir to source/bin/(platform)_(configuaration) folder.
   set_target_properties(git_id PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG "${DEV_BIN_DIR}/git_id")
   set_target_properties(git_id PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE "${DEV_BIN_DIR}/git_id")
   set_target_properties(git_id PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "$(OutDir)")
-
-  # Define windows application type to not see a console
-  set_target_properties(git_id PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS")
 endif()


### PR DESCRIPTION
The folder architecture stuff isn't needed and neither is the properties link flag since it'll fail linking on windows anyway

I based the inclusion on how recastdemomod is included but I should have based it on how extractors are included, which it is now

Ref: https://github.com/cmangos/mangos-tbc/commit/30a29c5593b2bf4e4d3c1dea86fd4dac3dd7a44c#commitcomment-32214692

I did test it underway and everything was working fine but I must have added the 
```
  # Define windows application type to not see a console
  set_target_properties(git_id PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS")

```
after and forgot to delete cache and reload cmake.. It should be working as intended with this change.