### PR TITLE
Implement modify commands for stats.

### DIFF
--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -78,3 +78,24 @@ UPDATE spell_template SET EffectRadiusIndex1=23 WHERE id=29234;
 
 -- Remove incorrect spell attribute for spell 30122 (Plague Cloud) used in Heigan the Unclean encounter
 UPDATE spell_template SET AttributesEx=(AttributesEx&~0x00000040) WHERE id=30122;
+
+-- Custom spells to be used with .modify commands. These spell ids are free in all expansions.
+INSERT INTO `spell_template` (`Id`, `Attributes`, `CastingTimeIndex`, `ProcChance`, `SpellLevel`, `DurationIndex`, `EquippedItemClass`, `Effect1`, `EffectApplyAuraName1`, `EffectMiscValue1`, `SpellName`) VALUES
+(15170, 64, 1, 101, 1, 21, -1, 6, 22, 1, 'Custom QA Mod Armor'),
+(15171, 64, 1, 101, 1, 21, -1, 6, 22, 2, 'Custom QA Mod Resist Holy'),
+(15172, 64, 1, 101, 1, 21, -1, 6, 22, 4, 'Custom QA Mod Resist Fire'),
+(15173, 64, 1, 101, 1, 21, -1, 6, 22, 8, 'Custom QA Mod Resist Nature'),
+(15174, 64, 1, 101, 1, 21, -1, 6, 22, 16, 'Custom QA Mod Resist Frost'),
+(15175, 64, 1, 101, 1, 21, -1, 6, 22, 32, 'Custom QA Mod Resist Shadow'),
+(15176, 64, 1, 101, 1, 21, -1, 6, 22, 64, 'Custom QA Mod Resist Arcane'),
+(15177, 64, 1, 101, 1, 21, -1, 6, 99, 0, 'Custom QA Mod Melee AP'),
+(15178, 64, 1, 101, 1, 21, -1, 6, 124, 0, 'Custom QA Mod Ranged AP'),
+(15179, 64, 1, 101, 1, 21, -1, 6, 52, 0, 'Custom QA Mod Melee Crit'),
+(15180, 64, 1, 101, 1, 21, -1, 6, 57, 0, 'Custom QA Mod Spell Crit'),
+(15181, 64, 1, 101, 1, 21, -1, 6, 138, 0, 'Custom QA Mod Melee Haste'),
+(15182, 64, 1, 101, 1, 21, -1, 6, 140, 0, 'Custom QA Mod Ranged Haste'),
+(15183, 64, 1, 101, 1, 21, -1, 6, 65, 0, 'Custom QA Mod Spell Haste'),
+(15184, 64, 1, 101, 1, 21, -1, 6, 47, 0, 'Custom QA Mod Parry Chance'),
+(15185, 64, 1, 101, 1, 21, -1, 6, 49, 0, 'Custom QA Mod Dodge Chance'),
+(15186, 64, 1, 101, 1, 21, -1, 6, 51, 0, 'Custom QA Mod Block Chance');
+

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -454,6 +454,29 @@ ChatCommand* ChatHandler::getCommandTable()
         { "standstate",     SEC_GAMEMASTER,     false, &ChatHandler::HandleModifyStandStateCommand,    "", nullptr },
         { "morph",          SEC_GAMEMASTER,     false, &ChatHandler::HandleModifyMorphCommand,         "", nullptr },
         { "gender",         SEC_GAMEMASTER,     false, &ChatHandler::HandleModifyGenderCommand,        "", nullptr },
+        { "strength",       SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyStrengthCommand,      "", nullptr },
+        { "agility",        SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyAgilityCommand,       "", nullptr },
+        { "stamina",        SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyStaminaCommand,       "", nullptr },
+        { "intellect",      SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyIntellectCommand,     "", nullptr },
+        { "spirit",         SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifySpiritCommand,        "", nullptr },
+        { "armor",          SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyArmorCommand,         "", nullptr },
+        { "holyresist",     SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyHolyCommand,          "", nullptr },
+        { "fireresist",     SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyFireCommand,          "", nullptr },
+        { "natureresist",   SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyNatureCommand,        "", nullptr },
+        { "frostresist",    SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyFrostCommand,         "", nullptr },
+        { "shadowresist",   SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyShadowCommand,        "", nullptr },
+        { "arcaneresist",   SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyArcaneCommand,        "", nullptr },
+        { "ap",             SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyMeleeApCommand,       "", nullptr },
+        { "rangeap",        SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyRangedApCommand,      "", nullptr },
+        { "spellpower",     SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifySpellPowerCommand,    "", nullptr },
+        { "crit",           SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyMeleeCritCommand,     "", nullptr },
+        { "spellcrit",      SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifySpellCritCommand,     "", nullptr },
+        { "meleehaste",     SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyMeleeHasteCommand,    "", nullptr },
+        { "rangehaste",     SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyRangedHasteCommand,   "", nullptr },
+        { "spellhaste",     SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifySpellHasteCommand,    "", nullptr },
+        { "block",          SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyBlockCommand,         "", nullptr },
+        { "dodge",          SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyDodgeCommand,         "", nullptr },
+        { "parry",          SEC_ADMINISTRATOR,  false, &ChatHandler::HandleModifyParryCommand,         "", nullptr },
         { nullptr,          0,                  false, nullptr,                                        "", nullptr }
     };
 
