### PR TITLE
Fix rare fail of npc_dashel_stonefistAI phase change.

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/stormwind_city.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/stormwind_city.cpp
@@ -137,7 +137,7 @@ struct npc_dashel_stonefistAI : public ScriptedAI
     {
         if (m_uiStartEventTimer)
         {
-            if (m_uiStartEventTimer < uiDiff)
+            if (m_uiStartEventTimer <= uiDiff)
             {
                 if (Player* pPlayer = m_creature->GetMap()->GetPlayer(m_playerGuid))
                 {
@@ -158,7 +158,7 @@ struct npc_dashel_stonefistAI : public ScriptedAI
 
         if (m_uiEndEventTimer)
         {
-            if (m_uiEndEventTimer < uiDiff)
+            if (m_uiEndEventTimer <= uiDiff)
             {
                 DoScriptText(SAY_STONEFIST_3, m_creature);
 


### PR DESCRIPTION

## 🍰 Pullrequest
m_uiStartEventTimer & m_uiEndEventTimer related conditions in UpdateAI have a boundary logic problem. 
if m_uiStartEventTimer == uiDiff exactly at one server tick, then the m_uiStartEventTimer will result in a certain 0 value at the very next server tick. 
This will cause a rare false on the if (m_uiStartEventTimer) check at the beginning of UpdateAI() and lead to the related quest cannot start. 
So as the m_uiEndEventTimer will lead to a cannot end.

### Proof
Maybe just accept quest 1447 and abort it while completed for several times. LOL

### Issues
This issue just happened on some rare time. But it did happened and some players filed me about this. So I checked.

### How2Test
- None

### Todo / Checklist
- [X] None
