### PR TITLE
[Playerbot] Fix crash bug when training skills

### DIFF
--- a/src/game/PlayerBot/Base/PlayerbotAI.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotAI.cpp
@@ -7856,12 +7856,14 @@ void PlayerbotAI::_HandleCommandSkill(std::string& text, Player& fromPlayer)
             for (std::list<uint32>::iterator it = m_spellsToLearn.begin(); it != m_spellsToLearn.end(); it++)
             {
                 uint32 spellId = *it;
+                TrainerSpell const* trainer_spell;
 
                 if (!spellId)
                     break;
 
-                TrainerSpell const* trainer_spell = cSpells->Find(spellId);
-                if (!trainer_spell)
+                if (cSpells)
+                    trainer_spell = cSpells->Find(spellId);
+                if (tSpells && !trainer_spell)
                     trainer_spell = tSpells->Find(spellId);
 
                 if (!trainer_spell)


### PR DESCRIPTION
Fix a segfault when we attempt to learn a spell from a trainer that doesn't teach that spell.

To reproduce:
- Create two bots of different classes 
- Target one of the class trainers (the ones below are the troll mage & priest trainers in Durotar) and instruct the bots to learn a class-specific spell that that trainer teaches, e.g. 
-- `/tar mai'ah`
-- `/p skill learn [Arcane Intellect]`
- Target the other class trainer and instruct the bots to learn the same spell, e.g. 
-- `/tar ken'jai`
-- `/p skill learn [Arcane Intellect]`