### PR TITLE
Memory access fixes for AHBot and other classes

### DIFF
--- a/src/game/AI/BaseAI/UnitAI.cpp
+++ b/src/game/AI/BaseAI/UnitAI.cpp
@@ -42,7 +42,8 @@ UnitAI::UnitAI(Unit* unit) :
     m_meleeEnabled(true),
     m_reactState(REACT_AGGRESSIVE),
     m_combatScriptHappening(false),
-    m_currentAIOrder(ORDER_NONE)
+    m_currentAIOrder(ORDER_NONE),
+    m_selfRooted(false)
 {
 }
 

--- a/src/game/AI/BaseAI/UnitAI.cpp
+++ b/src/game/AI/BaseAI/UnitAI.cpp
@@ -43,7 +43,8 @@ UnitAI::UnitAI(Unit* unit) :
     m_reactState(REACT_AGGRESSIVE),
     m_combatScriptHappening(false),
     m_currentAIOrder(ORDER_NONE),
-    m_selfRooted(false)
+    m_selfRooted(false),
+    m_currentSpell(nullptr)
 {
 }
 

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/stormwind_city.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/stormwind_city.cpp
@@ -102,6 +102,8 @@ struct npc_dashel_stonefistAI : public ScriptedAI
 {
     npc_dashel_stonefistAI(Creature* pCreature) : ScriptedAI(pCreature)
     {
+        m_uiStartEventTimer = 0;
+        m_uiEndEventTimer = 0;
         Reset();
     }
 

--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/world_kalimdor.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/world_kalimdor.cpp
@@ -62,6 +62,7 @@ struct world_map_kalimdor : public ScriptedMap
         for (auto& riftList : m_aElementalRiftGUIDs)
             riftList.clear();
         m_uiDronesTimer = 0;
+        memset(&m_encounter, 0, sizeof(m_encounter));
     }
 
     void OnCreatureCreate(Creature* pCreature)

--- a/src/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -173,7 +173,7 @@ void AuctionHouseBot::Update()
         AddLootToItemMap(&LootTemplates_Skinning, m_skinningLootConfig, m_skinningLootTemplates, itemMap);                   // skinning loot
 
         // profession items are a bit different (not looted)
