### PR TITLE
Fix VisibilityDistanceType sequence of CreatureInfo. 

### DIFF
--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -151,9 +151,9 @@ struct CreatureInfo
     uint32  TrainerTemplateId;
     uint32  VendorTemplateId;
     uint32  GossipMenuId;
+    VisibilityDistanceType visibilityDistanceType;
     uint32  EquipmentTemplateId;
     uint32  civilian;
-    VisibilityDistanceType visibilityDistanceType;
     char const* AIName;
     uint32  ScriptID;
 


### PR DESCRIPTION
Exchange member sequence of VisibilityDistanceType and EquipmentTemplateId in struct CreatureInfo.

## 🍰 Pullrequest
Switched the sequence of two members in CreatureInfo, VisibilityDistanceType and EquipmentTemplateId, to avoid data filling errors. 

### Proof
Login and find a mob with weapon on its hand. 

### Issues
In the CreatureInfo defines, member VisibilityDistanceType is behind of EquipmentTemplateId. 
While in DB table creature_template, VisibilityDistanceType is in front of EquipmentTemplateId. 
This will lead to a misplaced columns data filling on the Init of sStorageCreature. 
The directly appears issue is that creatures with EquipmenId!=0 have no equepment on their hands. 

### How2Test
- None

### Todo / Checklist
- [X] None
