### PR TITLE
fix column count in creature_template insert stmt

### DIFF
--- a/sql/base/mangos.sql
+++ b/sql/base/mangos.sql
@@ -1276,7 +1276,7 @@ CREATE TABLE `creature_template` (
 LOCK TABLES `creature_template` WRITE;
 /*!40000 ALTER TABLE `creature_template` DISABLE KEYS */;
 INSERT INTO `creature_template` VALUES
-(1,'Waypoint (Only GM can see it)','Visual',63,63,10045,0,0,0,35,0,8,8,7,1,0,0,4096,0,130,5242886,0.91,1.14286,20,0,0,0,0,0,3,1,1,1,1,1,1,9999,9999,0,0,7,7,1.76,2.42,0,3,100,2000,2200,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,'','');
+(1,'Waypoint (Only GM can see it)','Visual',63,63,10045,0,0,0,35,0,8,8,7,1,0,0,4096,0,130,5242886,0.91,1.14286,20,0,0,0,0,0,3,1,1,1,1,1,1,9999,9999,0,0,7,7,1.76,2.42,0,3,100,2000,2200,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,'','');
 /*!40000 ALTER TABLE `creature_template` ENABLE KEYS */;
 UNLOCK TABLES;
 


### PR DESCRIPTION
the commit 498765a breaks the numbers of columns without
adjusting the insert statements in sql/base/mangos.sql

Don't know which `VisibilityDistanceType` is fine therefore
using default value of column.

### Proof
```
mysql -h 127.0.0.1 -u root -p classicmangos < ./sql/base/mangos.sql
Enter password:
ERROR 1136 (21S01) at line 1278: Column count doesn't match value count at row 1
```