### PR TITLE
Fix player-controlled pet spellcasting by manual casting

### DIFF
--- a/src/game/Entities/PetHandler.cpp
+++ b/src/game/Entities/PetHandler.cpp
@@ -306,12 +306,7 @@ void WorldSession::HandlePetAction(WorldPacket& recv_data)
                     if (unit_target->GetTypeId() == TYPEID_PLAYER)
                         petUnit->SendCreateUpdateToPlayer((Player*)unit_target);
                 }
-                else if (Unit* unit_target2 = spell->m_targets.getUnitTarget())
-                {
-                    petUnit->SetInFront(unit_target2);
-                    if (unit_target2->GetTypeId() == TYPEID_PLAYER)
-                        petUnit->SendCreateUpdateToPlayer((Player*)unit_target2);
-                }
+
                 if (Unit* powner = petUnit->GetMaster())
                     if (powner->GetTypeId() == TYPEID_PLAYER)
                         petUnit->SendCreateUpdateToPlayer((Player*)powner);
@@ -320,8 +315,11 @@ void WorldSession::HandlePetAction(WorldPacket& recv_data)
 
             if (result == SPELL_CAST_OK)
             {
+                SpellCastTargets targets;
+                targets.setUnitTarget(unit_target);
+
                 charmInfo->SetSpellOpener();
-                spell->SpellStart(&(spell->m_targets));
+                spell->SpellStart(&targets);
             }
             else
             {


### PR DESCRIPTION
Stored pet spells don't execute properly because the spell is never applied the targets properly, but autocast spells do, so move stored spells further down the code and handle it along with autocast spells

Active pet spells cast manually have the same issue
in pethandler we never set a target for the spell so looking for a target in the spell is silly, remove that, we need to also set the target of the spell before casting it or the pet will cast it on itself.

This solves 
https://github.com/cmangos/issues/issues/1036
and https://github.com/cmangos/issues/issues/870