@@ -631,6 +654,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "stats",          SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleResetStatsCommand,          "", nullptr },
         { "talents",        SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleResetTalentsCommand,        "", nullptr },
         { "taxinodes",      SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleResetTaxiNodesCommand,      "", nullptr },
+        { "mods",           SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleResetModsCommand,           "", nullptr },
         { "all",            SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleResetAllCommand,            "", nullptr },
         { nullptr,          0,                  false, nullptr,                                        "", nullptr }
     };

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -382,6 +382,7 @@ class ChatHandler
         bool HandleModifyBlockCommand(char* args);
         bool HandleModifyDodgeCommand(char* args);
         bool HandleModifyParryCommand(char* args);
+        bool ModifyStatCommandHelper(char* args, char const* statName, uint32 spellId);
 
         //-----------------------Npc Commands-----------------------
         bool HandleNpcAddCommand(char* args);

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -359,6 +359,29 @@ class ChatHandler
         bool HandleModifyHonorCommand(char* args);
         bool HandleModifyRepCommand(char* args);
         bool HandleModifyGenderCommand(char* args);
+        bool HandleModifyStrengthCommand(char* args);
+        bool HandleModifyAgilityCommand(char* args);
+        bool HandleModifyStaminaCommand(char* args);
+        bool HandleModifyIntellectCommand(char* args);
+        bool HandleModifySpiritCommand(char* args);
+        bool HandleModifyArmorCommand(char* args);
+        bool HandleModifyHolyCommand(char* args);
+        bool HandleModifyFireCommand(char* args);
+        bool HandleModifyNatureCommand(char* args);
+        bool HandleModifyFrostCommand(char* args);
+        bool HandleModifyShadowCommand(char* args);
+        bool HandleModifyArcaneCommand(char* args);
+        bool HandleModifyMeleeApCommand(char* args);
+        bool HandleModifyRangedApCommand(char* args);
+        bool HandleModifySpellPowerCommand(char* args);
+        bool HandleModifyMeleeCritCommand(char* args);
+        bool HandleModifySpellCritCommand(char* args);
+        bool HandleModifyMeleeHasteCommand(char* args);
+        bool HandleModifyRangedHasteCommand(char* args);
+        bool HandleModifySpellHasteCommand(char* args);
+        bool HandleModifyBlockCommand(char* args);
+        bool HandleModifyDodgeCommand(char* args);
+        bool HandleModifyParryCommand(char* args);
 
         //-----------------------Npc Commands-----------------------
         bool HandleNpcAddCommand(char* args);
@@ -505,6 +528,7 @@ class ChatHandler
         bool HandleResetStatsCommand(char* args);
         bool HandleResetTalentsCommand(char* args);
         bool HandleResetTaxiNodesCommand(char* args);
+        bool HandleResetModsCommand(char* args);
 
         bool HandleSendItemsCommand(char* args);
         bool HandleSendMailCommand(char* args);

--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -7044,3 +7044,811 @@ bool ChatHandler::HandleLinkCheckCommand(char* args)
 
     return true;
 }
