### PR TITLE
add a null ptr check when cast a SummonWild spell

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -2940,6 +2940,9 @@ void Spell::EffectSummonWild(SpellEffectIndex eff_idx)
 
     CreatureInfo const* cInfo = ObjectMgr::GetCreatureTemplate(creature_entry);
 
+    if (!cInfo)
+        return;
+
     if (m_caster->getLevel() >= cInfo->MaxLevel)
         level = cInfo->MaxLevel;
 


### PR DESCRIPTION
for example if you execute :  
.cast 7975
you are making the server crash if you don't have this fix.