### PR TITLE
CLUCK!

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/world/npcs_special.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/world/npcs_special.cpp
@@ -62,7 +62,7 @@ struct npc_chicken_cluckAI : public ScriptedAI
 
     void Reset() override
     {
-        m_uiResetFlagTimer = 120000;
+        m_uiResetFlagTimer = 20000;
 
         m_creature->setFaction(FACTION_CHICKEN);
         m_creature->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
@@ -70,35 +70,17 @@ struct npc_chicken_cluckAI : public ScriptedAI
 
     void ReceiveEmote(Player* pPlayer, uint32 uiEmote) override
     {
-        if (uiEmote == TEXTEMOTE_CHICKEN)
+        if (uiEmote == TEXTEMOTE_CHICKEN && !urand(0, 49))
         {
-            if (!urand(0, 29))
-            {
-                if (pPlayer->GetQuestStatus(QUEST_CLUCK) == QUEST_STATUS_NONE)
-                {
-                    m_creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
-                    m_creature->setFaction(FACTION_FRIENDLY);
-
-                    DoScriptText(EMOTE_A_HELLO, m_creature);
-
-                    /* are there any difference in texts, after 3.x ?
-                    if (pPlayer->GetTeam() == HORDE)
-                        DoScriptText(EMOTE_H_HELLO, m_creature);
-                    else
-                        DoScriptText(EMOTE_A_HELLO, m_creature);
-                    */
-                }
-            }
+            m_creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
+            m_creature->setFaction(FACTION_FRIENDLY);
+            DoScriptText(EMOTE_A_HELLO, m_creature);
         }
-
-        if (uiEmote == TEXTEMOTE_CHEER)
+        else if (uiEmote == TEXTEMOTE_CHEER && pPlayer->GetQuestStatus(QUEST_CLUCK) == QUEST_STATUS_COMPLETE)
         {
-            if (pPlayer->GetQuestStatus(QUEST_CLUCK) == QUEST_STATUS_COMPLETE)
-            {
-                m_creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
-                m_creature->setFaction(FACTION_FRIENDLY);
-                DoScriptText(EMOTE_CLUCK_TEXT2, m_creature);
-            }
+            m_creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
+            m_creature->setFaction(FACTION_FRIENDLY);
+            DoScriptText(EMOTE_CLUCK_TEXT2, m_creature);
         }
     }
 
@@ -121,28 +103,6 @@ struct npc_chicken_cluckAI : public ScriptedAI
 UnitAI* GetAI_npc_chicken_cluck(Creature* pCreature)
 {
     return new npc_chicken_cluckAI(pCreature);
-}
-
-bool QuestAccept_npc_chicken_cluck(Player* /*pPlayer*/, Creature* pCreature, const Quest* pQuest)
-{
-    if (pQuest->GetQuestId() == QUEST_CLUCK)
-    {
-        if (npc_chicken_cluckAI* pChickenAI = dynamic_cast<npc_chicken_cluckAI*>(pCreature->AI()))
-            pChickenAI->Reset();
-    }
-
-    return true;
-}
-
-bool QuestRewarded_npc_chicken_cluck(Player* /*pPlayer*/, Creature* pCreature, const Quest* pQuest)
-{
-    if (pQuest->GetQuestId() == QUEST_CLUCK)
-    {
-        if (npc_chicken_cluckAI* pChickenAI = dynamic_cast<npc_chicken_cluckAI*>(pCreature->AI()))
-            pChickenAI->Reset();
-    }
-
-    return true;
 }
 
 /*######
@@ -1050,8 +1010,6 @@ void AddSC_npcs_special()
     pNewScript = new Script;
     pNewScript->Name = "npc_chicken_cluck";
     pNewScript->GetAI = &GetAI_npc_chicken_cluck;
-    pNewScript->pQuestAcceptNPC =   &QuestAccept_npc_chicken_cluck;
-    pNewScript->pQuestRewardedNPC = &QuestRewarded_npc_chicken_cluck;
     pNewScript->RegisterSelf();
 
     pNewScript = new Script;

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -11789,7 +11789,7 @@ void Player::SendPreparedQuest(ObjectGuid guid) const
                 else if (status == DIALOG_STATUS_INCOMPLETE)
                     PlayerTalkClass->SendQuestGiverRequestItems(pQuest, guid, false, true);
                 // Send completable on repeatable quest if player don't have quest
-                else if (pQuest->IsRepeatable())
+                else if (pQuest->IsRepeatable() && pQuest->IsAutoComplete())
                     PlayerTalkClass->SendQuestGiverRequestItems(pQuest, guid, CanCompleteRepeatableQuest(pQuest), true);
                 else
                     PlayerTalkClass->SendQuestGiverQuestDetails(pQuest, guid, true);

--- a/src/game/Quests/QuestHandler.cpp
+++ b/src/game/Quests/QuestHandler.cpp
@@ -547,7 +547,8 @@ uint32 WorldSession::getDialogStatus(const Player* pPlayer, const Object* questg
         QuestStatus status = pPlayer->GetQuestStatus(quest_id);
 
         if (status == QUEST_STATUS_COMPLETE && !pPlayer->GetQuestRewardStatus(quest_id))
-            dialogStatusNew = pQuest->IsRepeatable() ? DIALOG_STATUS_REWARD_REP : DIALOG_STATUS_REWARD2;
+            dialogStatusNew = pQuest->IsRepeatable() && pQuest->GetQuestMethod() != 2 ?
+                              DIALOG_STATUS_REWARD_REP : DIALOG_STATUS_REWARD2;
         else if (pQuest->IsAutoComplete() && pPlayer->CanTakeQuest(pQuest, false))
             dialogStatusNew = pQuest->IsRepeatable() ? DIALOG_STATUS_REWARD_REP : DIALOG_STATUS_AVAILABLE;
         else if (status == QUEST_STATUS_INCOMPLETE)

--- a/src/game/Quests/QuestHandler.cpp
+++ b/src/game/Quests/QuestHandler.cpp
@@ -570,28 +570,22 @@ uint32 WorldSession::getDialogStatus(const Player* pPlayer, const Object* questg
 
         QuestStatus status = pPlayer->GetQuestStatus(quest_id);
 
-        if (status == QUEST_STATUS_NONE)                    // For all other cases the mark is handled either at some place else, or with involved-relations already
+        // For all other cases the mark is handled either at some place else, or with involved-relations already
+        if (status == QUEST_STATUS_NONE && pPlayer->CanSeeStartQuest(pQuest))
         {
-            if (pPlayer->CanSeeStartQuest(pQuest))
+            if (pPlayer->SatisfyQuestLevel(pQuest, false))
             {
-                if (pPlayer->SatisfyQuestLevel(pQuest, false))
-                {
-                    int32 lowLevelDiff = sWorld.getConfig(CONFIG_INT32_QUEST_LOW_LEVEL_HIDE_DIFF);
+                int32 lowLevelDiff = sWorld.getConfig(CONFIG_INT32_QUEST_LOW_LEVEL_HIDE_DIFF);
 
-                    if (pQuest->IsAutoComplete())
-                    {
-                        dialogStatusNew = DIALOG_STATUS_REWARD_REP;
-                    }
-                    else if (lowLevelDiff < 0 || pPlayer->getLevel() <= pPlayer->GetQuestLevelForPlayer(pQuest) + uint32(lowLevelDiff))
-                    {
-                        dialogStatusNew = DIALOG_STATUS_AVAILABLE;
-                    }
-                    else
-                        dialogStatusNew = DIALOG_STATUS_CHAT;
-                }
+                if (pQuest->IsAutoComplete())
+                    dialogStatusNew = DIALOG_STATUS_REWARD_REP;
+                else if (lowLevelDiff < 0 || pPlayer->getLevel() <= (pPlayer->GetQuestLevelForPlayer(pQuest) + uint32(lowLevelDiff)))
+                    dialogStatusNew = DIALOG_STATUS_AVAILABLE;
                 else
-                    dialogStatusNew = DIALOG_STATUS_UNAVAILABLE;
+                    dialogStatusNew = DIALOG_STATUS_CHAT;
             }
+            else
+                dialogStatusNew = DIALOG_STATUS_UNAVAILABLE;
         }
 
         if (dialogStatusNew > dialogStatus)


### PR DESCRIPTION
Thanks to @MantisLord who was invaluable in this and who in the end solved the puzzling issue. It was all down to a missing IsAutoComplete() check. You guys were right @cala , @Tobschinski , it was a sneaky little core issue.

Furthermore correct a tiny bit in the quest markers (for classic only) to make it correctly display the completion marker as yellow and not blue. (it already correctly displays them on tbc and wotlk since questmarker logic is slightly more complex there with stuff not available to classic sadly)

Also contain some corrections to the chicken SD2 script. Lower chance, much lower timer, generally more blizzlike behaviour.

The [Fix chicken SD2 script for quest Cluck](/cmangos/mangos-classic/pull/373/commits/894dfe7d24be90ddc9bf57c726c82d53f2783f76) commit is the only one also applicable to tbc and wotlk (respecting the fact that on wotlk it should be available to horde as well), the rest of the commits are classic-only.

Solves:
https://github.com/cmangos/classic-db/issues/213
https://github.com/classicdb/database/issues/228

Improvements remaining:
- The spell that spawns the egg seems to be coming from the player and not the chicken making it seem like the player laid the egg..
- The chicken when it is 'activated' needs to stay in place and not move until it resets
- The 'hello emote' that the chicken does should not only be for alliance, it should also be readable to horde, even though they shouldn't be able to interact with it, because...
- In classic and tbc the chicken would become friendly only to alliance as per this comment (and many others from horde players saying they can't interact with it after they got the emote);
https://www.wowhead.com/quest=3861/cluck#comments:id=556749
>After maybe 40-50 repetitions, I got the message "Chicken looks up at you quizzically. Maybe you should inspect it?" (I'm actually copying this verbatim from my screen.)
>
>I got excited and turned towards the chicken to discover that it did NOT have the question mark over its head, nor did my cursor change to the gear when I hovered over it. The cursor remained a sword.
>
>Instead, the guard over at the town boundary RAN OVER AND KILLED THE CHICKEN!
>
>That has to have been the single funniest thing I've seen while playing this game. Apparently, activating the quest script got the chicken flagged as an Alliance chicken. Ha ha ha!