+
+enum ModSpells
+{
+    // client spells
+    SPELL_MOD_STRENGTH     = 13372,
+    SPELL_MOD_AGILITY      = 13365,
+    SPELL_MOD_STAMINA      = 13370,
+    SPELL_MOD_INTELLECT    = 13366,
+    SPELL_MOD_SPIRIT       = 13368,
+    SPELL_MOD_SPELL_POWER  = 18058,
+
+    // custom spells
+    SPELL_MOD_ARMOR        = 15170,
+    SPELL_MOD_RES_HOLY     = 15171,
+    SPELL_MOD_RES_FIRE     = 15172,
+    SPELL_MOD_RES_NATURE   = 15173,
+    SPELL_MOD_RES_FROST    = 15174,
+    SPELL_MOD_RES_SHADOW   = 15175,
+    SPELL_MOD_RES_ARCANE   = 15176,
+    SPELL_MOD_MELEE_AP     = 15177,
+    SPELL_MOD_RANGE_AP     = 15178,
+    SPELL_MOD_MELEE_CRIT   = 15179,
+    SPELL_MOD_SPELL_CRIT   = 15180,
+    SPELL_MOD_MELEE_HASTE  = 15181,
+    SPELL_MOD_RANGE_HASTE  = 15182,
+    SPELL_MOD_SPELL_HASTE  = 15183,
+    SPELL_MOD_PARRY_CHANCE = 15184,
+    SPELL_MOD_DODGE_CHANCE = 15185,
+    SPELL_MOD_BLOCK_CHANCE = 15186,
+};
+
+bool ChatHandler::HandleResetModsCommand(char *args)
+{
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_STRENGTH);
+    target->RemoveAurasDueToSpell(SPELL_MOD_AGILITY);
+    target->RemoveAurasDueToSpell(SPELL_MOD_STAMINA);
+    target->RemoveAurasDueToSpell(SPELL_MOD_INTELLECT);
+    target->RemoveAurasDueToSpell(SPELL_MOD_SPIRIT);
+    target->RemoveAurasDueToSpell(SPELL_MOD_ARMOR);
+    target->RemoveAurasDueToSpell(SPELL_MOD_RES_HOLY);
+    target->RemoveAurasDueToSpell(SPELL_MOD_RES_FIRE);
+    target->RemoveAurasDueToSpell(SPELL_MOD_RES_NATURE);
+    target->RemoveAurasDueToSpell(SPELL_MOD_RES_FROST);
+    target->RemoveAurasDueToSpell(SPELL_MOD_RES_SHADOW);
+    target->RemoveAurasDueToSpell(SPELL_MOD_RES_ARCANE);
+    target->RemoveAurasDueToSpell(SPELL_MOD_MELEE_AP);
+    target->RemoveAurasDueToSpell(SPELL_MOD_RANGE_AP);
+    target->RemoveAurasDueToSpell(SPELL_MOD_SPELL_POWER);
+    target->RemoveAurasDueToSpell(SPELL_MOD_MELEE_CRIT);
+    target->RemoveAurasDueToSpell(SPELL_MOD_SPELL_CRIT);
+    target->RemoveAurasDueToSpell(SPELL_MOD_MELEE_HASTE);
+    target->RemoveAurasDueToSpell(SPELL_MOD_RANGE_HASTE);
+    target->RemoveAurasDueToSpell(SPELL_MOD_SPELL_HASTE);
+    target->RemoveAurasDueToSpell(SPELL_MOD_PARRY_CHANCE);
+    target->RemoveAurasDueToSpell(SPELL_MOD_DODGE_CHANCE);
+    target->RemoveAurasDueToSpell(SPELL_MOD_BLOCK_CHANCE);
+
+    PSendSysMessage("You removed all stat mods from %s.", target->GetName());
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyStrengthCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_STRENGTH);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_STRENGTH);
+    target->CastCustomSpell(target, SPELL_MOD_STRENGTH, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Strength of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyAgilityCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_AGILITY);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_AGILITY);
+    target->CastCustomSpell(target, SPELL_MOD_AGILITY, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Agility of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyStaminaCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_STAMINA);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_STAMINA);
+    target->CastCustomSpell(target, SPELL_MOD_STAMINA, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+    target->SetHealthPercent(100);
+
+    PSendSysMessage("You changed Stamina of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyIntellectCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_INTELLECT);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_INTELLECT);
+    target->CastCustomSpell(target, SPELL_MOD_INTELLECT, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+    target->SetPower(POWER_MANA, target->GetMaxPower(POWER_MANA));
+
+    PSendSysMessage("You changed Intellect of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifySpiritCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_SPIRIT);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_SPIRIT);
+    target->CastCustomSpell(target, SPELL_MOD_SPIRIT, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Spirit of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyArmorCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_ARMOR);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_ARMOR);
+    target->CastCustomSpell(target, SPELL_MOD_ARMOR, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Armor of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyHolyCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_RES_HOLY);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_RES_HOLY);
+    target->CastCustomSpell(target, SPELL_MOD_RES_HOLY, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Holy Resistance of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyFireCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_RES_FIRE);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_RES_FIRE);
+    target->CastCustomSpell(target, SPELL_MOD_RES_FIRE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Fire Resistance of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyNatureCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_RES_NATURE);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_RES_NATURE);
+    target->CastCustomSpell(target, SPELL_MOD_RES_NATURE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Nature Resistance of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyFrostCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_RES_FROST);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_RES_FROST);
+    target->CastCustomSpell(target, SPELL_MOD_RES_FROST, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Frost Resistance of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyShadowCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_RES_SHADOW);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_RES_SHADOW);
+    target->CastCustomSpell(target, SPELL_MOD_RES_SHADOW, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Frost Resistance of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyArcaneCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_RES_ARCANE);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_RES_ARCANE);
+    target->CastCustomSpell(target, SPELL_MOD_RES_ARCANE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Arcane Resistance of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyMeleeApCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_MELEE_AP);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_MELEE_AP);
+    target->CastCustomSpell(target, SPELL_MOD_MELEE_AP, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Melee Attack Power of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyRangedApCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_RANGE_AP);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_RANGE_AP);
+    target->CastCustomSpell(target, SPELL_MOD_RANGE_AP, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Ranged Attack Power of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifySpellPowerCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_SPELL_POWER);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_SPELL_POWER);
+    target->CastCustomSpell(target, SPELL_MOD_SPELL_POWER, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Spell Power of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyMeleeCritCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_MELEE_CRIT);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_MELEE_CRIT);
+    target->CastCustomSpell(target, SPELL_MOD_MELEE_CRIT, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Melee Crit of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifySpellCritCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_SPELL_CRIT);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_SPELL_CRIT);
+    target->CastCustomSpell(target, SPELL_MOD_SPELL_CRIT, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Spell Crit of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyMeleeHasteCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_MELEE_HASTE);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_MELEE_HASTE);
+    target->CastCustomSpell(target, SPELL_MOD_MELEE_HASTE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Melee Haste of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyRangedHasteCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_RANGE_HASTE);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_RANGE_HASTE);
+    target->CastCustomSpell(target, SPELL_MOD_RANGE_HASTE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Ranged Haste of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifySpellHasteCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_SPELL_HASTE);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_SPELL_HASTE);
+    target->CastCustomSpell(target, SPELL_MOD_SPELL_HASTE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Spell Haste of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyBlockCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_BLOCK_CHANCE);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_BLOCK_CHANCE);
+    target->CastCustomSpell(target, SPELL_MOD_BLOCK_CHANCE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Block Chance of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyDodgeCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_DODGE_CHANCE);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_DODGE_CHANCE);
+    target->CastCustomSpell(target, SPELL_MOD_DODGE_CHANCE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Dodge Chance of %s to %i.", target->GetName(), amount);
+
+    return true;
+}
+
+bool ChatHandler::HandleModifyParryCommand(char *args)
+{
+    if (!*args)
+        return false;
+
+    Unit* target = getSelectedUnit();
+
+    if (!target)
+    {
+        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    int32 amount;
+    if (!ExtractInt32(&args, amount))
+        return false;
+
+    if (!amount)
+    {
+        target->RemoveAurasDueToSpell(SPELL_MOD_PARRY_CHANCE);
+        return true;
+    }
+
+    target->RemoveAurasDueToSpell(SPELL_MOD_PARRY_CHANCE);
+    target->CastCustomSpell(target, SPELL_MOD_PARRY_CHANCE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+
+    PSendSysMessage("You changed Parry Chance of %s to %i.", target->GetName(), amount);
+
+    return true;
+}

--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -7115,11 +7115,11 @@ bool ChatHandler::HandleResetModsCommand(char *args)
     return true;
 }
 
-bool ChatHandler::HandleModifyStrengthCommand(char *args)
+bool ChatHandler::ModifyStatCommandHelper(char* args, char const* statName, uint32 spellId)
 {
     if (!*args)
         return false;
-
+    
     Unit* target = getSelectedUnit();
 
     if (!target)
@@ -7135,720 +7135,135 @@ bool ChatHandler::HandleModifyStrengthCommand(char *args)
 
     if (!amount)
     {
-        target->RemoveAurasDueToSpell(SPELL_MOD_STRENGTH);
+        target->RemoveAurasDueToSpell(spellId);
         return true;
     }
 
-    target->RemoveAurasDueToSpell(SPELL_MOD_STRENGTH);
-    target->CastCustomSpell(target, SPELL_MOD_STRENGTH, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
+    target->RemoveAurasDueToSpell(spellId);
+    target->CastCustomSpell(target, spellId, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
 
-    PSendSysMessage("You changed Strength of %s to %i.", target->GetName(), amount);
+    if (spellId == SPELL_MOD_STAMINA)
+        target->SetHealthPercent(100);
+    else if (spellId = SPELL_MOD_INTELLECT)
+        target->SetPower(POWER_MANA, target->GetMaxPower(POWER_MANA));
+
+    PSendSysMessage("You changed %s of %s to %i.", statName, target->GetName(), amount);
 
     return true;
+}
+
+bool ChatHandler::HandleModifyStrengthCommand(char *args)
+{
+    return ModifyStatCommandHelper(args, "Strength", SPELL_MOD_STRENGTH);
 }
 
 bool ChatHandler::HandleModifyAgilityCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_AGILITY);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_AGILITY);
-    target->CastCustomSpell(target, SPELL_MOD_AGILITY, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Agility of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Agility", SPELL_MOD_AGILITY);
 }
 
 bool ChatHandler::HandleModifyStaminaCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_STAMINA);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_STAMINA);
