### PR TITLE
Don't set double health/power for guardians

### DIFF
--- a/src/game/Entities/Pet.cpp
+++ b/src/game/Entities/Pet.cpp
@@ -1377,21 +1377,21 @@ void Pet::InitStatsForLevel(uint32 petlevel)
         SetCreateMana(mana);
         // Set base Armor
         SetModifierValue(UNIT_MOD_ARMOR, BASE_VALUE, armor);
+
+        // Need to update stats - calculates max health/mana etc
+        UpdateAllStats();
+
+        // Need to set Health to full
+        SetHealth(GetMaxHealth());
+
+        // Need to set Mana to full
+        if (GetPowerType() == POWER_MANA)
+            SetPower(POWER_MANA, GetMaxPower(POWER_MANA));
+
+        // Remove rage bar from pets (By setting rage = 0, and ensuring it stays that way by setting max rage = 0 as well)
+        SetMaxPower(POWER_RAGE, 0);
+        SetPower(POWER_RAGE, 0);
     }
-
-    // Need to update stats - calculates max health/mana etc
-    UpdateAllStats();
-
-    // Need to set Health to full
-    SetHealth(GetMaxHealth());
-
-    // Need to set Mana to full
-    if (GetPowerType() == POWER_MANA)
-        SetPower(POWER_MANA, GetMaxPower(POWER_MANA));
-
-    // Remove rage bar from pets (By setting rage = 0, and ensuring it stays that way by setting max rage = 0 as well)
-    SetMaxPower(POWER_RAGE, 0);
-    SetPower(POWER_RAGE, 0);
 }
 
 void Pet::PlayDismissSound()


### PR DESCRIPTION
## 🍰 Pullrequest
With commit 694b7391b85a4d7df42291960fb19efdcfa991ab health/power ended
up being set twice the intended value.
Max health/power was already set by the CLS function SelectLevel(), and
UpdateAllStats() caused these values to be doubled.

### Proof
- None

### Issues
- Fixes https://github.com/cmangos/issues/issues/2064

### How2Test
- Find any NPC with guardian (Except Imp Minion guardians, they do not use CLS, https://github.com/cmangos/classic-db/pull/239 fixes this), check health before and after this change, health should be halved and set to a sensible amount.

### Checklist
- UpdateAllStats() is not invoked for guardians, but I believe this is entirely covered by CLS.
- ~POWER_RAGE is not forced to 0 for guardians (unless CLS handles this as well)~. It seems like CLS do handle this, see https://github.com/cmangos/mangos-classic/blob/master/src/game/Entities/Creature.cpp#L1313-L1339
