### PR TITLE
fix ordering of mangos sql update scripts

### DIFF
--- a/sql/updates/mangos/z2739_01_mangos_creature_spawn_entry.sql
+++ b/sql/updates/mangos/z2739_01_mangos_creature_spawn_entry.sql
@@ -1,4 +1,4 @@
-ALTER TABLE db_version CHANGE COLUMN required_z2738_01_mangos_quest_template required_z2738_01_mangos_creature_spawn_entry bit;
+ALTER TABLE db_version CHANGE COLUMN required_z2738_01_mangos_quest_template required_z2739_01_mangos_creature_spawn_entry bit;
 
 DROP TABLE IF EXISTS `creature_spawn_entry`;
 CREATE TABLE `creature_spawn_entry` (

--- a/src/shared/revision_sql.h
+++ b/src/shared/revision_sql.h
@@ -2,5 +2,5 @@
 #define __REVISION_SQL_H__
  #define REVISION_DB_REALMD "required_z2716_01_realmd_totp"
  #define REVISION_DB_CHARACTERS "required_z2737_00_characters_cooldown"
- #define REVISION_DB_MANGOS "required_z2738_01_mangos_creature_spawn_entry"
+ #define REVISION_DB_MANGOS "required_z2739_01_mangos_creature_spawn_entry"
 #endif // __REVISION_SQL_H__


### PR DESCRIPTION
z2738_01_mangos_creature_spawn_entry is referencing
z2738_01_mangos_quest_template which will be executed
beforehand because the InstallFullDb script executes the updates in alphabetical order of filenames.

## 🍰 Pullrequest
InstallFullDb.sh fails due to an sql error related to the `db_version` table

### Proof
```sql
> Trying to apply additional core updates from path ../cmangos-vanilla ...
    Appending core update z2728_01_mangos_cones.sql to database cmangos_vanilla_prod_world
    Appending core update z2729_01_mangos_creature_template_faction_removal.sql to database cmangos_vanilla_prod_world
    Appending core update z2730_01_mangos_seal_of_righteousness_restored.sql to database cmangos_vanilla_prod_world
    Appending core update z2731_01_mangos_seal_of_righteousness_proc_restored.sql to database cmangos_vanilla_prod_world
    Appending core update z2732_01_mangos_seal_of_righteousness_cleanup.sql to database cmangos_vanilla_prod_world
    Appending core update z2733_01_mangos_playercreate_skills_vanilla.sql to database cmangos_vanilla_prod_world
    Appending core update z2735_01_mangos_weapon_skills_fix_vanilla.sql to database cmangos_vanilla_prod_world
    Appending core update z2738_01_mangos_creature_spawn_entry.sql to database cmangos_vanilla_prod_world
ERROR 1054 (42S22) at line 1: Unknown column 'required_z2738_01_mangos_quest_template' in 'db_version'
ERROR: cannot apply ../cmangos-vanilla/sql/updates/mangos/z2738_01_mangos_creature_spawn_entry.sql
```

### Issues
- None

### How2Test
prepare fresh mariadb and run the classic-db install script with core_path set

### Todo / Checklist
- None