-    target->CastCustomSpell(target, SPELL_MOD_STAMINA, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-    target->SetHealthPercent(100);
-
-    PSendSysMessage("You changed Stamina of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Stamina", SPELL_MOD_STAMINA);
 }
 
 bool ChatHandler::HandleModifyIntellectCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_INTELLECT);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_INTELLECT);
-    target->CastCustomSpell(target, SPELL_MOD_INTELLECT, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-    target->SetPower(POWER_MANA, target->GetMaxPower(POWER_MANA));
-
-    PSendSysMessage("You changed Intellect of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Intellect", SPELL_MOD_INTELLECT);
 }
 
 bool ChatHandler::HandleModifySpiritCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_SPIRIT);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_SPIRIT);
-    target->CastCustomSpell(target, SPELL_MOD_SPIRIT, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Spirit of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Spirit", SPELL_MOD_SPIRIT);
 }
 
 bool ChatHandler::HandleModifyArmorCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_ARMOR);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_ARMOR);
-    target->CastCustomSpell(target, SPELL_MOD_ARMOR, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Armor of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Armor", SPELL_MOD_ARMOR);
 }
 
 bool ChatHandler::HandleModifyHolyCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_RES_HOLY);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_RES_HOLY);
-    target->CastCustomSpell(target, SPELL_MOD_RES_HOLY, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Holy Resistance of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Holy Resistance", SPELL_MOD_RES_HOLY);
 }
 
 bool ChatHandler::HandleModifyFireCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_RES_FIRE);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_RES_FIRE);
