### PR TITLE
Hearthstone pet fix

### DIFF
--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -9949,7 +9949,7 @@ void Unit::RemoveAurasAtMechanicImmunity(uint32 mechMask, uint32 exceptSpellId, 
 void Unit::NearTeleportTo(float x, float y, float z, float orientation, bool casting /*= false*/)
 {
     if (GetTypeId() == TYPEID_PLAYER)
-        static_cast<Player*>(this)->TeleportTo(GetMapId(), x, y, z, orientation, TELE_TO_NOT_LEAVE_TRANSPORT | TELE_TO_NOT_LEAVE_COMBAT | TELE_TO_NOT_UNSUMMON_PET | (casting ? TELE_TO_SPELL : 0));
+        static_cast<Player*>(this)->TeleportTo(GetMapId(), x, y, z, orientation, TELE_TO_NOT_LEAVE_TRANSPORT | TELE_TO_NOT_LEAVE_COMBAT | (casting ? TELE_TO_SPELL : 0));
     else
     {
         DisableSpline();


### PR DESCRIPTION
## 🍰 Pullrequest
While playing WoW locally, I noticed that hearthstone did not teleport pet correctly.  They become unresponsive, you can't dismiss them and pet appears only after logout. If distance is small, pet will try running to you, which does not look "natural". 

### Proof
Captured few gifs so you can witness how fix works

![warlock](https://user-images.githubusercontent.com/2003618/90333275-caf72500-dfc4-11ea-9bf4-7cec9be39d26.gif)
![hunter](https://user-images.githubusercontent.com/2003618/90333425-e6aefb00-dfc5-11ea-8ab6-0b71e79cac90.gif)


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None. Decided to create PR straight away

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
1. Have class with pet as it's part (e.g. warlock/hunter)
2. Use hearthstone 
3. See that pet is teleport along with you

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
