### PR TITLE
Load world safe locs orientation values.

### DIFF
--- a/sql/base/mangos.sql
+++ b/sql/base/mangos.sql
@@ -23,7 +23,7 @@ DROP TABLE IF EXISTS `db_version`;
 CREATE TABLE `db_version` (
   `version` varchar(120) DEFAULT NULL,
   `creature_ai_version` varchar(120) DEFAULT NULL,
-  `required_z2745_01_mangos_game_event_split` bit(1) DEFAULT NULL
+  `required_z2746_01_mangos_world_safe_locs_facing` bit(1) DEFAULT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Used DB version notes';
 
 --

--- a/sql/updates/mangos/z2746_01_mangos_world_safe_locs_facing.sql
+++ b/sql/updates/mangos/z2746_01_mangos_world_safe_locs_facing.sql
@@ -1,0 +1,11 @@
+ALTER TABLE db_version CHANGE COLUMN required_z2745_01_mangos_game_event_split required_z2746_01_mangos_world_safe_locs_facing bit;
+
+CREATE TABLE IF NOT EXISTS `world_safe_locs_facing` (
+  `id` int(10) unsigned NOT NULL,
+  `orientation` float NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+ALTER TABLE `battleground_template`
+	DROP COLUMN `AllianceStartO`,
+	DROP COLUMN `HordeStartO`;

--- a/sql/updates/mangos/z2746_01_mangos_world_safe_locs_facing.sql
+++ b/sql/updates/mangos/z2746_01_mangos_world_safe_locs_facing.sql
@@ -1,10 +1,15 @@
 ALTER TABLE db_version CHANGE COLUMN required_z2745_01_mangos_game_event_split required_z2746_01_mangos_world_safe_locs_facing bit;
 
-CREATE TABLE IF NOT EXISTS `world_safe_locs_facing` (
-  `id` int(10) unsigned NOT NULL,
-  `orientation` float NOT NULL DEFAULT '0',
+CREATE TABLE IF NOT EXISTS `world_safe_locs` (
+  `id` int(11) unsigned NOT NULL,
+  `map` int(10) unsigned NOT NULL DEFAULT '0',
+  `x` float NOT NULL DEFAULT '0',
+  `y` float NOT NULL DEFAULT '0',
+  `z` float NOT NULL DEFAULT '0',
+  `o` float NOT NULL DEFAULT '0',
+  `name` varchar(50) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 ALTER TABLE `battleground_template`
 	DROP COLUMN `AllianceStartO`,

--- a/src/game/BattleGround/BattleGroundAB.cpp
+++ b/src/game/BattleGround/BattleGroundAB.cpp
@@ -24,7 +24,7 @@
 #include "BattleGroundMgr.h"
 #include "Tools/Language.h"
 #include "WorldPacket.h"
-#include "Server/DBCStores.h"                                   // TODO REMOVE this when graveyard handling for pvp is updated
+#include "Globals/ObjectMgr.h"
 
 BattleGroundAB::BattleGroundAB(): m_IsInformedNearVictory(false), m_honorTicks(0), m_ReputationTics(0)
 {

--- a/src/game/BattleGround/BattleGroundAB.cpp
+++ b/src/game/BattleGround/BattleGroundAB.cpp
@@ -463,7 +463,7 @@ WorldSafeLocsEntry const* BattleGroundAB::GetClosestGraveYard(Player* player)
         float mindist = 999999.0f;
         for (unsigned char node : nodes)
         {
-            WorldSafeLocsEntry const* entry = sWorldSafeLocsStore.LookupEntry(BG_AB_GraveyardIds[node]);
+            WorldSafeLocsEntry const* entry = sWorldSafeLocsStore.LookupEntry<WorldSafeLocsEntry>(BG_AB_GraveyardIds[node]);
             if (!entry)
                 continue;
             float dist = (entry->x - plr_x) * (entry->x - plr_x) + (entry->y - plr_y) * (entry->y - plr_y);
@@ -477,7 +477,7 @@ WorldSafeLocsEntry const* BattleGroundAB::GetClosestGraveYard(Player* player)
     }
     // If not, place ghost on starting location
     if (!good_entry)
-        good_entry = sWorldSafeLocsStore.LookupEntry(BG_AB_GraveyardIds[teamIndex + 5]);
+        good_entry = sWorldSafeLocsStore.LookupEntry<WorldSafeLocsEntry>(BG_AB_GraveyardIds[teamIndex + 5]);
 
     return good_entry;
 }

--- a/src/game/BattleGround/BattleGroundAV.cpp
+++ b/src/game/BattleGround/BattleGroundAV.cpp
@@ -659,7 +659,7 @@ WorldSafeLocsEntry const* BattleGroundAV::GetClosestGraveYard(Player* plr)
         {
             if (m_Nodes[i].Owner != teamIdx || m_Nodes[i].State != POINT_CONTROLLED)
                 continue;
-            WorldSafeLocsEntry const* entry = sWorldSafeLocsStore.LookupEntry(BG_AV_GraveyardIds[i]);
+            WorldSafeLocsEntry const* entry = sWorldSafeLocsStore.LookupEntry<WorldSafeLocsEntry>(BG_AV_GraveyardIds[i]);
             if (!entry)
                 continue;
             float dist = (entry->x - x) * (entry->x - x) + (entry->y - y) * (entry->y - y);
@@ -672,7 +672,7 @@ WorldSafeLocsEntry const* BattleGroundAV::GetClosestGraveYard(Player* plr)
     }
     // If not, place ghost in the starting-cave
     if (!good_entry)
-        good_entry = sWorldSafeLocsStore.LookupEntry(BG_AV_GraveyardIds[teamIdx + 7]);
+        good_entry = sWorldSafeLocsStore.LookupEntry<WorldSafeLocsEntry>(BG_AV_GraveyardIds[teamIdx + 7]);
 
     return good_entry;
 }

--- a/src/game/BattleGround/BattleGroundAV.cpp
+++ b/src/game/BattleGround/BattleGroundAV.cpp
@@ -24,7 +24,7 @@
 #include "Entities/GameObject.h"
 #include "Tools/Language.h"
 #include "WorldPacket.h"
-#include "Server/DBCStores.h"                                   // TODO REMOVE this when graveyard handling for pvp is updated
+#include "Globals/ObjectMgr.h"
 
 BattleGroundAV::BattleGroundAV(): m_HonorMapComplete(0), m_RepTowerDestruction(0), m_RepCaptain(0), m_RepBoss(0), m_RepOwnedGrave(0), m_RepOwnedMine(0), m_RepSurviveCaptain(0), m_RepSurviveTower(0)
 {

--- a/src/game/BattleGround/BattleGroundMgr.cpp
+++ b/src/game/BattleGround/BattleGroundMgr.cpp
@@ -1162,13 +1162,13 @@ void BattleGroundMgr::CreateInitialBattleGrounds()
 
         uint32 start1 = fields[5].GetUInt32();
 
-        WorldSafeLocsEntry const* start = sWorldSafeLocsStore.LookupEntry(start1);
+        WorldSafeLocsEntry const* start = sWorldSafeLocsStore.LookupEntry<WorldSafeLocsEntry>(start1);
         if (start)
         {
             AStartLoc[0] = start->x;
             AStartLoc[1] = start->y;
             AStartLoc[2] = start->z;
-            AStartLoc[3] = sObjectMgr.GetWorldSafeLocFacing(start->ID);
+            AStartLoc[3] = start->o;
         }
         else
         {
@@ -1178,13 +1178,13 @@ void BattleGroundMgr::CreateInitialBattleGrounds()
 
         uint32 start2 = fields[6].GetUInt32();
 
-        start = sWorldSafeLocsStore.LookupEntry(start2);
+        start = sWorldSafeLocsStore.LookupEntry<WorldSafeLocsEntry>(start2);
         if (start)
         {
             HStartLoc[0] = start->x;
             HStartLoc[1] = start->y;
             HStartLoc[2] = start->z;
-            HStartLoc[3] = sObjectMgr.GetWorldSafeLocFacing(start->ID);
+            HStartLoc[3] = start->o;
         }
         else
         {

--- a/src/game/BattleGround/BattleGroundMgr.cpp
+++ b/src/game/BattleGround/BattleGroundMgr.cpp
@@ -1129,8 +1129,8 @@ uint32 BattleGroundMgr::CreateBattleGround(BattleGroundTypeId bgTypeId, uint32 M
 void BattleGroundMgr::CreateInitialBattleGrounds()
 {
     uint32 count = 0;
-    //                                                0   1                 2                 3      4      5                6              7             8           9
-    QueryResult* result = WorldDatabase.Query("SELECT id, MinPlayersPerTeam,MaxPlayersPerTeam,MinLvl,MaxLvl,AllianceStartLoc,AllianceStartO,HordeStartLoc,HordeStartO,StartMaxDist FROM battleground_template");
+    //                                                0   1                 2                 3      4      5                6             7 
+    QueryResult* result = WorldDatabase.Query("SELECT id, MinPlayersPerTeam,MaxPlayersPerTeam,MinLvl,MaxLvl,AllianceStartLoc,HordeStartLoc,StartMaxDist FROM battleground_template");
 
     if (!result)
     {
@@ -1168,7 +1168,7 @@ void BattleGroundMgr::CreateInitialBattleGrounds()
             AStartLoc[0] = start->x;
             AStartLoc[1] = start->y;
             AStartLoc[2] = start->z;
-            AStartLoc[3] = fields[6].GetFloat();
+            AStartLoc[3] = sObjectMgr.GetWorldSafeLocFacing(start->ID);
         }
         else
         {
@@ -1176,7 +1176,7 @@ void BattleGroundMgr::CreateInitialBattleGrounds()
             continue;
         }
 
-        uint32 start2 = fields[7].GetUInt32();
+        uint32 start2 = fields[6].GetUInt32();
 
         start = sWorldSafeLocsStore.LookupEntry(start2);
         if (start)
@@ -1184,7 +1184,7 @@ void BattleGroundMgr::CreateInitialBattleGrounds()
             HStartLoc[0] = start->x;
             HStartLoc[1] = start->y;
             HStartLoc[2] = start->z;
-            HStartLoc[3] = fields[8].GetFloat();
+            HStartLoc[3] = sObjectMgr.GetWorldSafeLocFacing(start->ID);
         }
         else
         {
@@ -1203,7 +1203,7 @@ void BattleGroundMgr::CreateInitialBattleGrounds()
             continue;
         }
 
-        float startMaxDist = fields[9].GetFloat();
+        float startMaxDist = fields[7].GetFloat();
 
         // sLog.outDetail("Creating battleground %s, %u-%u", bl->name[sWorld.GetDBClang()], MinLvl, MaxLvl);
         if (!CreateBattleGround(bgTypeID, MinPlayersPerTeam, MaxPlayersPerTeam, MinLvl, MaxLvl, name, mapId, AStartLoc[0], AStartLoc[1], AStartLoc[2], AStartLoc[3], HStartLoc[0], HStartLoc[1], HStartLoc[2], HStartLoc[3], startMaxDist))

--- a/src/game/BattleGround/BattleGroundWS.cpp
+++ b/src/game/BattleGround/BattleGroundWS.cpp
@@ -561,12 +561,12 @@ WorldSafeLocsEntry const* BattleGroundWS::GetClosestGraveYard(Player* player)
     if (player->GetTeam() == ALLIANCE)
     {
         if (GetStatus() == STATUS_IN_PROGRESS)
-            return sWorldSafeLocsStore.LookupEntry(WS_GRAVEYARD_MAIN_ALLIANCE);
-        return sWorldSafeLocsStore.LookupEntry(WS_GRAVEYARD_FLAGROOM_ALLIANCE);
+            return sWorldSafeLocsStore.LookupEntry<WorldSafeLocsEntry>(WS_GRAVEYARD_MAIN_ALLIANCE);
+        return sWorldSafeLocsStore.LookupEntry<WorldSafeLocsEntry>(WS_GRAVEYARD_FLAGROOM_ALLIANCE);
     }
     if (GetStatus() == STATUS_IN_PROGRESS)
-        return sWorldSafeLocsStore.LookupEntry(WS_GRAVEYARD_MAIN_HORDE);
-    return sWorldSafeLocsStore.LookupEntry(WS_GRAVEYARD_FLAGROOM_HORDE);
+        return sWorldSafeLocsStore.LookupEntry<WorldSafeLocsEntry>(WS_GRAVEYARD_MAIN_HORDE);
+    return sWorldSafeLocsStore.LookupEntry<WorldSafeLocsEntry>(WS_GRAVEYARD_FLAGROOM_HORDE);
 }
 
 void BattleGroundWS::FillInitialWorldStates(WorldPacket& data, uint32& count)

--- a/src/game/Chat/Level2.cpp
+++ b/src/game/Chat/Level2.cpp
@@ -438,7 +438,7 @@ bool ChatHandler::HandleGoGraveyardCommand(char* args)
     if (!ExtractUInt32(&args, gyId))
         return false;
 
-    WorldSafeLocsEntry const* gy = sWorldSafeLocsStore.LookupEntry(gyId);
+    WorldSafeLocsEntry const* gy = sWorldSafeLocsStore.LookupEntry<WorldSafeLocsEntry>(gyId);
     if (!gy)
     {
         PSendSysMessage(LANG_COMMAND_GRAVEYARDNOEXIST, gyId);

--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -3717,7 +3717,7 @@ bool ChatHandler::HandleLinkGraveCommand(char* args)
     else
         return false;
 
-    WorldSafeLocsEntry const* graveyard = sWorldSafeLocsStore.LookupEntry(g_id);
+    WorldSafeLocsEntry const* graveyard = sWorldSafeLocsStore.LookupEntry<WorldSafeLocsEntry>(g_id);
     if (!graveyard)
     {
         PSendSysMessage(LANG_COMMAND_GRAVEYARDNOEXIST, g_id);

--- a/src/game/Entities/NPCHandler.cpp
+++ b/src/game/Entities/NPCHandler.cpp
@@ -425,7 +425,7 @@ void WorldSession::SendSpiritResurrect() const
                 _player->GetPositionX(), _player->GetPositionY(), _player->GetPositionZ(), _player->GetMapId(), _player->GetTeam());
 
         if (corpseGrave != ghostGrave)
-            _player->TeleportTo(corpseGrave->map_id, corpseGrave->x, corpseGrave->y, corpseGrave->z, _player->GetOrientation());
+            _player->TeleportTo(corpseGrave->map_id, corpseGrave->x, corpseGrave->y, corpseGrave->z, sObjectMgr.GetWorldSafeLocFacing(corpseGrave->ID));
         // or update at original position
         else
         {

--- a/src/game/Entities/NPCHandler.cpp
+++ b/src/game/Entities/NPCHandler.cpp
@@ -425,7 +425,7 @@ void WorldSession::SendSpiritResurrect() const
                 _player->GetPositionX(), _player->GetPositionY(), _player->GetPositionZ(), _player->GetMapId(), _player->GetTeam());
 
         if (corpseGrave != ghostGrave)
-            _player->TeleportTo(corpseGrave->map_id, corpseGrave->x, corpseGrave->y, corpseGrave->z, sObjectMgr.GetWorldSafeLocFacing(corpseGrave->ID));
+            _player->TeleportTo(corpseGrave->map_id, corpseGrave->x, corpseGrave->y, corpseGrave->z, corpseGrave->o);
         // or update at original position
         else
         {

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -4694,7 +4694,7 @@ void Player::RepopAtGraveyard()
     if (ClosestGrave)
     {
         bool updateVisibility = IsInWorld() && GetMapId() == ClosestGrave->map_id;
-        TeleportTo(ClosestGrave->map_id, ClosestGrave->x, ClosestGrave->y, ClosestGrave->z, GetOrientation());
+        TeleportTo(ClosestGrave->map_id, ClosestGrave->x, ClosestGrave->y, ClosestGrave->z, sObjectMgr.GetWorldSafeLocFacing(ClosestGrave->ID));
         if (updateVisibility && IsInWorld())
             UpdateVisibilityAndView();
     }
@@ -17365,7 +17365,7 @@ void Player::SetBattleGroundEntryPoint(Player* leader /*= nullptr*/)
         {
             if (const WorldSafeLocsEntry* entry = sObjectMgr.GetClosestGraveYard(leader->GetPositionX(), leader->GetPositionY(), leader->GetPositionZ(), leader->GetMapId(), leader->GetTeam()))
             {
-                m_bgData.joinPos = WorldLocation(entry->map_id, entry->x, entry->y, entry->z, 0.0f);
+                m_bgData.joinPos = WorldLocation(entry->map_id, entry->x, entry->y, entry->z, sObjectMgr.GetWorldSafeLocFacing(entry->ID));
                 m_bgData.m_needSave = true;
                 return;
             }

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -4694,7 +4694,7 @@ void Player::RepopAtGraveyard()
     if (ClosestGrave)
     {
         bool updateVisibility = IsInWorld() && GetMapId() == ClosestGrave->map_id;
-        TeleportTo(ClosestGrave->map_id, ClosestGrave->x, ClosestGrave->y, ClosestGrave->z, sObjectMgr.GetWorldSafeLocFacing(ClosestGrave->ID));
+        TeleportTo(ClosestGrave->map_id, ClosestGrave->x, ClosestGrave->y, ClosestGrave->z, ClosestGrave->o);
         if (updateVisibility && IsInWorld())
             UpdateVisibilityAndView();
     }
@@ -17365,7 +17365,7 @@ void Player::SetBattleGroundEntryPoint(Player* leader /*= nullptr*/)
         {
             if (const WorldSafeLocsEntry* entry = sObjectMgr.GetClosestGraveYard(leader->GetPositionX(), leader->GetPositionY(), leader->GetPositionZ(), leader->GetMapId(), leader->GetTeam()))
             {
-                m_bgData.joinPos = WorldLocation(entry->map_id, entry->x, entry->y, entry->z, sObjectMgr.GetWorldSafeLocFacing(entry->ID));
+                m_bgData.joinPos = WorldLocation(entry->map_id, entry->x, entry->y, entry->z, entry->o);
                 m_bgData.m_needSave = true;
                 return;
             }

--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -5694,6 +5694,43 @@ void ObjectMgr::SetGraveYardLinkTeam(uint32 id, uint32 zoneId, Team team)
     AddGraveYardLink(id, zoneId, team);                     // Add to prevent further error message and correct mechanismn
 }
 
+void ObjectMgr::LoadWorldSafeLocsFacing()
+{
+    uint32 count = 0;
+    std::unique_ptr<QueryResult> result(WorldDatabase.Query("SELECT `id`, `orientation` FROM `world_safe_locs_facing`"));
+    if (!result)
+    {
+        BarGoLink bar(1);
+        bar.step();
+
+        sLog.outString();
+        sLog.outString(">> Loaded %u world safe locs facing values", count);
+        return;
+    }
+    BarGoLink bar(result->GetRowCount());
+    do
+    {
+        bar.step();
+        Field* fields = result->Fetch();
+
+        uint32 safeLocId = fields[0].GetUInt32();
+        float orientation = fields[1].GetFloat();
+
+        m_worldSafeLocsFacingMap[safeLocId] = orientation;
+        count++;
+    } while (result->NextRow());
+    sLog.outString();
+    sLog.outString(">> Loaded %u world safe locs facing values", count);
+}
+
+float ObjectMgr::GetWorldSafeLocFacing(uint32 id) const
+{
+    auto itr = m_worldSafeLocsFacingMap.find(id);
+    if (itr != m_worldSafeLocsFacingMap.end())
+        return itr->second;
+    return 0.0f;
+}
+
 void ObjectMgr::LoadAreaTriggerTeleports()
 {
     mAreaTriggers.clear();                                  // need for reload case

--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -5491,7 +5491,7 @@ void ObjectMgr::LoadGraveyardZones()
         uint32 zoneId = fields[1].GetUInt32();
         uint32 team   = fields[2].GetUInt32();
 
-        WorldSafeLocsEntry const* entry = sWorldSafeLocsStore.LookupEntry(safeLocId);
+        WorldSafeLocsEntry const* entry = sWorldSafeLocsStore.LookupEntry<WorldSafeLocsEntry>(safeLocId);
         if (!entry)
         {
             sLog.outErrorDb("Table `game_graveyard_zone` has record for not existing graveyard (WorldSafeLocs.dbc id) %u, skipped.", safeLocId);
@@ -5568,7 +5568,7 @@ WorldSafeLocsEntry const* ObjectMgr::GetClosestGraveYard(float x, float y, float
         GraveYardData const& data = itr->second;
 
         // Checked on load
-        WorldSafeLocsEntry const* entry = sWorldSafeLocsStore.LookupEntry(data.safeLocId);
+        WorldSafeLocsEntry const* entry = sWorldSafeLocsStore.LookupEntry<WorldSafeLocsEntry>(data.safeLocId);
 
         // skip enemy faction graveyard
         // team == TEAM_BOTH_ALLOWED case can be at call from .neargrave
@@ -5694,41 +5694,10 @@ void ObjectMgr::SetGraveYardLinkTeam(uint32 id, uint32 zoneId, Team team)
     AddGraveYardLink(id, zoneId, team);                     // Add to prevent further error message and correct mechanismn
 }
 
-void ObjectMgr::LoadWorldSafeLocsFacing()
+void ObjectMgr::LoadWorldSafeLocs() const
 {
-    uint32 count = 0;
-    std::unique_ptr<QueryResult> result(WorldDatabase.Query("SELECT `id`, `orientation` FROM `world_safe_locs_facing`"));
-    if (!result)
-    {
-        BarGoLink bar(1);
-        bar.step();
-
-        sLog.outString();
-        sLog.outString(">> Loaded %u world safe locs facing values", count);
-        return;
-    }
-    BarGoLink bar(result->GetRowCount());
-    do
-    {
-        bar.step();
-        Field* fields = result->Fetch();
-
-        uint32 safeLocId = fields[0].GetUInt32();
-        float orientation = fields[1].GetFloat();
-
-        m_worldSafeLocsFacingMap[safeLocId] = orientation;
-        count++;
-    } while (result->NextRow());
-    sLog.outString();
-    sLog.outString(">> Loaded %u world safe locs facing values", count);
-}
-
-float ObjectMgr::GetWorldSafeLocFacing(uint32 id) const
-{
-    auto itr = m_worldSafeLocsFacingMap.find(id);
-    if (itr != m_worldSafeLocsFacingMap.end())
-        return itr->second;
-    return 0.0f;
+    sWorldSafeLocsStore.Load(true);
+    sLog.outString(">> Loaded %u world safe locs", sWorldSafeLocsStore.GetRecordCount());
 }
 
 void ObjectMgr::LoadAreaTriggerTeleports()

--- a/src/game/Globals/ObjectMgr.h
+++ b/src/game/Globals/ObjectMgr.h
@@ -287,6 +287,7 @@ struct GraveYardData
 };
 typedef std::multimap < uint32 /*zoneId*/, GraveYardData > GraveYardMap;
 typedef std::pair<GraveYardMap::const_iterator, GraveYardMap::const_iterator> GraveYardMapBounds;
+typedef std::unordered_map<uint32, float> WorldSafeLocsFacingMap;
 
 struct QuestgiverGreeting
 {
@@ -608,6 +609,8 @@ class ObjectMgr
         void SetGraveYardLinkTeam(uint32 id, uint32 zoneId, Team team);
         void LoadGraveyardZones();
         GraveYardData const* FindGraveYardData(uint32 id, uint32 zoneId) const;
+        void LoadWorldSafeLocsFacing();
+        float GetWorldSafeLocFacing(uint32 id) const;
 
         AreaTrigger const* GetAreaTrigger(uint32 trigger) const
         {
@@ -1219,6 +1222,7 @@ class ObjectMgr
         TaxiShortcutMap     m_TaxiShortcutMap;
 
         GraveYardMap        mGraveYardMap;
+        WorldSafeLocsFacingMap m_worldSafeLocsFacingMap;
 
         GameTeleMap         m_GameTeleMap;
 

--- a/src/game/Globals/ObjectMgr.h
+++ b/src/game/Globals/ObjectMgr.h
@@ -287,7 +287,17 @@ struct GraveYardData
 };
 typedef std::multimap < uint32 /*zoneId*/, GraveYardData > GraveYardMap;
 typedef std::pair<GraveYardMap::const_iterator, GraveYardMap::const_iterator> GraveYardMapBounds;
-typedef std::unordered_map<uint32, float> WorldSafeLocsFacingMap;
+
+struct WorldSafeLocsEntry
+{
+    uint32    ID;
+    uint32    map_id;
+    float     x;
+    float     y;
+    float     z;
+    float     o;
+    char*     name;
+};
 
 struct QuestgiverGreeting
 {
@@ -609,8 +619,7 @@ class ObjectMgr
         void SetGraveYardLinkTeam(uint32 id, uint32 zoneId, Team team);
         void LoadGraveyardZones();
         GraveYardData const* FindGraveYardData(uint32 id, uint32 zoneId) const;
-        void LoadWorldSafeLocsFacing();
-        float GetWorldSafeLocFacing(uint32 id) const;
+        void LoadWorldSafeLocs() const;
 
         AreaTrigger const* GetAreaTrigger(uint32 trigger) const
         {
@@ -1222,7 +1231,6 @@ class ObjectMgr
         TaxiShortcutMap     m_TaxiShortcutMap;
 
         GraveYardMap        mGraveYardMap;
-        WorldSafeLocsFacingMap m_worldSafeLocsFacingMap;
 
         GameTeleMap         m_GameTeleMap;
 

--- a/src/game/Server/DBCStores.cpp
+++ b/src/game/Server/DBCStores.cpp
@@ -140,7 +140,6 @@ static DBCStorage <TaxiPathNodeEntry> sTaxiPathNodeStore(TaxiPathNodeEntryfmt);
 DBCStorage <WMOAreaTableEntry>  sWMOAreaTableStore(WMOAreaTableEntryfmt);
 DBCStorage <WorldMapAreaEntry>  sWorldMapAreaStore(WorldMapAreaEntryfmt);
 // DBCStorage <WorldMapOverlayEntry> sWorldMapOverlayStore(WorldMapOverlayEntryfmt);
-DBCStorage <WorldSafeLocsEntry> sWorldSafeLocsStore(WorldSafeLocsEntryfmt);
 
 typedef std::list<std::string> StoreProblemList;
 
@@ -489,7 +488,7 @@ void LoadDBCStores(const std::string& dataPath)
         }
     }
     // LoadDBC(availableDbcLocales,bar,bad_dbc_files,sWorldMapOverlayStore,     dbcPath,"WorldMapOverlay.dbc");
-    LoadDBC(availableDbcLocales, bar, bad_dbc_files, sWorldSafeLocsStore,       dbcPath, "WorldSafeLocs.dbc");
+    // LoadDBC(availableDbcLocales, bar, bad_dbc_files, sWorldSafeLocsStore,       dbcPath, "WorldSafeLocs.dbc");
 
     // error checks
     if (bad_dbc_files.size() >= DBCFilesCount)

--- a/src/game/Server/DBCStores.h
+++ b/src/game/Server/DBCStores.h
@@ -122,7 +122,6 @@ extern TaxiPathNodesByPath                       sTaxiPathNodesByPath;
 extern DBCStorage <WMOAreaTableEntry>            sWMOAreaTableStore;
 // extern DBCStorage <WorldMapAreaEntry>           sWorldMapAreaStore; -- use Zone2MapCoordinates and Map2ZoneCoordinates
 // extern DBCStorage <WorldMapOverlayEntry>         sWorldMapOverlayStore;
-extern DBCStorage <WorldSafeLocsEntry>           sWorldSafeLocsStore;
 
 void LoadDBCStores(const std::string& dataPath);
 

--- a/src/game/Server/DBCStructure.h
+++ b/src/game/Server/DBCStructure.h
@@ -918,6 +918,7 @@ struct WorldMapOverlayEntry
     // 16       m_hitRectRight
 };
 
+/*
 struct WorldSafeLocsEntry
 {
     uint32    ID;                                           // 0        m_ID
@@ -928,6 +929,7 @@ struct WorldSafeLocsEntry
     // char*   name[8]                                      // 5-12     m_AreaName_lang
     // 13 string flags
 };
+*/
 
 // GCC have alternative #pragma pack() syntax and old gcc version not support pack(pop), also any gcc version not support it at some platform
 #if defined( __GNUC__ )

--- a/src/game/Server/SQLStorages.cpp
+++ b/src/game/Server/SQLStorages.cpp
@@ -41,6 +41,7 @@ const char SpellScriptTargetFmt[] = "iiii";
 const char SpellEntryfmt[] = "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiifiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiffffffiiiiiiiiiiiiiiiiiiiiifffiiiiiiiiiiiifffiiiissssssssssssssssiiiiiLiiiifffiiiii";
 const char SpellConefmt[] = "ii";
 const char DungeonEncounterFmt[] = "iiiiissssssssssssssssii";
+const char WorldSafeLocsFmt[] = "iiffffs";
 
 SQLStorage sCreatureStorage(CreatureInfosrcfmt, CreatureInfodstfmt, "entry", "creature_template");
 SQLStorage sCreatureDataAddonStorage(CreatureDataAddonInfofmt, "guid", "creature_addon");
@@ -56,6 +57,7 @@ SQLStorage sSpellTemplate(SpellEntryfmt, "id", "spell_template");
 SQLStorage sSpellCones(SpellConefmt, "id", "spell_cone");
 SQLStorage sDungeonEncounterStore(DungeonEncounterFmt, "id", "instance_dungeon_encounters");
 SQLStorage sCreatureConditionalSpawnStore(CreatureConditionalSpawnSrcFmt, CreatureConditionalSpawnDstFmt, "guid", "creature_conditional_spawn");
+SQLStorage sWorldSafeLocsStore(WorldSafeLocsFmt, "id", "world_safe_locs");
 
 SQLHashStorage sGOStorage(GameObjectInfosrcfmt, GameObjectInfodstfmt, "entry", "gameobject_template");
 SQLHashStorage sCreatureTemplateSpellsStorage(CreatureTemplateSpellsFmt, "entry", "creature_template_spells");

--- a/src/game/Server/SQLStorages.h
+++ b/src/game/Server/SQLStorages.h
@@ -35,6 +35,8 @@ extern SQLStorage sSpellTemplate;
 extern SQLStorage sSpellCones;
 extern SQLStorage sDungeonEncounterStore;
 extern SQLStorage sCreatureConditionalSpawnStore;
+extern SQLStorage sWorldSafeLocsStore;
+
 
 extern SQLHashStorage sGOStorage;
 extern SQLHashStorage sCreatureTemplateSpellsStorage;

--- a/src/game/World/World.cpp
+++ b/src/game/World/World.cpp
@@ -1038,6 +1038,9 @@ void World::SetInitialWorldSettings()
     sLog.outString("Loading Graveyard-zone links...");
     sObjectMgr.LoadGraveyardZones();
 
+    sLog.outString("Loading world safe locs facing values ...");
+    sObjectMgr.LoadWorldSafeLocsFacing();
+
     sLog.outString("Loading taxi flight shortcuts...");
     sObjectMgr.LoadTaxiShortcuts();
 

--- a/src/game/World/World.cpp
+++ b/src/game/World/World.cpp
@@ -829,6 +829,9 @@ void World::SetInitialWorldSettings()
     sLog.outString("Loading spell_template...");
     sObjectMgr.LoadSpellTemplate();
 
+    sLog.outString("Loading world safe locs ...");
+    sObjectMgr.LoadWorldSafeLocs();
+
     ///- Load the DBC files
     sLog.outString("Initialize DBC data stores...");
     LoadDBCStores(m_dataPath);
@@ -1037,9 +1040,6 @@ void World::SetInitialWorldSettings()
 
     sLog.outString("Loading Graveyard-zone links...");
     sObjectMgr.LoadGraveyardZones();
-
-    sLog.outString("Loading world safe locs facing values ...");
-    sObjectMgr.LoadWorldSafeLocsFacing();
 
     sLog.outString("Loading taxi flight shortcuts...");
     sObjectMgr.LoadTaxiShortcuts();

--- a/src/shared/revision_sql.h
+++ b/src/shared/revision_sql.h
@@ -2,5 +2,5 @@
 #define __REVISION_SQL_H__
  #define REVISION_DB_REALMD "required_z2743_00_realmd_account_drop_sha"
  #define REVISION_DB_CHARACTERS "required_z2745_01_characters_weekly_quests"
- #define REVISION_DB_MANGOS "required_z2745_01_mangos_game_event_split"
+ #define REVISION_DB_MANGOS "required_z2746_01_mangos_world_safe_locs_facing"
 #endif // __REVISION_SQL_H__


### PR DESCRIPTION
The new classic client includes orientation values in WorldSafeLocs.db2. This pull requests adds support for loading these values from the database.

Blizzard defined the orientation for all graveyards back in patch 1.8 but they didn't export the orientation value to the client dbc until a later expansion.

> World of Warcraft Client Patch 1.8.0 (2005-10-11)
> - All graveyards that needed adjustment were changed so that a 
>   character's spirit comes into the world facing toward the Spirit Healer.

Database update https://github.com/cmangos/classic-db/pull/246