### PR TITLE
[PlayerBot] Fix bots going into idle state after looting

### DIFF
--- a/src/game/PlayerBot/Base/PlayerbotAI.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotAI.cpp
@@ -2878,6 +2878,8 @@ void PlayerbotAI::DoLoot()
     {
         // DEBUG_LOG ("[PlayerbotAI]: DoLoot - %s is going back to idle", m_bot->GetName());
         SetState(BOTSTATE_NORMAL);
+        if (m_movementOrder == MOVEMENT_FOLLOW)
+            MovementReset();
         m_bot->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_LOOTING);
         m_inventory_full = false;
         return;


### PR DESCRIPTION
9c19a96a seems to have introduced a regression that caused bots to stop
following the master after looting.

This commit adds a check after bots are finished looting to see if they are 
ordered to follow, and resets their motion if so.