### PR TITLE
Chat command .learn all_gm teaches internal spells

### DIFF
--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -2021,20 +2021,14 @@ bool ChatHandler::HandleLearnAllGMCommand(char* /*args*/)
 {
     static uint32 gmSpellList[] =
     {
-        24347,                                            // Become A Fish, No Breath Bar
-        35132,                                            // Visual Boom
-        38488,                                            // Attack 4000-8000 AOE
-        38795,                                            // Attack 2000 AOE + Slow Down 90%
-        15712,                                            // Attack 200
-        1852,                                             // GM Spell Silence
-        31899,                                            // Kill
-        31924,                                            // Kill
-        29878,                                            // Kill My Self
-        26644,                                            // More Kill
-
-        28550,                                            // Invisible 24
-        23452,                                            // Invisible + Target
-        0
+		5,      // Death Touch
+		11,     // Frostbolt of Ages 
+		265,    // Area Death (Test)
+		1908,   // Uber Heal Over Time
+		18209,  // Test Grow
+		18210,  // Test Shrink
+		25565,  // Clear All
+		26368,  // ClearAllo
     };
 
     for (uint32 spell : gmSpellList)


### PR DESCRIPTION
When entering .learn all_gm (with a security level 3 account) in the chat, the character should only learn spell from category "Internal" (-> good for testing etc).

Note: The spellbook category "Internal" does not exist in classic.
I picked the spells which are "Internal" due to TBC (and also available in classic).