### PR TITLE
Fix Issue #2235: SMSG_SPELLDAMAGESHIELD sending incorrect values to set

### DIFF
--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -1979,10 +1979,9 @@ void Unit::DealMeleeDamage(CalcDamageInfo* calcDamageInfo, bool durabilityLoss)
 
                 Unit::DealDamageMods(victim, this, damage, nullptr, SPELL_DIRECT_DAMAGE, spellProto);
 
-                WorldPacket data(SMSG_SPELLDAMAGESHIELD, (8 + 8 + 4 + 4 + 4));
+                WorldPacket data(SMSG_SPELLDAMAGESHIELD, (8 + 8 + 4 + 4));
                 data << victim->GetObjectGuid();
                 data << GetObjectGuid();
-                data << uint32(spellProto->Id);
                 data << uint32(damage);                  // Damage
                 data << uint32(spellProto->School);
                 victim->SendMessageToSet(data, true);


### PR DESCRIPTION
## 🍰 Pullrequest
SpellId was being inserted into the SMSG_SPELLDAMAGESHIELD packet in void Unit::DealMeleeDamage, making it the damage and the damage the School. I simply reverted that section to how it was in commit 2484c82. This only affected the combat log and the scrolling combat text, not the actual damage being done.

### Proof
https://i.imgur.com/2hhsnJl.png
https://i.imgur.com/k91TOvb.png
https://i.imgur.com/splVxmr.jpg

### Issues
- fixes #2235

### How2Test
1. Use spell or item with Apply Aura: Damage shield on Apply Area Aura: Damage shield
2. Get attacked

### Todo / Checklist
Confirm the packet structure for SMSG_SPELLDAMAGESHIELD, check in tbc and wotlk as well (seems that wotlk just needs the overkill added)