-    target->CastCustomSpell(target, SPELL_MOD_RES_FIRE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Fire Resistance of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Fire Resistance", SPELL_MOD_RES_FIRE);
 }
 
 bool ChatHandler::HandleModifyNatureCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_RES_NATURE);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_RES_NATURE);
-    target->CastCustomSpell(target, SPELL_MOD_RES_NATURE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Nature Resistance of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Nature Resistance", SPELL_MOD_RES_NATURE);
 }
 
 bool ChatHandler::HandleModifyFrostCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_RES_FROST);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_RES_FROST);
-    target->CastCustomSpell(target, SPELL_MOD_RES_FROST, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Frost Resistance of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Frost Resistance", SPELL_MOD_RES_FROST);
 }
 
 bool ChatHandler::HandleModifyShadowCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_RES_SHADOW);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_RES_SHADOW);
-    target->CastCustomSpell(target, SPELL_MOD_RES_SHADOW, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Frost Resistance of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Shadow Resistance", SPELL_MOD_RES_SHADOW);
 }
 
 bool ChatHandler::HandleModifyArcaneCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_RES_ARCANE);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_RES_ARCANE);
-    target->CastCustomSpell(target, SPELL_MOD_RES_ARCANE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Arcane Resistance of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Arcane Resistance", SPELL_MOD_RES_ARCANE);
 }
 
 bool ChatHandler::HandleModifyMeleeApCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_MELEE_AP);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_MELEE_AP);
-    target->CastCustomSpell(target, SPELL_MOD_MELEE_AP, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Melee Attack Power of %s to %i.", target->GetName(), amount);
-
-    return true;
+   
+    return ModifyStatCommandHelper(args, "Melee Attack Power", SPELL_MOD_MELEE_AP);
 }
 
 bool ChatHandler::HandleModifyRangedApCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_RANGE_AP);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_RANGE_AP);
