### PR TITLE
Fix base\mangos.sql

### DIFF
--- a/sql/base/mangos.sql
+++ b/sql/base/mangos.sql
@@ -8107,7 +8107,6 @@ INSERT INTO `playercreateinfo_skills` VALUES
 (0,     8,  38, 0,  'Rogue: Combat'),
 (0,     8, 253, 0,  'Rogue: Assassination'),
 (0,     8,  39, 0,  'Rogue: Subtlety'),
-(0,     8, 176, 0,  'Weapon: Thrown'),
 (0,     8, 173, 0,  'Weapon: Daggers (Rogue)'),
 (0,     8, 176, 0,  'Weapon: Thrown (Rogue)'),
 -- PRIEST CLASS:


### PR DESCRIPTION
ERROR 1062 (23000) at line 8074: Duplicate entry '0-8-176' for key 'PRIMARY'

Doesn't require any sql update as it's only the base file which is affected, it is however preventing us from running the sql file.
It is only classic which has this error in the base file.