### PR TITLE
fix number of arguments for sLog.outErrorDb()

### DIFF
--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -555,7 +555,7 @@ void ObjectMgr::LoadCreatureTemplates()
 
         if (cInfo->visibilityDistanceType >= VisibilityDistanceType::Max)
         {
-            sLog.outErrorDb("sql.sql", "Creature (Entry: %u) has invalid visibilityDistanceType (%u) defined in `creature_template`.", cInfo->Entry, AsUnderlyingType(cInfo->visibilityDistanceType));
+            sLog.outErrorDb("Creature (Entry: %u) has invalid visibilityDistanceType (%u) defined in `creature_template`.", cInfo->Entry, AsUnderlyingType(cInfo->visibilityDistanceType));
             const_cast<CreatureInfo*>(cInfo)->visibilityDistanceType = VisibilityDistanceType::Normal;
         }
 


### PR DESCRIPTION
## 🍰 Pullrequest
the commit https://github.com/cmangos/mangos-classic/commit/498765a7ea48241b66d1d62aa171014d6ef3db6a introduces a new logline containig two text lines followed by the arguments interpolated into the log string.

GCC as well as CLANG dropping a warning about that.

### Proof
```
[ 80%] Building CXX object src/game/CMakeFiles/game.dir/Globals/ObjectAccessor.cpp.o
[ 80%] Building CXX object src/game/CMakeFiles/game.dir/Globals/ObjectMgr.cpp.o
/home/travis/build/cmangos/mangos-classic/src/game/Globals/ObjectMgr.cpp: In member function ‘void ObjectMgr::LoadCreatureTemplates()’:
/home/travis/build/cmangos/mangos-classic/src/game/Globals/ObjectMgr.cpp:558:227: warning: too many arguments for format [-Wformat-extra-args]
             sLog.outErrorDb("sql.sql", "Creature (Entry: %u) has invalid visibilityDistanceType (%u) defined in `creature_template`.", cInfo->Entry, AsUnderlyingType(cInfo->visibilityDistanceType));
                                                                                                                                                                                                                                   ^
[ 80%] Building CXX object src/game/CMakeFiles/game.dir/Grids/GridNotifiers.cpp.o
```

### Issues
- None

### How2Test
compile the core in a fresh build directory
