### PR TITLE
Include pet owner in pet's list of allies when in group

### DIFF
--- a/src/game/AI/BaseAI/PetAI.cpp
+++ b/src/game/AI/BaseAI/PetAI.cpp
@@ -400,8 +400,7 @@ void PetAI::UpdateAllies()
             m_AllySet.insert(target->GetObjectGuid());
         }
     }
-    else                                                    // remove group
-        m_AllySet.insert(owner->GetObjectGuid());
+    m_AllySet.insert(owner->GetObjectGuid());
 }
 
 void PetAI::AttackedBy(Unit* attacker)


### PR DESCRIPTION
## 🍰 Pullrequest
When in a group the pet owner was not added to the pet's list of allies.
This resulted in i.e. Warlock Imp not automatically casting Fire Shield
on Warlock, while still casting the buff on every other player in the
group.

### Proof
- None

### Issues
- None

### How2Test
- Create party including a Warlock with Imp pet. Make sure Imp has Fire Shield set to automatic casting. Before this change Imp would not cast Fire Shield on Warlock, but on every other party member. With this change the Imp will cast the spell on the Warlock as well.

### Todo / Checklist
- [X] None