### PR TITLE
Correct CLUCK emotes

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -797,10 +797,10 @@ INSERT INTO script_texts (entry,content_default,sound,type,language,emote,commen
 (-1000202,'HOORAY! I AM SAVED!',0,0,0,0,'injured_patient SAY_DOC2'),
 (-1000203,'Sweet, sweet embrace... take me...',0,0,0,0,'injured_patient SAY_DOC3'),
 
-(-1000204,'%s looks up at you quizzically. Maybe you should inspect it?',0,2,0,0,'cluck EMOTE_A_HELLO'),
-(-1000205,'%s looks at you unexpectadly.',0,2,0,0,'cluck EMOTE_H_HELLO'),
-(-1000206,'%s starts pecking at the feed.',0,2,0,0,'cluck EMOTE_CLUCK_TEXT2'),
+(-1000204,'%s looks up at you quizzically. Maybe you should inspect it?',0,2,0,0,'cluck EMOTE_CLUCK_TEXT1'),
+(-1000205,'%s looks at you unexpectadly.',0,2,0,0,'cluck EMOTE_CLUCK_TEXT2'),
 
+(-1000206,'REUSE ME',0,0,0,0,'REUSE ME'),
 (-1000207,'REUSE ME',0,0,0,0,'REUSE ME'),
 
 (-1000208,'Frenzyheart kill you if you come back. You no welcome here no more!',0,0,0,0,'vekjik SAY_TEXTID_VEKJIK1'),

--- a/src/game/AI/ScriptDevAI/scripts/world/npcs_special.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/world/npcs_special.cpp
@@ -45,9 +45,8 @@ EndContentData */
 
 enum
 {
-    EMOTE_A_HELLO           = -1000204,
-    EMOTE_H_HELLO           = -1000205,
-    EMOTE_CLUCK_TEXT2       = -1000206,
+    EMOTE_CLUCK_TEXT1       = -1000204,
+    EMOTE_CLUCK_TEXT2       = -1000205,
 
     QUEST_CLUCK             = 3861,
     FACTION_FRIENDLY        = 35,
@@ -74,7 +73,7 @@ struct npc_chicken_cluckAI : public ScriptedAI
         {
             m_creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
             m_creature->setFaction(FACTION_FRIENDLY);
-            DoScriptText(EMOTE_A_HELLO, m_creature);
+            DoScriptText(EMOTE_CLUCK_TEXT1, m_creature);
         }
         else if (uiEmote == TEXTEMOTE_CHEER && pPlayer->GetQuestStatus(QUEST_CLUCK) == QUEST_STATUS_COMPLETE)
         {


### PR DESCRIPTION
https://www.youtube.com/watch?v=Pn2qPJWBCdw (2:25)
We see a horde here get the same emote as an alliance, and also we see that the emote being done on /cheer is the unused one in the scriptdev sql while the one that is currently used on /cheer there seems to be no evidence of anywhere.
https://www.youtube.com/watch?v=az8BNDNqzc4 (3:20)