-        if (m_professionItemsConfig[1] > 0 && m_professionItemsConfig[3] > 0)
+        if (m_professionItemsConfig[1] > 0 && m_professionItemsConfig[3] > 0 && m_professionItems.size() > 0)
         {
             int32 maxTemplates = m_professionItemsConfig[0] < 0 ? urand(0, m_professionItemsConfig[1] + 1 - m_professionItemsConfig[0]) + m_professionItemsConfig[0] : urand(m_professionItemsConfig[0], m_professionItemsConfig[1] + 1);
             if (maxTemplates > 0)
@@ -455,7 +455,7 @@ void AuctionHouseBot::ParseItemValueConfig(char const* fieldname, std::vector<ui
 
 void AuctionHouseBot::AddLootToItemMap(LootStore* store, std::vector<int32>& lootConfig, std::vector<uint32>& lootTemplates, std::unordered_map<uint32, uint32>& itemMap)
 {
-    if (lootConfig[1] <= 0 || lootConfig[3] <= 0)
+    if (lootConfig[1] <= 0 || lootConfig[3] <= 0 || lootTemplates.size() <= 0)
         return;
     int32 maxTemplates = lootConfig[0] < 0 ? urand(0, lootConfig[1] + 1 - lootConfig[0]) + lootConfig[0] : urand(lootConfig[0], lootConfig[1] + 1);
     if (maxTemplates <= 0)

--- a/src/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -269,7 +269,7 @@ bool AuctionHouseBot::ReloadAllConfig()
 
 void AuctionHouseBot::Rebuild(bool all)
 {
-    sLog.outError("AHBot: Rebuilding auction house items");
+    sLog.outString("AHBot: Rebuilding auction house items");
     for (uint32 i = 0; i < MAX_AUCTION_HOUSE_TYPE; ++i)
     {
         AuctionHouseObject::AuctionEntryMapBounds bounds = sAuctionMgr.GetAuctionsMap(AuctionHouseType(i))->GetAuctionsBounds();

--- a/src/game/Combat/ThreatManager.cpp
+++ b/src/game/Combat/ThreatManager.cpp
@@ -85,6 +85,7 @@ HostileReference::HostileReference(Unit* unit, ThreatManager* threatManager, flo
     link(unit, threatManager);
     iUnitGuid = unit->GetObjectGuid();
     m_online = true;
+    m_suppresabilityToggle = false;
     iAccessible = true;
 }
 


### PR DESCRIPTION
## 🍰 Pullrequest
Ran classic core with Valgrind and discovered some out-of-bounds array access in AHBot as well as usage of uninitialized variables in other classes.

### Proof
See commit comments for stacktraces from Valgrind.

### Issues
- None

### How2Test
- None (or run classic core with `valgrind --track-origins=yes` before & after merging changes)

### Todo / Checklist
In Spell.cpp there is still an uninitialized variable being read, I did not dare touching this class. Here's the stacktrace from Valgrind:
```
Conditional jump or move depends on uninitialised value(s)
   at 0x72FE9E: Spell::CheckTarget(Unit*, SpellEffectIndex, bool, CheckException) const (Spell.cpp:6149)
   by 0x743A43: Spell::FillTargetMap() (Spell.cpp:532)
   by 0x744EF1: Spell::cast(bool) (Spell.cpp:2841)
   by 0x745845: Spell::SpellStart(SpellCastTargets const*, Aura*) (Spell.cpp:2592)
   by 0x5AD963: Unit::CastSpell(Unit*, SpellEntry const*, unsigned int, Item*, Aura*, ObjectGuid, SpellEntry const*) (Unit.cpp:1321)
   by 0x7C44BF: UnitAI::DoCastSpellIfCan(Unit*, unsigned int, unsigned int) (UnitAI.cpp:212)
   by 0x7CFD0D: CreatureEventAI::DoCastSpellIfCan(Unit*, unsigned int, unsigned int) (CreatureEventAI.cpp:1993)
   by 0x7D11EB: CreatureEventAI::ProcessAction(CreatureEventAI_Action const&, unsigned int, unsigned int, Unit*, Unit*, Unit*) (CreatureEventAI.cpp:788)
   by 0x7D0C65: ProcessEvent (CreatureEventAI.cpp:607)
   by 0x7D0C65: CreatureEventAI::ProcessEvents(Unit*, Unit*) (CreatureEventAI.cpp:267)
   by 0x7D8F5B: CreatureEventAI::JustRespawned() (CreatureEventAI.cpp:1343)
   by 0x4D0FBC: Creature::AIM_Initialize() (Creature.cpp:789)
   by 0x4D875C: Creature::LoadFromDB(unsigned int, Map*) (Creature.cpp:1520)
```

Another unresolved uninitialized value I've not looked into (yet):
```
Conditional jump or move depends on uninitialised value(s)
   at 0x5F5992: GameEventMgr::WeeklyEventTimerRecalculation() (GameEventMgr.cpp:1124)
   by 0x7A816F: World::Update(unsigned int) (World.cpp:1411)
   by 0x410F56: WorldRunnable::run() (WorldRunnable.cpp:59)
   by 0x5DB86DE: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25)
   by 0x4E436DA: start_thread (pthread_create.c:463)
   by 0x675BA3E: clone (clone.S:95)
```

And a couple more issues:
```
Conditional jump or move depends on uninitialised value(s)
   at 0x60B06D: ObjectMgr::ReturnOrDeleteOldMails(bool) (ObjectMgr.cpp:5219)
   by 0x7A8253: World::Update(unsigned int) (World.cpp:1423)
   by 0x410F56: WorldRunnable::run() (WorldRunnable.cpp:59)
   by 0x5DB86DE: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25)
   by 0x4E436DA: start_thread (pthread_create.c:463)
   by 0x675BA3E: clone (clone.S:95)
```
```
Use of uninitialised value of size 8
   at 0x66928FB: _itoa_word (_itoa.c:179)
   by 0x6695F9D: vfprintf (vfprintf.c:1642)
   by 0x676C318: __vsnprintf_chk (vsnprintf_chk.c:63)
   by 0x423F34: vsnprintf (stdio2.h:78)
   by 0x423F34: Database::PExecute(char const*, ...) (Database.cpp:356)
   by 0x60B083: ObjectMgr::ReturnOrDeleteOldMails(bool) (ObjectMgr.cpp:5220)
   by 0x7A8253: World::Update(unsigned int) (World.cpp:1423)
   by 0x410F56: WorldRunnable::run() (WorldRunnable.cpp:59)
   by 0x5DB86DE: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25)
   by 0x4E436DA: start_thread (pthread_create.c:463)
   by 0x675BA3E: clone (clone.S:95)
```