### PR TITLE
Enable max levels for quests

### DIFF
--- a/sql/base/mangos.sql
+++ b/sql/base/mangos.sql
@@ -9856,6 +9856,7 @@ CREATE TABLE `quest_template` (
   `Method` tinyint(3) unsigned NOT NULL DEFAULT '2',
   `ZoneOrSort` smallint(6) NOT NULL DEFAULT '0',
   `MinLevel` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `MaxLevel` tinyint(3) unsigned NOT NULL DEFAULT '255',
   `QuestLevel` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `Type` smallint(5) unsigned NOT NULL DEFAULT '0',
   `RequiredClasses` smallint(5) unsigned NOT NULL DEFAULT '0',

--- a/sql/updates/mangos/z27xx_01_.SQL
+++ b/sql/updates/mangos/z27xx_01_.SQL
@@ -1,0 +1,2 @@
+
+ALTER TABLE account ADD COLUMN MaxLevel tinyint(3) unsigned NOT NULL DEFAULT '255' AFTER MinLevel;

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -12501,7 +12501,8 @@ bool Player::SatisfyQuestCondition(Quest const* qInfo, bool msg) const
 
 bool Player::SatisfyQuestLevel(Quest const* qInfo, bool msg) const
 {
-    if (getLevel() < qInfo->GetMinLevel())
+    uint32 level = getLevel();
+    if (level < qInfo->GetMinLevel() || level > qInfo->GetMaxLevel())
     {
         if (msg)
             SendCanTakeQuestResponse(INVALIDREASON_DONT_HAVE_REQ);

--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -3241,39 +3241,39 @@ void ObjectMgr::LoadQuests()
 
     m_ExclusiveQuestGroups.clear();
 
-    //                                                0      1       2           3         4           5     6                7              8              9
-    QueryResult* result = WorldDatabase.Query("SELECT entry, Method, ZoneOrSort, MinLevel, QuestLevel, Type, RequiredClasses, RequiredRaces, RequiredSkill, RequiredSkillValue,"
-                          //   10                   11                 12                     13                   14                     15                   16                17
+    //                                                0      1       2           3         4         5           6     7                8              9              10
+    QueryResult* result = WorldDatabase.Query("SELECT entry, Method, ZoneOrSort, MinLevel, MaxLevel, QuestLevel, Type, RequiredClasses, RequiredRaces, RequiredSkill, RequiredSkillValue,"
+                          //   11                   12                 13                     14                   15                     16                   17                18
                           "RepObjectiveFaction, RepObjectiveValue, RequiredMinRepFaction, RequiredMinRepValue, RequiredMaxRepFaction, RequiredMaxRepValue, SuggestedPlayers, LimitTime,"
-                          //   18          19            20           21           22              23                24         25            26
+                          //   19          20            21           22           23              24                25         26            27
                           "QuestFlags, SpecialFlags, PrevQuestId, NextQuestId, ExclusiveGroup, NextQuestInChain, SrcItemId, SrcItemCount, SrcSpell,"
-                          //   27     28       29          30               31                32       33              34              35              36
+                          //   28     29       30          31               32                33       34              35              36              37
                           "Title, Details, Objectives, OfferRewardText, RequestItemsText, EndText, ObjectiveText1, ObjectiveText2, ObjectiveText3, ObjectiveText4,"
-                          //   37          38          39          40          41             42             43             44
+                          //   38          39          40          41          42             43             44             45
                           "ReqItemId1, ReqItemId2, ReqItemId3, ReqItemId4, ReqItemCount1, ReqItemCount2, ReqItemCount3, ReqItemCount4,"
-                          //   45            46            47            48            49               50               51               52
+                          //   46            47            48            49            50               51               52               53
                           "ReqSourceId1, ReqSourceId2, ReqSourceId3, ReqSourceId4, ReqSourceCount1, ReqSourceCount2, ReqSourceCount3, ReqSourceCount4,"
-                          //   53                  54                  55                  56                  57                     58                     59                     60
+                          //   54                  55                  56                  57                  58                     59                     60                     60
                           "ReqCreatureOrGOId1, ReqCreatureOrGOId2, ReqCreatureOrGOId3, ReqCreatureOrGOId4, ReqCreatureOrGOCount1, ReqCreatureOrGOCount2, ReqCreatureOrGOCount3, ReqCreatureOrGOCount4,"
-                          //   61             62             63             64
+                          //   62             63             64             65
                           "ReqSpellCast1, ReqSpellCast2, ReqSpellCast3, ReqSpellCast4,"
-                          //   65                66                67                68                69                70
+                          //   66                67                68                69                70                71
                           "RewChoiceItemId1, RewChoiceItemId2, RewChoiceItemId3, RewChoiceItemId4, RewChoiceItemId5, RewChoiceItemId6,"
-                          //   71                   72                   73                   74                   75                   76
+                          //   72                   73                   74                   75                   76                   77
                           "RewChoiceItemCount1, RewChoiceItemCount2, RewChoiceItemCount3, RewChoiceItemCount4, RewChoiceItemCount5, RewChoiceItemCount6,"
-                          //   77          78          79          80          81             82             83             84
+                          //   78          79          80          81          82             83             84             85
                           "RewItemId1, RewItemId2, RewItemId3, RewItemId4, RewItemCount1, RewItemCount2, RewItemCount3, RewItemCount4,"
-                          //   85              86              87              88              89              90            91            92            93            94
+                          //   86              87              88              89              90              91            92            93            94            95
                           "RewRepFaction1, RewRepFaction2, RewRepFaction3, RewRepFaction4, RewRepFaction5, RewRepValue1, RewRepValue2, RewRepValue3, RewRepValue4, RewRepValue5,"
-                          //   95             96                97        98            99                 100               101         102     103     104
+                          //   96             97                98        99            100                101               102       103     104     105
                           "RewOrReqMoney, RewMoneyMaxLevel, RewSpell, RewSpellCast, RewMailTemplateId, RewMailDelaySecs, PointMapId, PointX, PointY, PointOpt,"
-                          //   105            106            107            108            109                 110                 111                 112
+                          //   106            107            108            109            110                 111                 112                 113
                           "DetailsEmote1, DetailsEmote2, DetailsEmote3, DetailsEmote4, DetailsEmoteDelay1, DetailsEmoteDelay2, DetailsEmoteDelay3, DetailsEmoteDelay4,"
-                          //   113              114            115                116                117                118
+                          //   114              115            116                117                118                119
                           "IncompleteEmote, CompleteEmote, OfferRewardEmote1, OfferRewardEmote2, OfferRewardEmote3, OfferRewardEmote4,"
-                          //   119                     120                     121                     122
+                          //   120                     121                     122                     123
                           "OfferRewardEmoteDelay1, OfferRewardEmoteDelay2, OfferRewardEmoteDelay3, OfferRewardEmoteDelay4,"
-                          //   123          124          125
+                          //   124          125          126
                           "StartScript, CompleteScript, RequiredCondition"
                           " FROM quest_template");
     if (!result)

--- a/src/game/Quests/QuestDef.cpp
+++ b/src/game/Quests/QuestDef.cpp
@@ -26,113 +26,114 @@ Quest::Quest(Field* questRecord)
     QuestMethod = questRecord[1].GetUInt32();
     ZoneOrSort = questRecord[2].GetInt32();
     MinLevel = questRecord[3].GetUInt32();
-    QuestLevel = questRecord[4].GetUInt32();
-    Type = questRecord[5].GetUInt32();
-    RequiredClasses = questRecord[6].GetUInt32();
-    RequiredRaces = questRecord[7].GetUInt32();
-    RequiredSkill = questRecord[8].GetUInt32();
-    RequiredSkillValue = questRecord[9].GetUInt32();
-    RepObjectiveFaction = questRecord[10].GetUInt32();
-    RepObjectiveValue = questRecord[11].GetInt32();
-    RequiredMinRepFaction = questRecord[12].GetUInt32();
-    RequiredMinRepValue = questRecord[13].GetInt32();
-    RequiredMaxRepFaction = questRecord[14].GetUInt32();
-    RequiredMaxRepValue = questRecord[15].GetInt32();
-    SuggestedPlayers = questRecord[16].GetUInt32();
-    LimitTime = questRecord[17].GetUInt32();
-    m_QuestFlags = questRecord[18].GetUInt16();
-    m_SpecialFlags = questRecord[19].GetUInt16();
-    PrevQuestId = questRecord[20].GetInt32();
-    NextQuestId = questRecord[21].GetInt32();
-    ExclusiveGroup = questRecord[22].GetInt32();
-    NextQuestInChain = questRecord[23].GetUInt32();
-    SrcItemId = questRecord[24].GetUInt32();
-    SrcItemCount = questRecord[25].GetUInt32();
-    SrcSpell = questRecord[26].GetUInt32();
-    Title = questRecord[27].GetCppString();
-    Details = questRecord[28].GetCppString();
-    Objectives = questRecord[29].GetCppString();
-    OfferRewardText = questRecord[30].GetCppString();
-    RequestItemsText = questRecord[31].GetCppString();
-    EndText = questRecord[32].GetCppString();
+    MaxLevel = questRecord[4].GetUInt32();
+    QuestLevel = questRecord[5].GetUInt32();
+    Type = questRecord[6].GetUInt32();
+    RequiredClasses = questRecord[7].GetUInt32();
+    RequiredRaces = questRecord[8].GetUInt32();
+    RequiredSkill = questRecord[9].GetUInt32();
+    RequiredSkillValue = questRecord[10].GetUInt32();
+    RepObjectiveFaction = questRecord[11].GetUInt32();
+    RepObjectiveValue = questRecord[12].GetInt32();
+    RequiredMinRepFaction = questRecord[13].GetUInt32();
+    RequiredMinRepValue = questRecord[14].GetInt32();
+    RequiredMaxRepFaction = questRecord[15].GetUInt32();
+    RequiredMaxRepValue = questRecord[16].GetInt32();
+    SuggestedPlayers = questRecord[17].GetUInt32();
+    LimitTime = questRecord[18].GetUInt32();
+    m_QuestFlags = questRecord[19].GetUInt16();
+    m_SpecialFlags = questRecord[20].GetUInt16();
+    PrevQuestId = questRecord[21].GetInt32();
+    NextQuestId = questRecord[22].GetInt32();
+    ExclusiveGroup = questRecord[23].GetInt32();
+    NextQuestInChain = questRecord[24].GetUInt32();
+    SrcItemId = questRecord[25].GetUInt32();
+    SrcItemCount = questRecord[26].GetUInt32();
+    SrcSpell = questRecord[27].GetUInt32();
+    Title = questRecord[28].GetCppString();
+    Details = questRecord[29].GetCppString();
+    Objectives = questRecord[30].GetCppString();
+    OfferRewardText = questRecord[31].GetCppString();
+    RequestItemsText = questRecord[32].GetCppString();
+    EndText = questRecord[33].GetCppString();
 
     for (int i = 0; i < QUEST_OBJECTIVES_COUNT; ++i)
-        ObjectiveText[i] = questRecord[33 + i].GetCppString();
+        ObjectiveText[i] = questRecord[34 + i].GetCppString();
 
     for (int i = 0; i < QUEST_ITEM_OBJECTIVES_COUNT; ++i)
-        ReqItemId[i] = questRecord[37 + i].GetUInt32();
+        ReqItemId[i] = questRecord[38 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_OBJECTIVES_COUNT; ++i)
-        ReqItemCount[i] = questRecord[41 + i].GetUInt32();
+        ReqItemCount[i] = questRecord[42 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_SOURCE_ITEM_IDS_COUNT; ++i)
-        ReqSourceId[i] = questRecord[45 + i].GetUInt32();
+        ReqSourceId[i] = questRecord[46 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_SOURCE_ITEM_IDS_COUNT; ++i)
-        ReqSourceCount[i] = questRecord[49 + i].GetUInt32();
+        ReqSourceCount[i] = questRecord[50 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_OBJECTIVES_COUNT; ++i)
-        ReqCreatureOrGOId[i] = questRecord[53 + i].GetInt32();
+        ReqCreatureOrGOId[i] = questRecord[54 + i].GetInt32();
 
     for (int i = 0; i < QUEST_OBJECTIVES_COUNT; ++i)
-        ReqCreatureOrGOCount[i] = questRecord[57 + i].GetUInt32();
+        ReqCreatureOrGOCount[i] = questRecord[58 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_OBJECTIVES_COUNT; ++i)
-        ReqSpell[i] = questRecord[61 + i].GetUInt32();
+        ReqSpell[i] = questRecord[62 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_REWARD_CHOICES_COUNT; ++i)
-        RewChoiceItemId[i] = questRecord[65 + i].GetUInt32();
+        RewChoiceItemId[i] = questRecord[66 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_REWARD_CHOICES_COUNT; ++i)
-        RewChoiceItemCount[i] = questRecord[71 + i].GetUInt32();
+        RewChoiceItemCount[i] = questRecord[72 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_REWARDS_COUNT; ++i)
-        RewItemId[i] = questRecord[77 + i].GetUInt32();
+        RewItemId[i] = questRecord[78 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_REWARDS_COUNT; ++i)
-        RewItemCount[i] = questRecord[81 + i].GetUInt32();
+        RewItemCount[i] = questRecord[82 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_REPUTATIONS_COUNT; ++i)
-        RewRepFaction[i] = questRecord[85 + i].GetUInt32();
+        RewRepFaction[i] = questRecord[86 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_REPUTATIONS_COUNT; ++i)
-        RewRepValue[i] = questRecord[90 + i].GetInt32();
+        RewRepValue[i] = questRecord[91 + i].GetInt32();
 
-    RewOrReqMoney = questRecord[95].GetInt32();
-    RewMoneyMaxLevel = questRecord[96].GetUInt32();
-    RewSpell = questRecord[97].GetUInt32();
-    RewSpellCast = questRecord[98].GetUInt32();
-    RewMailTemplateId = questRecord[99].GetUInt32();
-    RewMailDelaySecs = questRecord[100].GetUInt32();
-    PointMapId = questRecord[101].GetUInt32();
-    PointX = questRecord[102].GetFloat();
-    PointY = questRecord[103].GetFloat();
-    PointOpt = questRecord[104].GetUInt32();
+    RewOrReqMoney = questRecord[96].GetInt32();
+    RewMoneyMaxLevel = questRecord[97].GetUInt32();
+    RewSpell = questRecord[98].GetUInt32();
+    RewSpellCast = questRecord[99].GetUInt32();
+    RewMailTemplateId = questRecord[100].GetUInt32();
+    RewMailDelaySecs = questRecord[101].GetUInt32();
+    PointMapId = questRecord[102].GetUInt32();
+    PointX = questRecord[103].GetFloat();
+    PointY = questRecord[104].GetFloat();
+    PointOpt = questRecord[105].GetUInt32();
 
     m_detailsemotecount = 0;
     for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
     {
-        DetailsEmote[i] = questRecord[105 + i].GetUInt32();
+        DetailsEmote[i] = questRecord[106 + i].GetUInt32();
         if (DetailsEmote[i] != 0)
             m_detailsemotecount = i + 1;
     }
 
     for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
-        DetailsEmoteDelay[i] = questRecord[109 + i].GetUInt32();
+        DetailsEmoteDelay[i] = questRecord[110 + i].GetUInt32();
 
-    IncompleteEmote = questRecord[113].GetUInt32();
-    CompleteEmote = questRecord[114].GetUInt32();
-
-    for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
-        OfferRewardEmote[i] = questRecord[115 + i].GetInt32();
+    IncompleteEmote = questRecord[114].GetUInt32();
+    CompleteEmote = questRecord[115].GetUInt32();
 
     for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
-        OfferRewardEmoteDelay[i] = questRecord[119 + i].GetInt32();
+        OfferRewardEmote[i] = questRecord[116 + i].GetInt32();
 
-    QuestStartScript = questRecord[123].GetUInt32();
-    QuestCompleteScript = questRecord[124].GetUInt32();
+    for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
+        OfferRewardEmoteDelay[i] = questRecord[120 + i].GetInt32();
 
-    RequiredCondition = questRecord[125].GetUInt32();
+    QuestStartScript = questRecord[124].GetUInt32();
+    QuestCompleteScript = questRecord[125].GetUInt32();
+
+    RequiredCondition = questRecord[126].GetUInt32();
 
     m_isActive = true;
 

--- a/src/game/Quests/QuestDef.h
+++ b/src/game/Quests/QuestDef.h
@@ -191,6 +191,7 @@ class Quest
         uint32 GetQuestMethod() const { return QuestMethod; }
         int32  GetZoneOrSort() const { return ZoneOrSort; }
         uint32 GetMinLevel() const { return MinLevel; }
+        uint32 GetMaxLevel() const { return MaxLevel; }
         uint32 GetQuestLevel() const { return QuestLevel; }
         uint32 GetType() const { return Type; }
         uint32 GetRequiredClasses() const { return RequiredClasses; }
@@ -291,6 +292,7 @@ class Quest
         uint32 QuestMethod;
         int32  ZoneOrSort;
         uint32 MinLevel;
+        uint32 MaxLevel;
         uint32 QuestLevel;
         uint32 Type;
         uint32 RequiredClasses;


### PR DESCRIPTION
Some quests have level iterations (bg quests), we need to hide all but 1.

~Fixes~ Scratch that, it enbles fixing of https://github.com/classicdb/database/issues/221

It was either adding a new field or going in the direction of this monstrosity; https://github.com/Phatcat/mangos-classic/commit/1ed7fabcd7543cbd6d7d6a5aef08f09be3f087e2 (which is horrible, I know)