-    target->CastCustomSpell(target, SPELL_MOD_RANGE_AP, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Ranged Attack Power of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Ranged Attack Power", SPELL_MOD_RANGE_AP);
 }
 
 bool ChatHandler::HandleModifySpellPowerCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_SPELL_POWER);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_SPELL_POWER);
-    target->CastCustomSpell(target, SPELL_MOD_SPELL_POWER, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Spell Power of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Spell Power", SPELL_MOD_SPELL_POWER);
 }
 
 bool ChatHandler::HandleModifyMeleeCritCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_MELEE_CRIT);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_MELEE_CRIT);
-    target->CastCustomSpell(target, SPELL_MOD_MELEE_CRIT, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Melee Crit of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Melee Crit", SPELL_MOD_MELEE_CRIT);
 }
 
 bool ChatHandler::HandleModifySpellCritCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_SPELL_CRIT);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_SPELL_CRIT);
-    target->CastCustomSpell(target, SPELL_MOD_SPELL_CRIT, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Spell Crit of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Spell Crit", SPELL_MOD_SPELL_CRIT);
 }
 
 bool ChatHandler::HandleModifyMeleeHasteCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_MELEE_HASTE);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_MELEE_HASTE);
-    target->CastCustomSpell(target, SPELL_MOD_MELEE_HASTE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Melee Haste of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Melee Haste", SPELL_MOD_MELEE_HASTE);
 }
 
 bool ChatHandler::HandleModifyRangedHasteCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_RANGE_HASTE);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_RANGE_HASTE);
-    target->CastCustomSpell(target, SPELL_MOD_RANGE_HASTE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Ranged Haste of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Ranged Haste", SPELL_MOD_RANGE_HASTE);
 }
 
 bool ChatHandler::HandleModifySpellHasteCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_SPELL_HASTE);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_SPELL_HASTE);
-    target->CastCustomSpell(target, SPELL_MOD_SPELL_HASTE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Spell Haste of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Spell Haste", SPELL_MOD_SPELL_HASTE);
 }
 
 bool ChatHandler::HandleModifyBlockCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_BLOCK_CHANCE);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_BLOCK_CHANCE);
-    target->CastCustomSpell(target, SPELL_MOD_BLOCK_CHANCE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Block Chance of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Block Chance", SPELL_MOD_BLOCK_CHANCE);
 }
 
 bool ChatHandler::HandleModifyDodgeCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_DODGE_CHANCE);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_DODGE_CHANCE);
-    target->CastCustomSpell(target, SPELL_MOD_DODGE_CHANCE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Dodge Chance of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Dodge Chance", SPELL_MOD_DODGE_CHANCE);
 }
 
 bool ChatHandler::HandleModifyParryCommand(char *args)
 {
-    if (!*args)
-        return false;
-
-    Unit* target = getSelectedUnit();
-
-    if (!target)
-    {
-        PSendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
-    int32 amount;
-    if (!ExtractInt32(&args, amount))
-        return false;
-
-    if (!amount)
-    {
-        target->RemoveAurasDueToSpell(SPELL_MOD_PARRY_CHANCE);
-        return true;
-    }
-
-    target->RemoveAurasDueToSpell(SPELL_MOD_PARRY_CHANCE);
-    target->CastCustomSpell(target, SPELL_MOD_PARRY_CHANCE, &amount, &amount, nullptr, TRIGGERED_OLD_TRIGGERED);
-
-    PSendSysMessage("You changed Parry Chance of %s to %i.", target->GetName(), amount);
-
-    return true;
+    return ModifyStatCommandHelper(args, "Parry Chance", SPELL_MOD_PARRY_CHANCE);
 }

--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -7053,7 +7053,7 @@ enum ModSpells
     SPELL_MOD_STAMINA      = 13370,
     SPELL_MOD_INTELLECT    = 13366,
     SPELL_MOD_SPIRIT       = 13368,
-    SPELL_MOD_SPELL_POWER  = 18058,
+    SPELL_MOD_SPELL_POWER  = 22747,
 
     // custom spells
     SPELL_MOD_ARMOR        = 15170,


### PR DESCRIPTION
This adds .modify commands for all stats. It's a very nice feature to have when testing things, or even just for fun. And unlike the commands to modify hp and mana, these will not reset when you change items or are hit with an aura that changes your stats. Implemented using spells as requested by killerwife.

You can use this to clear all modifications:

> .reset mods