### PR TITLE
pin/totp impl by Chaosvex

### DIFF
--- a/sql/base/realmd.sql
+++ b/sql/base/realmd.sql
@@ -58,7 +58,8 @@ CREATE TABLE `account` (
   `expansion` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `mutetime` bigint(40) unsigned NOT NULL DEFAULT '0',
   `locale` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `token` text,
+  `security` int(11) DEFAULT '0',
+  `token` varchar(16) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_username` (`username`),
   KEY `idx_gmlevel` (`gmlevel`)

--- a/sql/updates/realmd/z2739_01_realmd_pin.sql
+++ b/sql/updates/realmd/z2739_01_realmd_pin.sql
@@ -1,0 +1,5 @@
+ALTER TABLE realmd_db_version CHANGE COLUMN required_z2716_01_realmd_totp required_z2739_01_realmd_pin bit;
+
+ALTER TABLE account DROP COLUMN token;
+ALTER TABLE account ADD COLUMN `token` varchar(16) DEFAULT NULL AFTER locale;
+ALTER TABLE account ADD COLUMN `security` int(11) DEFAULT '0' AFTER locale;

--- a/src/game/Accounts/AccountMgr.cpp
+++ b/src/game/Accounts/AccountMgr.cpp
@@ -169,6 +169,43 @@ AccountTypes AccountMgr::GetSecurity(uint32 acc_id)
     return SEC_PLAYER;
 }
 
+uint8 AccountMgr::GetSecuritySetting(uint32 accid) const
+{
+    QueryResult* result = LoginDatabase.PQuery("SELECT security FROM account WHERE id = '%u'", accid);
+    if (result)
+    {
+        uint8 sec = uint8((*result)[0].GetInt32());
+        delete result;
+        return sec;
+    }
+    else
+        return 0;
+}
+
+AccountOpResult AccountMgr::SecuritySetNone(uint32 accid) const
+{
+    if (!LoginDatabase.PExecute("UPDATE account SET security='0', token=NULL WHERE id = '%u'", accid))
+        return AOR_DB_INTERNAL_ERROR;                       // unexpected error
+
+    return AOR_OK;
+}
+
+AccountOpResult AccountMgr::SecuritySetPin(uint32 accid, uint32 pin) const
+{
+    if (!LoginDatabase.PExecute("UPDATE account SET security='1', token='%u' WHERE id = '%u'", pin, accid))
+        return AOR_DB_INTERNAL_ERROR;                       // unexpected error
+
+    return AOR_OK;
+}
+
+AccountOpResult AccountMgr::SecuritySetTOTP(uint32 accid, std::string& token) const
+{
+    if (!LoginDatabase.PExecute("UPDATE account SET security='4', token='%s' WHERE id = '%u'", token.c_str(), accid))
+        return AOR_DB_INTERNAL_ERROR;                       // unexpected error
+
+    return AOR_OK;
+}
+
 bool AccountMgr::GetName(uint32 acc_id, std::string& name) const
 {
     QueryResult* result = LoginDatabase.PQuery("SELECT username FROM account WHERE id = '%u'", acc_id);

--- a/src/game/Accounts/AccountMgr.h
+++ b/src/game/Accounts/AccountMgr.h
@@ -51,6 +51,11 @@ class AccountMgr
         uint32 GetCharactersCount(uint32 acc_id) const;
         std::string CalculateShaPassHash(std::string& name, std::string& password) const;
 
+        uint8 GetSecuritySetting(uint32 accid) const;
+        AccountOpResult SecuritySetNone(uint32 accid) const;
+        AccountOpResult SecuritySetPin(uint32 accid, uint32 pin) const;
+        AccountOpResult SecuritySetTOTP(uint32 accid, std::string& token) const;
+
         static bool normalizeString(std::string& utf8str);
 };
 

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -63,6 +63,21 @@ bool ChatHandler::load_command_table = true;
 
 ChatCommand* ChatHandler::getCommandTable()
 {
+    static ChatCommand accountSecuritySetCommandTable[] =
+    {
+        { "none",           SEC_PLAYER,         true,  &ChatHandler::HandleAccountSecuritySetNoneCommand,   "", nullptr },
+        { "pin",            SEC_PLAYER,         true,  &ChatHandler::HandleAccountSecuritySetPinCommand,    "", nullptr },
+        { "totp",           SEC_CONSOLE,        true,  &ChatHandler::HandleAccountSecuritySetTOTPCommand,   "", nullptr },
+        { nullptr,          0,                  false, nullptr,                                             "", nullptr }
+    };
+
+    static ChatCommand accountSecurityCommandTable[] =
+    {
+        { "get",            SEC_PLAYER,         true,  &ChatHandler::HandleAccountSecurityGetCommand,  "", nullptr },
+        { "set",            SEC_PLAYER,         true,  nullptr,                                        "", accountSecuritySetCommandTable },
+        { nullptr,          0,                  false, nullptr,                                        "", nullptr }
+    };
+
     static ChatCommand accountSetCommandTable[] =
     {
         { "addon",          SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleAccountSetAddonCommand,     "", nullptr },
@@ -80,6 +95,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "lock",           SEC_PLAYER,         true,  &ChatHandler::HandleAccountLockCommand,         "", nullptr },
         { "set",            SEC_ADMINISTRATOR,  true,  nullptr,                                        "", accountSetCommandTable },
         { "password",       SEC_PLAYER,         true,  &ChatHandler::HandleAccountPasswordCommand,     "", nullptr },
+        { "security",       SEC_PLAYER,         true,  nullptr,                                        "", accountSecurityCommandTable },
         { "",               SEC_PLAYER,         true,  &ChatHandler::HandleAccountCommand,             "", nullptr },
         { nullptr,          0,                  false, nullptr,                                        "", nullptr }
     };

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -164,6 +164,10 @@ class ChatHandler
         bool HandleAccountSetAddonCommand(char* args);
         bool HandleAccountSetGmLevelCommand(char* args);
         bool HandleAccountSetPasswordCommand(char* args);
+        bool HandleAccountSecurityGetCommand(char* args);
+        bool HandleAccountSecuritySetNoneCommand(char* args);
+        bool HandleAccountSecuritySetPinCommand(char* args);
+        bool HandleAccountSecuritySetTOTPCommand(char* args);
 
         bool HandleAHBotItemsAmountCommand(char* args);
         template <int Q>

--- a/src/realmd/AuthSocket.h
+++ b/src/realmd/AuthSocket.h
@@ -34,7 +34,7 @@
 
 #include <functional>
 
-#define HMAC_RES_SIZE 20
+struct AUTH_LOGON_PIN_DATA_C;  // forward decl
 
 class AuthSocket : public MaNGOS::Socket
 {
@@ -45,7 +45,8 @@ class AuthSocket : public MaNGOS::Socket
 
         void SendProof(Sha1Hash sha);
         void LoadRealmlist(ByteBuffer& pkt, uint32 acctid);
-        int32 generateToken(char const* b32key);
+        bool VerifyPinData(uint32 pin, const AUTH_LOGON_PIN_DATA_C& clientData);
+        uint32 generateTotpPin(const std::string& secret, int interval);
 
         bool VerifyVersion(uint8 const* a, int32 aLength, uint8 const* versionProof, bool isReconnect);
         bool _HandleLogonChallenge();
@@ -79,10 +80,16 @@ class AuthSocket : public MaNGOS::Socket
 
         eStatus _status;
 
+        bool promptPin;
+
         std::string _login;
         std::string _safelogin;
         std::string _token;
         std::string m_os;
+
+        BigNumber serverSecuritySalt;
+        uint8 securityFlags;
+        uint32 gridSeed;
 
         // Since GetLocaleByName() is _NOT_ bijective, we have to store the locale as a string. Otherwise we can't differ
         // between enUS and enGB, which is important for the patch system

--- a/src/shared/Auth/AuthCrypt.cpp
+++ b/src/shared/Auth/AuthCrypt.cpp
@@ -17,7 +17,7 @@
  */
 
 #include "AuthCrypt.h"
-#include "HMACSHA1.h"
+#include "Hmac.h"
 #include "Log.h"
 #include "BigNumber.h"
 

--- a/src/shared/Auth/Hmac.cpp
+++ b/src/shared/Auth/Hmac.cpp
@@ -16,35 +16,33 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include "Auth/HMACSHA1.h"
+#include "Auth/Hmac.h"
 #include "BigNumber.h"
 
-HMACSHA1::HMACSHA1(uint32 len, uint8* seed)
-{
-    memcpy(&m_key, seed, len);
-#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
-    m_ctx = HMAC_CTX_new();
-    HMAC_Init_ex(m_ctx, &m_key, len, EVP_sha1(), nullptr);
-#else
-    HMAC_CTX_init(&m_ctx);
-    HMAC_Init_ex(&m_ctx, &m_key, len, EVP_sha1(), nullptr);
-#endif
-}
-
-HMACSHA1::HMACSHA1(uint32 len, uint8* seed, bool) // to get over the default constructor
+HmacHash::HmacHash(const uint8* data, int length)
 {
 #if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
     m_ctx = HMAC_CTX_new();
-    HMAC_Init_ex(m_ctx, seed, len, EVP_sha1(), nullptr);
+    HMAC_Init_ex(m_ctx, data, length, EVP_sha1(), nullptr);
 #else
     HMAC_CTX_init(&m_ctx);
-    HMAC_Init_ex(&m_ctx, seed, len, EVP_sha1(), nullptr);
+    HMAC_Init_ex(&m_ctx, data, length, EVP_sha1(), nullptr);
 #endif
 }
 
-HMACSHA1::~HMACSHA1()
+HmacHash::HmacHash(const uint8* data, int length, bool) // to get over the default constructor
 {
-    memset(&m_key, 0x00, SEED_KEY_SIZE);
+#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
+    m_ctx = HMAC_CTX_new();
+    HMAC_Init_ex(m_ctx, data, length, EVP_sha1(), nullptr);
+#else
+    HMAC_CTX_init(&m_ctx);
+    HMAC_Init_ex(&m_ctx, data, length, EVP_sha1(), nullptr);
+#endif
+}
+
+HmacHash::~HmacHash()
+{
 #if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
     HMAC_CTX_free(m_ctx);
 #else
@@ -52,12 +50,12 @@ HMACSHA1::~HMACSHA1()
 #endif
 }
 
-void HMACSHA1::UpdateBigNumber(BigNumber* bn)
+void HmacHash::UpdateBigNumber(BigNumber* bn)
 {
     UpdateData(bn->AsByteArray(), bn->GetNumBytes());
 }
 
-void HMACSHA1::UpdateData(const uint8* data, int length)
+void HmacHash::UpdateData(const uint8* data, int length)
 {
 #if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
     HMAC_Update(m_ctx, data, length);
@@ -66,16 +64,7 @@ void HMACSHA1::UpdateData(const uint8* data, int length)
 #endif
 }
 
-void HMACSHA1::Initialize()
-{
-#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
-    HMAC_Init_ex(m_ctx, &m_key, SEED_KEY_SIZE, EVP_sha1(), NULL);
-#else
-    HMAC_Init_ex(&m_ctx, &m_key, SEED_KEY_SIZE, EVP_sha1(), NULL);
-#endif
-}
-
-void HMACSHA1::Finalize()
+void HmacHash::Finalize()
 {
     uint32 length = 0;
 #if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L

--- a/src/shared/Auth/Hmac.h
+++ b/src/shared/Auth/Hmac.h
@@ -25,14 +25,12 @@
 
 class BigNumber;
 
-#define SEED_KEY_SIZE 16
-
-class HMACSHA1
+class HmacHash
 {
     public:
-        HMACSHA1(uint32 len, uint8* seed);
-        HMACSHA1(uint32 len, uint8* seed, bool);
-        ~HMACSHA1();
+        HmacHash(const uint8* data, int length);
+        HmacHash(const uint8* data, int length, bool);
+        ~HmacHash();
         void UpdateBigNumber(BigNumber* bn);
         void UpdateData(const uint8* data, int length);
         void Initialize();
@@ -45,7 +43,6 @@ class HMACSHA1
 #else
         HMAC_CTX m_ctx;
 #endif
-        uint8 m_key[SEED_KEY_SIZE];
         uint8 m_digest[SHA_DIGEST_LENGTH];
 };
 #endif

--- a/src/shared/Auth/base32.cpp
+++ b/src/shared/Auth/base32.cpp
@@ -19,18 +19,14 @@
 
 #include "base32.h"
 
-int base32_decode(char const* encoded, char* result, int bufSize)
+int base32_decode(const uint8_t *encoded, uint8_t *result, int bufSize)
 {
-    // Base32 implementation
-    // Copyright 2010 Google Inc.
-    // Author: Markus Gutschke
-    // Licensed under the Apache License, Version 2.0
     int buffer = 0;
     int bitsLeft = 0;
     int count = 0;
-    for (const char* ptr = encoded; count < bufSize && *ptr; ++ptr)
+    for (const uint8_t *ptr = encoded; count < bufSize && *ptr; ++ptr)
     {
-        char ch = *ptr;
+        uint8_t ch = *ptr;
         if (ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n' || ch == '-')
             continue;
         buffer <<= 5;
@@ -60,6 +56,44 @@ int base32_decode(char const* encoded, char* result, int bufSize)
         }
     }
 
+    if (count < bufSize)
+        result[count] = '\000';
+    return count;
+}
+
+int base32_encode(const uint8_t *data, int length, uint8_t *result, int bufSize)
+{
+    if (length < 0 || length > (1 << 28))
+        return -1;
+ 
+    int count = 0;
+    if (length > 0)
+    {
+        int buffer = data[0];
+        int next = 1;
+        int bitsLeft = 8;
+        while (count < bufSize && (bitsLeft > 0 || next < length))
+        {
+            if (bitsLeft < 5)
+            {
+                if (next < length)
+                {
+                    buffer <<= 8;
+                    buffer |= data[next++] & 0xFF;
+                    bitsLeft += 8;
+                }
+                else
+                {
+                    int pad = 5 - bitsLeft;
+                    buffer <<= pad;
+                    bitsLeft += pad;
+                }
+            }
+            int index = 0x1F & (buffer >> (bitsLeft - 5));
+            bitsLeft -= 5;
+            result[count++] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"[index];
+        }
+    }
     if (count < bufSize)
         result[count] = '\000';
     return count;

--- a/src/shared/Auth/base32.h
+++ b/src/shared/Auth/base32.h
@@ -30,6 +30,7 @@
 
 #include <stdint.h>
 
-int base32_decode(char const* encoded, char* result, int bufSize);
+int base32_decode(const uint8_t *encoded, uint8_t *result, int bufSize);
+int base32_encode(const uint8_t *data, int length, uint8_t *result, int bufSize);
 
 #endif /* _BASE32_H_ */

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -23,8 +23,8 @@ set(SRC_GRP_AUTH
     Auth/AuthCrypt.h
     Auth/BigNumber.cpp
     Auth/BigNumber.h
-    Auth/HMACSHA1.cpp
-    Auth/HMACSHA1.h
+    Auth/Hmac.cpp
+    Auth/Hmac.h
     Auth/md5.h
     Auth/Sha1.cpp
     Auth/Sha1.h

--- a/src/shared/revision_sql.h
+++ b/src/shared/revision_sql.h
@@ -1,6 +1,6 @@
 #ifndef __REVISION_SQL_H__
 #define __REVISION_SQL_H__
- #define REVISION_DB_REALMD "required_z2716_01_realmd_totp"
+ #define REVISION_DB_REALMD "required_z2739_01_realmd_pin"
  #define REVISION_DB_CHARACTERS "required_z2737_00_characters_cooldown"
  #define REVISION_DB_MANGOS "required_z2735_01_mangos_weapon_skills_fix_vanilla"
 #endif // __REVISION_SQL_H__


### PR DESCRIPTION
- Rebased, refitted and squashed
- Added commands

Difference to the original PR: 
- Adds field uint8 'Security' and uses that for determining security type and not 'Locked'.
- Redefine type of and use already present token field and not security for storing the token pin.
- Uses, but initializes slightly differently, already present 'pinData' struct (sAuthLogonPinData_C)

Ref: https://github.com/cmangos/mangos-classic/pull/193