### PR TITLE
Update VS labels to be consistent to the modules name

### DIFF
--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -109,7 +109,7 @@ if(PCH)
     #set_property(SOURCE ${PrecompiledSource} PROPERTY COMPILE_FLAGS "/Yc\"${PrecompiledHeader}\" /Fp\"${PrecompiledBinary}\"")
     set_target_properties(${LIBRARY_NAME} PROPERTIES COMPILE_FLAGS " /Yu\"${PrecompiledHeader}\" /FI\"${PrecompiledHeader}\" /Fp\"${PrecompiledBinary}\" /bigobj")
     set_source_files_properties(${PrecompiledSource} PROPERTIES COMPILE_FLAGS "/Yc\"${PrecompiledHeader}\" /Fp\"${PrecompiledBinary}\"")
-    set_target_properties(${LIBRARY_NAME} PROPERTIES PROJECT_LABEL "Game")
+    set_target_properties(${LIBRARY_NAME} PROPERTIES PROJECT_LABEL "game")
   elseif(NOT MINGW)
     # TODO: Resolve issues with order of includes before enabling Cotire for MinGW builds
     cotire(${LIBRARY_NAME})

--- a/src/mangosd/CMakeLists.txt
+++ b/src/mangosd/CMakeLists.txt
@@ -76,7 +76,7 @@ if(WIN32)
   set_target_properties(${EXECUTABLE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG "${DEV_BIN_DIR}")
   set_target_properties(${EXECUTABLE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE "${DEV_BIN_DIR}")
   set_target_properties(${EXECUTABLE_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "$(OutDir)")
-  set_target_properties(${EXECUTABLE_NAME} PROPERTIES PROJECT_LABEL "WorldServer")
+  set_target_properties(${EXECUTABLE_NAME} PROPERTIES PROJECT_LABEL "mangosd")
 
   # Add provided dependency lib to dev folder
   string(REGEX REPLACE "/" "\\\\" LibFolder ${DEV_PROVIDED_LIBS_FOLDER})

--- a/src/realmd/CMakeLists.txt
+++ b/src/realmd/CMakeLists.txt
@@ -65,7 +65,7 @@ if(WIN32)
   set_target_properties(${EXECUTABLE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG "${DEV_BIN_DIR}")
   set_target_properties(${EXECUTABLE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE "${DEV_BIN_DIR}")
   set_target_properties(${EXECUTABLE_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "$(OutDir)")
-  set_target_properties(${EXECUTABLE_NAME} PROPERTIES PROJECT_LABEL "AuthServer")
+  set_target_properties(${EXECUTABLE_NAME} PROPERTIES PROJECT_LABEL "realmd")
 
   # Add provided dependency lib to dev folder
   string(REGEX REPLACE "/" "\\\\" LibFolder ${DEV_PROVIDED_LIBS_FOLDER})

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -208,5 +208,5 @@ set_source_files_properties(${CMAKE_SOURCE_DIR}/src/shared/revision.h
   PROPERTIES GENERATED TRUE
              HEADER_FILE_ONLY TRUE)
 if(MSVC)
-  set_target_properties(${LIBRARY_NAME} PROPERTIES PROJECT_LABEL "Shared")
+  set_target_properties(${LIBRARY_NAME} PROPERTIES PROJECT_LABEL "shared")
 endif()


### PR DESCRIPTION
Not sure if this is something the dev team will accept, but figured I'd get your thoughts on this considering it is a minor change.

**Before:**
![devenv_2019-05-25_04-14-00](https://user-images.githubusercontent.com/1935706/58341980-a08ee880-7ea3-11e9-9eb3-3aa32c7e045c.png)
**After:**
![devenv_2019-05-25_04-05-30](https://user-images.githubusercontent.com/1935706/58341821-3bd38e00-7ea3-11e9-9eca-11fe2a332276.png) 

Let me know if there is a naming standard and I can update it? But this seems better.