### PR TITLE
Fixed fishing from pools while in group

### DIFF
--- a/src/game/Loot/LootMgr.cpp
+++ b/src/game/Loot/LootMgr.cpp
@@ -471,7 +471,7 @@ LootSlotType LootItem::GetSlotTypeForSharedLoot(Player const* player, Loot const
         {
             if (!isBlocked)
             {
-                if (loot->m_isChest)
+                if (loot->m_isChest || loot->m_lootType == LOOT_FISHINGHOLE)
                     return LOOT_SLOT_NORMAL;
 
                 if (isReleased || currentLooterPass || player->GetObjectGuid() == loot->m_currentLooterGuid)
@@ -485,7 +485,7 @@ LootSlotType LootItem::GetSlotTypeForSharedLoot(Player const* player, Loot const
         {
             if (isUnderThreshold)
             {
-                if (loot->m_isChest)
+                if (loot->m_isChest || loot->m_lootType == LOOT_FISHINGHOLE)
                     return LOOT_SLOT_NORMAL;
 
                 if (isReleased || currentLooterPass || player->GetObjectGuid() == loot->m_currentLooterGuid)
@@ -505,7 +505,7 @@ LootSlotType LootItem::GetSlotTypeForSharedLoot(Player const* player, Loot const
         }
         case ROUND_ROBIN:
         {
-            if (loot->m_isChest)
+            if (loot->m_isChest || loot->m_lootType == LOOT_FISHINGHOLE)
                 return LOOT_SLOT_NORMAL;
 
             if (isReleased || currentLooterPass || player->GetObjectGuid() == loot->m_currentLooterGuid)
@@ -1023,6 +1023,9 @@ bool Loot::CanLoot(Player const* player)
         return true;
 
     if (m_lootMethod == NOT_GROUP_TYPE_LOOT || m_lootMethod == FREE_FOR_ALL)
+        return true;
+
+    if (m_lootType == LOOT_FISHINGHOLE)
         return true;
 
     if (m_haveItemOverThreshold)


### PR DESCRIPTION
## 🍰 Pullrequest
Fixed issue [2074](https://github.com/cmangos/issues/issues/2074)

### Proof
Fixed not only group loot but also master and round robin loots. Player can easily fish from pools and can loot them. Other party members just see what he received, and loot type has no influence on fishing from pools. Fishing outside of pools worked before and works after fix.

### Issues
- fixes https://github.com/cmangos/issues/issues/2074

### How2Test
- Create or take character with enough fishing skill to fish from pools
- Find any kind of pool (e.g. Oily Blackmouth School or Floating Debris) 
- Be in group with group loot (master and round robin can should also be checked)
- Group member should be near you
- Try fishing from the pool
- On successful try, see that you can loot goodies safely

### Todo / Checklist
- [X] None
