### PR TITLE
Pass along player owner to SavePetToDB

### DIFF
--- a/src/game/Entities/Pet.h
+++ b/src/game/Entities/Pet.h
@@ -170,7 +170,7 @@ class Pet : public Creature
         bool Create(uint32 guidlow, CreatureCreatePos& cPos, CreatureInfo const* cinfo, uint32 pet_number);
         bool CreateBaseAtCreature(Creature* creature);
         bool LoadPetFromDB(Player* owner, uint32 petentry = 0, uint32 petnumber = 0, bool current = false, uint32 healthPercentage = 0, bool permanentOnly = false);
-        void SavePetToDB(PetSaveMode mode);
+        void SavePetToDB(PetSaveMode mode, Player* owner);
         bool isLoading() const { return m_loading; }
         void SetLoading(bool state) { m_loading = state; }
         void Unsummon(PetSaveMode mode, Unit* owner = nullptr);

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -15311,7 +15311,7 @@ void Player::SaveToDB()
 
     // save pet (hunter pet level and experience and all type pets health/mana).
     if (Pet* pet = GetPet())
-        pet->SavePetToDB(PET_SAVE_AS_CURRENT);
+        pet->SavePetToDB(PET_SAVE_AS_CURRENT, this);
 }
 
 // fast save function for item/money cheating preventing - save only inventory and money state


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

Should hopefully fix the locking error occuring when using the command .saveall
This is actually Cyberiums suggested fix, just my realization of his suggestion.

LoadPetFromDB looks to see if the owner is a player towards the end of the function, which in of itself seems ridiculous considering owner in this context is a player type object, not a unit type, and if the owner wasn't an actual player it would have returned false at the beginning where it checks the character database. (there's also some typecasting player into player which is just weird)

Everywhere the pet is saved to the db the owner is checked to be a player first, so the checks inside the function itself are redundant if we can pass along the owner in the function call.

Player.cpp only has 1 instance of SavePetToDB (this is the 1 instance which causes the issue). Easy enough to pass on itself in this case.

Spelleffects has a few instances, but all of them are related to a player caster so we just pass along what we got.

Specifically in EffectSummonPet which I helped rewriting/updating back in 2016, there is quite a bit of redundant typecasting, it's done every single time something needs to be done in relation to the player owner of the pet, so I've replaced all of that with a single static cast and used that everywhere in that function instead.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/1355
- relates to already closed https://github.com/cmangos/issues/issues/787 which contains a detailed description of why the issue is occurring.
- relates to https://github.com/cmangos/mangos-tbc/pull/264 which is another attempt at the same issue, but a whole different solution.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
 make a char, get a permanent pet (warlock or hunter pet) then use the command .saveall - if the server keeps running hurray.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
