### PR TITLE
Feature cleanup playerbot nullable args

### DIFF
--- a/src/game/PlayerBot/AI/PlayerbotDruidAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotDruidAI.cpp
@@ -20,7 +20,7 @@
 
 class PlayerbotAI;
 
-PlayerbotDruidAI::PlayerbotDruidAI(Player* const master, Player* const bot, PlayerbotAI* const ai) : PlayerbotClassAI(master, bot, ai)
+PlayerbotDruidAI::PlayerbotDruidAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
 {
     MOONFIRE                      = m_ai->initSpell(MOONFIRE_1); // attacks
     STARFIRE                      = m_ai->initSpell(STARFIRE_1);

--- a/src/game/PlayerBot/AI/PlayerbotDruidAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotDruidAI.cpp
@@ -20,84 +20,84 @@
 
 class PlayerbotAI;
 
-PlayerbotDruidAI::PlayerbotDruidAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
+PlayerbotDruidAI::PlayerbotDruidAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(master, bot, ai)
 {
-    MOONFIRE                      = m_ai->initSpell(MOONFIRE_1); // attacks
-    STARFIRE                      = m_ai->initSpell(STARFIRE_1);
-    WRATH                         = m_ai->initSpell(WRATH_1);
-    ROOTS                         = m_ai->initSpell(ENTANGLING_ROOTS_1);
-    INSECT_SWARM                  = m_ai->initSpell(INSECT_SWARM_1);
-    MARK_OF_THE_WILD              = m_ai->initSpell(MARK_OF_THE_WILD_1); // buffs
-    GIFT_OF_THE_WILD              = m_ai->initSpell(GIFT_OF_THE_WILD_1);
-    THORNS                        = m_ai->initSpell(THORNS_1);
-    BARKSKIN                      = m_ai->initSpell(BARKSKIN_1);
-    HIBERNATE                     = m_ai->initSpell(HIBERNATE_1);
-    INNERVATE                     = m_ai->initSpell(INNERVATE_1);
-    FAERIE_FIRE                   = m_ai->initSpell(FAERIE_FIRE_1); // debuffs
-    FAERIE_FIRE_FERAL             = m_ai->initSpell(FAERIE_FIRE_FERAL_1);
-    REJUVENATION                  = m_ai->initSpell(REJUVENATION_1); // heals
-    REGROWTH                      = m_ai->initSpell(REGROWTH_1);
-    OMEN_OF_CLARITY               = m_ai->initSpell(OMEN_OF_CLARITY_1);
-    NATURES_SWIFTNESS             = m_ai->initSpell(NATURES_SWIFTNESS_DRUID_1);
-    HEALING_TOUCH                 = m_ai->initSpell(HEALING_TOUCH_1);
-    SWIFTMEND                     = m_ai->initSpell(SWIFTMEND_1);
-    TRANQUILITY                   = m_ai->initSpell(TRANQUILITY_1);
-    REBIRTH                       = m_ai->initSpell(REBIRTH_1);
-    REMOVE_CURSE                  = m_ai->initSpell(REMOVE_CURSE_DRUID_1);
-    CURE_POISON                   = m_ai->initSpell(CURE_POISON_1);
-    ABOLISH_POISON                = m_ai->initSpell(ABOLISH_POISON_1);
+    MOONFIRE                      = m_ai.initSpell(MOONFIRE_1); // attacks
+    STARFIRE                      = m_ai.initSpell(STARFIRE_1);
+    WRATH                         = m_ai.initSpell(WRATH_1);
+    ROOTS                         = m_ai.initSpell(ENTANGLING_ROOTS_1);
+    INSECT_SWARM                  = m_ai.initSpell(INSECT_SWARM_1);
+    MARK_OF_THE_WILD              = m_ai.initSpell(MARK_OF_THE_WILD_1); // buffs
+    GIFT_OF_THE_WILD              = m_ai.initSpell(GIFT_OF_THE_WILD_1);
+    THORNS                        = m_ai.initSpell(THORNS_1);
+    BARKSKIN                      = m_ai.initSpell(BARKSKIN_1);
+    HIBERNATE                     = m_ai.initSpell(HIBERNATE_1);
+    INNERVATE                     = m_ai.initSpell(INNERVATE_1);
+    FAERIE_FIRE                   = m_ai.initSpell(FAERIE_FIRE_1); // debuffs
+    FAERIE_FIRE_FERAL             = m_ai.initSpell(FAERIE_FIRE_FERAL_1);
+    REJUVENATION                  = m_ai.initSpell(REJUVENATION_1); // heals
+    REGROWTH                      = m_ai.initSpell(REGROWTH_1);
+    OMEN_OF_CLARITY               = m_ai.initSpell(OMEN_OF_CLARITY_1);
+    NATURES_SWIFTNESS             = m_ai.initSpell(NATURES_SWIFTNESS_DRUID_1);
+    HEALING_TOUCH                 = m_ai.initSpell(HEALING_TOUCH_1);
+    SWIFTMEND                     = m_ai.initSpell(SWIFTMEND_1);
+    TRANQUILITY                   = m_ai.initSpell(TRANQUILITY_1);
+    REBIRTH                       = m_ai.initSpell(REBIRTH_1);
+    REMOVE_CURSE                  = m_ai.initSpell(REMOVE_CURSE_DRUID_1);
+    CURE_POISON                   = m_ai.initSpell(CURE_POISON_1);
+    ABOLISH_POISON                = m_ai.initSpell(ABOLISH_POISON_1);
     // Druid Forms
-    MOONKIN_FORM                  = m_ai->initSpell(MOONKIN_FORM_1);
-    DIRE_BEAR_FORM                = m_ai->initSpell(DIRE_BEAR_FORM_1);
-    BEAR_FORM                     = m_ai->initSpell(BEAR_FORM_1);
-    CAT_FORM                      = m_ai->initSpell(CAT_FORM_1);
-    TRAVEL_FORM                   = m_ai->initSpell(TRAVEL_FORM_1);
+    MOONKIN_FORM                  = m_ai.initSpell(MOONKIN_FORM_1);
+    DIRE_BEAR_FORM                = m_ai.initSpell(DIRE_BEAR_FORM_1);
+    BEAR_FORM                     = m_ai.initSpell(BEAR_FORM_1);
+    CAT_FORM                      = m_ai.initSpell(CAT_FORM_1);
+    TRAVEL_FORM                   = m_ai.initSpell(TRAVEL_FORM_1);
     // Cat Attack type's
-    RAKE                          = m_ai->initSpell(RAKE_1);
-    CLAW                          = m_ai->initSpell(CLAW_1); // 45
-    COWER                         = m_ai->initSpell(COWER_1); // 20
-    SHRED                         = m_ai->initSpell(SHRED_1);
-    TIGERS_FURY                   = m_ai->initSpell(TIGERS_FURY_1);
+    RAKE                          = m_ai.initSpell(RAKE_1);
+    CLAW                          = m_ai.initSpell(CLAW_1); // 45
+    COWER                         = m_ai.initSpell(COWER_1); // 20
+    SHRED                         = m_ai.initSpell(SHRED_1);
+    TIGERS_FURY                   = m_ai.initSpell(TIGERS_FURY_1);
     // Cat Finishing Move's
-    RIP                           = m_ai->initSpell(RIP_1); // 30
-    FEROCIOUS_BITE                = m_ai->initSpell(FEROCIOUS_BITE_1); // 35
+    RIP                           = m_ai.initSpell(RIP_1); // 30
+    FEROCIOUS_BITE                = m_ai.initSpell(FEROCIOUS_BITE_1); // 35
     // Bear/Dire Bear Attacks & Buffs
-    BASH                          = m_ai->initSpell(BASH_1);
-    MAUL                          = m_ai->initSpell(MAUL_1); // 15
-    SWIPE                         = m_ai->initSpell(SWIPE_BEAR_1); // 20
-    DEMORALIZING_ROAR             = m_ai->initSpell(DEMORALIZING_ROAR_1); // 10
-    CHALLENGING_ROAR              = m_ai->initSpell(CHALLENGING_ROAR_1);
-    ENRAGE                        = m_ai->initSpell(ENRAGE_1);
-    GROWL                         = m_ai->initSpell(GROWL_1);
+    BASH                          = m_ai.initSpell(BASH_1);
+    MAUL                          = m_ai.initSpell(MAUL_1); // 15
+    SWIPE                         = m_ai.initSpell(SWIPE_BEAR_1); // 20
+    DEMORALIZING_ROAR             = m_ai.initSpell(DEMORALIZING_ROAR_1); // 10
+    CHALLENGING_ROAR              = m_ai.initSpell(CHALLENGING_ROAR_1);
+    ENRAGE                        = m_ai.initSpell(ENRAGE_1);
+    GROWL                         = m_ai.initSpell(GROWL_1);
 
     RECENTLY_BANDAGED             = 11196; // first aid check
 
     // racial
-    SHADOWMELD                    = m_ai->initSpell(SHADOWMELD_ALL);
-    WAR_STOMP                     = m_ai->initSpell(WAR_STOMP_ALL); // tauren
+    SHADOWMELD                    = m_ai.initSpell(SHADOWMELD_ALL);
+    WAR_STOMP                     = m_ai.initSpell(WAR_STOMP_ALL); // tauren
 }
 
 PlayerbotDruidAI::~PlayerbotDruidAI() {}
 
 CombatManeuverReturns PlayerbotDruidAI::DoFirstCombatManeuver(Unit* pTarget)
 {
-    bool meleeReach = m_bot->CanReachWithMeleeAttack(pTarget);
+    bool meleeReach = m_bot.CanReachWithMeleeAttack(pTarget);
     // There are NPCs in BGs and Open World PvP, so don't filter this on PvP scenarios (of course if PvP targets anyone but tank, all bets are off anyway)
     // Wait until the tank says so, until any non-tank gains aggro or X seconds - whichever is shortest
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->GroupTankHoldsAggro())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.GroupTankHoldsAggro())
         {
-            if (PlayerbotAI::ORDERS_TANK & m_ai->GetCombatOrder())
+            if (PlayerbotAI::ORDERS_TANK & m_ai.GetCombatOrder())
             {
                 if (meleeReach)
                 {
                     // Set everyone's UpdateAI() waiting to 2 seconds
-                    m_ai->SetGroupIgnoreUpdateTime(2);
+                    m_ai.SetGroupIgnoreUpdateTime(2);
                     // Clear their TEMP_WAIT_TANKAGGRO flag
-                    m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
+                    m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
                     // Start attacking, force target on current target
-                    m_ai->Attack(m_ai->GetCurrentTarget());
+                    m_ai.Attack(m_ai.GetCurrentTarget());
 
                     // While everyone else is waiting 2 second, we need to build up aggro, so don't return
                 }
@@ -107,26 +107,26 @@ CombatManeuverReturns PlayerbotDruidAI::DoFirstCombatManeuver(Unit* pTarget)
                     return RETURN_NO_ACTION_OK; // wait for target to get nearer
                 }
             }
-            else if (PlayerbotAI::ORDERS_HEAL & m_ai->GetCombatOrder())
+            else if (PlayerbotAI::ORDERS_HEAL & m_ai.GetCombatOrder())
                 return _DoNextPVECombatManeuverHeal();
             else
                 return RETURN_NO_ACTION_OK; // wait it out
         }
         else
         {
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
         }
     }
 
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->IsGroupReady())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.IsGroupReady())
             return RETURN_NO_ACTION_OK; // wait it out
         else
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
     }
 
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -154,7 +154,7 @@ CombatManeuverReturns PlayerbotDruidAI::DoFirstCombatManeuverPVP(Unit* /*pTarget
 
 CombatManeuverReturns PlayerbotDruidAI::DoNextCombatManeuver(Unit* pTarget)
 {
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -172,20 +172,17 @@ CombatManeuverReturns PlayerbotDruidAI::DoNextCombatManeuver(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotDruidAI::DoNextCombatManeuverPVE(Unit* pTarget)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
+    bool meleeReach = m_bot.CanReachWithMeleeAttack(pTarget);
 
-    bool meleeReach = m_bot->CanReachWithMeleeAttack(pTarget);
-
-    uint32 spec = m_bot->GetSpec();
+    uint32 spec = m_bot.GetSpec();
     if (spec == 0) // default to spellcasting or healing for healer
-        spec = (PlayerbotAI::ORDERS_HEAL & m_ai->GetCombatOrder() ? DRUID_SPEC_RESTORATION : DRUID_SPEC_BALANCE);
+        spec = (PlayerbotAI::ORDERS_HEAL & m_ai.GetCombatOrder() ? DRUID_SPEC_RESTORATION : DRUID_SPEC_BALANCE);
 
     // Make sure healer stays put, don't even melee (aggro) if in range: only melee if feral spec AND not healer
-    if (!m_ai->IsHealer() && spec == DRUID_SPEC_FERAL && m_ai->GetCombatStyle() != PlayerbotAI::COMBAT_MELEE)
-        m_ai->SetCombatStyle(PlayerbotAI::COMBAT_MELEE);
+    if (!m_ai.IsHealer() && spec == DRUID_SPEC_FERAL && m_ai.GetCombatStyle() != PlayerbotAI::COMBAT_MELEE)
+        m_ai.SetCombatStyle(PlayerbotAI::COMBAT_MELEE);
     else    // ranged combat in all other cases
-        m_ai->SetCombatStyle(PlayerbotAI::COMBAT_RANGED);
+        m_ai.SetCombatStyle(PlayerbotAI::COMBAT_RANGED);
 
     //Unit* pVictim = pTarget->GetVictim();
     uint32 BEAR = (DIRE_BEAR_FORM > 0 ? DIRE_BEAR_FORM : BEAR_FORM);
@@ -210,25 +207,25 @@ CombatManeuverReturns PlayerbotDruidAI::DoNextCombatManeuverPVE(Unit* pTarget)
 
     // Low mana and bot is a caster/healer: cast Innervate on self
     // TODO add group check to also cast on low mana healers or master
-    if (m_ai->GetManaPercent() < 15 && ((m_ai->IsHealer() || spec == DRUID_SPEC_RESTORATION)))
-        if (INNERVATE > 0 && !m_bot->HasAura(INNERVATE, EFFECT_INDEX_0) && CastSpell(INNERVATE, m_bot))
+    if (m_ai.GetManaPercent() < 15 && ((m_ai.IsHealer() || spec == DRUID_SPEC_RESTORATION)))
+        if (INNERVATE > 0 && !m_bot.HasAura(INNERVATE, EFFECT_INDEX_0) && CastSpell(INNERVATE, &m_bot))
             return RETURN_CONTINUE;
 
     //Used to determine if this bot is highest on threat
-    Unit* newTarget = m_ai->FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), m_bot);
-    if (newTarget && !(m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TANK) && !PlayerbotAI::IsNeutralized(newTarget)) // TODO: && party has a tank
+    Unit* newTarget = m_ai.FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), &m_bot);
+    if (newTarget && !(m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TANK) && !PlayerbotAI::IsNeutralized(newTarget)) // TODO: && party has a tank
     {
-        if (HealPlayer(m_bot) == RETURN_CONTINUE)
+        if (HealPlayer(&m_bot) == RETURN_CONTINUE)
             return RETURN_CONTINUE;
 
         // Aggroed by an elite that came in melee range
-        if (m_ai->IsElite(newTarget) && meleeReach)
+        if (m_ai.IsElite(newTarget) && meleeReach)
         {
             // protect the bot with barkskin: the increased casting time is meaningless
             // because bot will then avoid to cast to not angry mob further
-            if (m_ai->IsHealer() || spec == DRUID_SPEC_RESTORATION || spec == DRUID_SPEC_BALANCE)
+            if (m_ai.IsHealer() || spec == DRUID_SPEC_RESTORATION || spec == DRUID_SPEC_BALANCE)
             {
-                if (BARKSKIN > 0 && !m_bot->HasAura(BARKSKIN, EFFECT_INDEX_0) && CastSpell(BARKSKIN, m_bot))
+                if (BARKSKIN > 0 && !m_bot.HasAura(BARKSKIN, EFFECT_INDEX_0) && CastSpell(BARKSKIN, &m_bot))
                     return RETURN_CONTINUE;
 
                 return RETURN_NO_ACTION_OK;
@@ -237,22 +234,22 @@ CombatManeuverReturns PlayerbotDruidAI::DoNextCombatManeuverPVE(Unit* pTarget)
         }
     }
 
-    if (m_ai->IsHealer())
+    if (m_ai.IsHealer())
         if (_DoNextPVECombatManeuverHeal() & RETURN_CONTINUE)
             return RETURN_CONTINUE;
 
     switch (spec)
     {
         case DRUID_SPEC_FERAL:
-            if (BEAR > 0 && m_bot->HasAura(BEAR))
+            if (BEAR > 0 && m_bot.HasAura(BEAR))
                 return _DoNextPVECombatManeuverBear(pTarget);
-            if (CAT_FORM > 0 && m_bot->HasAura(CAT_FORM))
+            if (CAT_FORM > 0 && m_bot.HasAura(CAT_FORM))
                 return _DoNextPVECombatManeuverCat(pTarget);
         // NO break - failover to DRUID_SPEC_BALANCE
 
         case DRUID_SPEC_RESTORATION: // There is no Resto DAMAGE rotation. If you insist, go Balance...
         case DRUID_SPEC_BALANCE:
-            if (m_bot->HasAura(BEAR) || m_bot->HasAura(CAT_FORM))
+            if (m_bot.HasAura(BEAR) || m_bot.HasAura(CAT_FORM))
                 return RETURN_NO_ACTION_UNKNOWN; // Didn't shift out of inappropriate form
 
             return _DoNextPVECombatManeuverSpellDPS(pTarget);
@@ -271,7 +268,7 @@ CombatManeuverReturns PlayerbotDruidAI::DoNextCombatManeuverPVE(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotDruidAI::DoNextCombatManeuverPVP(Unit* pTarget)
 {
-    if (m_ai->CastSpell(MOONFIRE) == SPELL_CAST_OK)
+    if (m_ai.CastSpell(MOONFIRE) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
     return DoNextCombatManeuverPVE(pTarget); // TODO: bad idea perhaps, but better than the alternative
@@ -279,29 +276,26 @@ CombatManeuverReturns PlayerbotDruidAI::DoNextCombatManeuverPVP(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotDruidAI::_DoNextPVECombatManeuverBear(Unit* pTarget)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
-    if (!m_bot->HasAura((DIRE_BEAR_FORM > 0 ? DIRE_BEAR_FORM : BEAR_FORM))) return RETURN_NO_ACTION_ERROR;
+    if (!m_bot.HasAura((DIRE_BEAR_FORM > 0 ? DIRE_BEAR_FORM : BEAR_FORM))) return RETURN_NO_ACTION_ERROR;
 
     // Used to determine if this bot is highest on threat
-    Unit* newTarget = m_ai->FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), m_bot);
+    Unit* newTarget = m_ai.FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), &m_bot);
 
     // Face enemy, make sure you're attacking
-    m_ai->FaceTarget(pTarget);
+    m_ai.FaceTarget(pTarget);
 
-    if (PlayerbotAI::ORDERS_TANK & m_ai->GetCombatOrder() && !newTarget && GROWL > 0 && m_bot->IsSpellReady(GROWL))
+    if (PlayerbotAI::ORDERS_TANK & m_ai.GetCombatOrder() && !newTarget && GROWL > 0 && m_bot.IsSpellReady(GROWL))
         if (CastSpell(GROWL, pTarget))
             return RETURN_CONTINUE;
 
-    if (FAERIE_FIRE_FERAL > 0 && m_ai->In_Reach(pTarget, FAERIE_FIRE_FERAL) && !pTarget->HasAura(FAERIE_FIRE_FERAL, EFFECT_INDEX_0))
+    if (FAERIE_FIRE_FERAL > 0 && m_ai.In_Reach(pTarget, FAERIE_FIRE_FERAL) && !pTarget->HasAura(FAERIE_FIRE_FERAL, EFFECT_INDEX_0))
         if (CastSpell(FAERIE_FIRE_FERAL, pTarget))
             return RETURN_CONTINUE;
 
-    if (SWIPE > 0 && m_ai->In_Reach(pTarget, SWIPE) && m_ai->GetAttackerCount() >= 2 && CastSpell(SWIPE, pTarget))
+    if (SWIPE > 0 && m_ai.In_Reach(pTarget, SWIPE) && m_ai.GetAttackerCount() >= 2 && CastSpell(SWIPE, pTarget))
         return RETURN_CONTINUE;
 
-    if (ENRAGE > 0 && m_bot->IsSpellReady(ENRAGE) && CastSpell(ENRAGE, m_bot))
+    if (ENRAGE > 0 && m_bot.IsSpellReady(ENRAGE) && CastSpell(ENRAGE, &m_bot))
         return RETURN_CONTINUE;
 
     if (DEMORALIZING_ROAR > 0 && !pTarget->HasAura(DEMORALIZING_ROAR, EFFECT_INDEX_0) && CastSpell(DEMORALIZING_ROAR, pTarget))
@@ -315,19 +309,16 @@ CombatManeuverReturns PlayerbotDruidAI::_DoNextPVECombatManeuverBear(Unit* pTarg
 
 CombatManeuverReturns PlayerbotDruidAI::_DoNextPVECombatManeuverCat(Unit* pTarget)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
-    if (!m_bot->HasAura(CAT_FORM)) return RETURN_NO_ACTION_UNKNOWN;
+    if (!m_bot.HasAura(CAT_FORM)) return RETURN_NO_ACTION_UNKNOWN;
 
     //Used to determine if this bot is highest on threat
-    Unit* newTarget = m_ai->FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), m_bot);
+    Unit* newTarget = m_ai.FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), &m_bot);
 
     // Face enemy, make sure you're attacking
-    m_ai->FaceTarget(pTarget);
+    m_ai.FaceTarget(pTarget);
 
     // Attempt to do a finishing move
-    if (m_bot->GetComboPoints() >= 5)
+    if (m_bot.GetComboPoints() >= 5)
     {
         if (RIP > 0 && !pTarget->HasAura(RIP, EFFECT_INDEX_0))
         {
@@ -342,16 +333,16 @@ CombatManeuverReturns PlayerbotDruidAI::_DoNextPVECombatManeuverCat(Unit* pTarge
         }
     } // End 5 ComboPoints
 
-    if (newTarget && COWER > 0 && m_bot->IsSpellReady(COWER) && CastSpell(COWER, pTarget))
+    if (newTarget && COWER > 0 && m_bot.IsSpellReady(COWER) && CastSpell(COWER, pTarget))
         return RETURN_CONTINUE;
 
-    if (SHRED > 0 && pTarget->isInBackInMap(m_bot, 5.0f) && m_ai->CastSpell(SHRED, *pTarget) == SPELL_CAST_OK)
+    if (SHRED > 0 && pTarget->isInBackInMap(&m_bot, 5.0f) && m_ai.CastSpell(SHRED, *pTarget) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
-    if (FAERIE_FIRE_FERAL > 0 && m_ai->In_Reach(pTarget, FAERIE_FIRE_FERAL) && !pTarget->HasAura(FAERIE_FIRE_FERAL, EFFECT_INDEX_0) && CastSpell(FAERIE_FIRE_FERAL, pTarget))
+    if (FAERIE_FIRE_FERAL > 0 && m_ai.In_Reach(pTarget, FAERIE_FIRE_FERAL) && !pTarget->HasAura(FAERIE_FIRE_FERAL, EFFECT_INDEX_0) && CastSpell(FAERIE_FIRE_FERAL, pTarget))
         return RETURN_CONTINUE;
 
-    if (TIGERS_FURY > 0 && m_bot->IsSpellReady(TIGERS_FURY) && !m_bot->HasAura(TIGERS_FURY, EFFECT_INDEX_0) && CastSpell(TIGERS_FURY))
+    if (TIGERS_FURY > 0 && m_bot.IsSpellReady(TIGERS_FURY) && !m_bot.HasAura(TIGERS_FURY, EFFECT_INDEX_0) && CastSpell(TIGERS_FURY))
         return RETURN_CONTINUE;
 
     if (RAKE > 0 && !pTarget->HasAura(RAKE) && CastSpell(RAKE, pTarget))
@@ -365,13 +356,10 @@ CombatManeuverReturns PlayerbotDruidAI::_DoNextPVECombatManeuverCat(Unit* pTarge
 
 CombatManeuverReturns PlayerbotDruidAI::_DoNextPVECombatManeuverSpellDPS(Unit* pTarget)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
     uint32 NATURE = (STARFIRE > 0 ? STARFIRE : WRATH);
 
     // Dispel curse/poison
-    if (m_ai->HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
+    if (m_ai.HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
         return RETURN_CONTINUE;
 
     // Combat resurrection (only tanks or master. If other targets are required, let master explicitly ask to)
@@ -379,39 +367,36 @@ CombatManeuverReturns PlayerbotDruidAI::_DoNextPVECombatManeuverSpellDPS(Unit* p
         return RETURN_CONTINUE;
 
     // Face enemy, make sure you're attacking
-    m_ai->FaceTarget(pTarget);
+    m_ai.FaceTarget(pTarget);
 
-    if (FAERIE_FIRE > 0 && m_ai->In_Reach(pTarget, FAERIE_FIRE) && !pTarget->HasAura(FAERIE_FIRE, EFFECT_INDEX_0) && CastSpell(FAERIE_FIRE, pTarget))
+    if (FAERIE_FIRE > 0 && m_ai.In_Reach(pTarget, FAERIE_FIRE) && !pTarget->HasAura(FAERIE_FIRE, EFFECT_INDEX_0) && CastSpell(FAERIE_FIRE, pTarget))
         return RETURN_CONTINUE;
 
-    if (INSECT_SWARM > 0 && m_ai->In_Reach(pTarget, INSECT_SWARM) && !pTarget->HasAura(INSECT_SWARM, EFFECT_INDEX_0) && CastSpell(INSECT_SWARM, pTarget))
+    if (INSECT_SWARM > 0 && m_ai.In_Reach(pTarget, INSECT_SWARM) && !pTarget->HasAura(INSECT_SWARM, EFFECT_INDEX_0) && CastSpell(INSECT_SWARM, pTarget))
         return RETURN_CONTINUE;
 
     // Healer? Don't waste more mana on DPS
-    if (m_ai->IsHealer())
+    if (m_ai.IsHealer())
         return RETURN_NO_ACTION_OK;
 
-    if (MOONFIRE > 0 && m_ai->In_Reach(pTarget, MOONFIRE) && !pTarget->HasAura(MOONFIRE, EFFECT_INDEX_0) && CastSpell(MOONFIRE, pTarget))
+    if (MOONFIRE > 0 && m_ai.In_Reach(pTarget, MOONFIRE) && !pTarget->HasAura(MOONFIRE, EFFECT_INDEX_0) && CastSpell(MOONFIRE, pTarget))
         return RETURN_CONTINUE;
 
     if (NATURE > 0 && CastSpell(NATURE, pTarget))
         return RETURN_CONTINUE;
 
-    if (m_ai->GetCombatStyle() == PlayerbotAI::COMBAT_MELEE)
-        m_bot->Attack(pTarget, true);
+    if (m_ai.GetCombatStyle() == PlayerbotAI::COMBAT_MELEE)
+        m_bot.Attack(pTarget, true);
     else
-        m_bot->AttackStop();
+        m_bot.AttackStop();
 
     return RETURN_NO_ACTION_UNKNOWN;
 }
 
 CombatManeuverReturns PlayerbotDruidAI::_DoNextPVECombatManeuverHeal()
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
     // Dispel curse/poison
-    if (m_ai->HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
+    if (m_ai.HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
         return RETURN_CONTINUE;
 
     // Combat resurrection (only tanks or master. If other targets are required, let master explicitly requests it)
@@ -439,10 +424,10 @@ CombatManeuverReturns PlayerbotDruidAI::HealPlayer(Player* target)
     // TODO: This code should be common to all healers and will probably
     // move to a more suitable place like PlayerbotAI::DoCombatMovement()
     if ((GetTargetJob(target) == JOB_TANK || GetTargetJob(target) == JOB_MAIN_TANK)
-            && m_bot->GetPlayerbotAI()->GetMovementOrder() != PlayerbotAI::MOVEMENT_STAY
-            && !m_ai->In_Reach(target, HEALING_TOUCH))
+            && m_bot.GetPlayerbotAI()->GetMovementOrder() != PlayerbotAI::MOVEMENT_STAY
+            && !m_ai.In_Reach(target, HEALING_TOUCH))
     {
-        m_bot->GetMotionMaster()->MoveFollow(target, 39.0f, m_bot->GetOrientation());
+        m_bot.GetMotionMaster()->MoveFollow(target, 39.0f, m_bot.GetOrientation());
         return RETURN_CONTINUE;
     }
 
@@ -457,14 +442,14 @@ CombatManeuverReturns PlayerbotDruidAI::HealPlayer(Player* target)
             || (GetTargetJob(target) != JOB_TANK && GetTargetJob(target) != JOB_MAIN_TANK && hp < 15))
     {
         // first try Nature's Swiftness + Healing Touch: instant heal
-        if (NATURES_SWIFTNESS > 0 && m_bot->IsSpellReady(NATURES_SWIFTNESS))
-            CastSpell(NATURES_SWIFTNESS, m_bot);
+        if (NATURES_SWIFTNESS > 0 && m_bot.IsSpellReady(NATURES_SWIFTNESS))
+            CastSpell(NATURES_SWIFTNESS, &m_bot);
 
-        if (HEALING_TOUCH > 0 && m_bot->HasAura(NATURES_SWIFTNESS, EFFECT_INDEX_0) && m_ai->In_Reach(target, HEALING_TOUCH) && CastSpell(HEALING_TOUCH, target))
+        if (HEALING_TOUCH > 0 && m_bot.HasAura(NATURES_SWIFTNESS, EFFECT_INDEX_0) && m_ai.In_Reach(target, HEALING_TOUCH) && CastSpell(HEALING_TOUCH, target))
             return RETURN_CONTINUE;
 
         // Else try to Swiftmend the target if druid HoT is active on it
-        if (SWIFTMEND > 0 && m_bot->IsSpellReady(SWIFTMEND) && m_ai->In_Reach(target, SWIFTMEND) && (target->HasAura(REJUVENATION) || target->HasAura(REGROWTH)) && CastSpell(SWIFTMEND, target))
+        if (SWIFTMEND > 0 && m_bot.IsSpellReady(SWIFTMEND) && m_ai.In_Reach(target, SWIFTMEND) && (target->HasAura(REJUVENATION) || target->HasAura(REGROWTH)) && CastSpell(SWIFTMEND, target))
             return RETURN_CONTINUE;
     }
 
@@ -472,18 +457,18 @@ CombatManeuverReturns PlayerbotDruidAI::HealPlayer(Player* target)
     if (((GetTargetJob(target) == JOB_TANK || GetTargetJob(target) == JOB_MAIN_TANK) && hp < 15)
             || (GetTargetJob(target) != JOB_TANK && GetTargetJob(target) != JOB_MAIN_TANK && hp < 25))
     {
-        if (REGROWTH > 0 && m_ai->In_Reach(target, REGROWTH) && !target->HasAura(REGROWTH) && CastSpell(REGROWTH, target))
+        if (REGROWTH > 0 && m_ai.In_Reach(target, REGROWTH) && !target->HasAura(REGROWTH) && CastSpell(REGROWTH, target))
             return RETURN_CONTINUE;
-        if (REJUVENATION > 0 && m_ai->In_Reach(target, REJUVENATION) && target->HasAura(REGROWTH) && !target->HasAura(REJUVENATION) && CastSpell(REJUVENATION, target))
+        if (REJUVENATION > 0 && m_ai.In_Reach(target, REJUVENATION) && target->HasAura(REGROWTH) && !target->HasAura(REJUVENATION) && CastSpell(REJUVENATION, target))
             return RETURN_CONTINUE;
-        if (SWIFTMEND > 0 && m_bot->IsSpellReady(SWIFTMEND) && m_ai->In_Reach(target, SWIFTMEND) && (target->HasAura(REJUVENATION) || target->HasAura(REGROWTH)) && CastSpell(SWIFTMEND, target))
+        if (SWIFTMEND > 0 && m_bot.IsSpellReady(SWIFTMEND) && m_ai.In_Reach(target, SWIFTMEND) && (target->HasAura(REJUVENATION) || target->HasAura(REGROWTH)) && CastSpell(SWIFTMEND, target))
             return RETURN_CONTINUE;
     }
 
-    if (hp < 60 && HEALING_TOUCH > 0 && m_ai->In_Reach(target, HEALING_TOUCH) && CastSpell(HEALING_TOUCH, target))
+    if (hp < 60 && HEALING_TOUCH > 0 && m_ai.In_Reach(target, HEALING_TOUCH) && CastSpell(HEALING_TOUCH, target))
         return RETURN_CONTINUE;
 
-    if (hp < 80 && REJUVENATION > 0 && m_ai->In_Reach(target, REJUVENATION) && !target->HasAura(REJUVENATION) && CastSpell(REJUVENATION, target))
+    if (hp < 80 && REJUVENATION > 0 && m_ai.In_Reach(target, REJUVENATION) && !target->HasAura(REJUVENATION) && CastSpell(REJUVENATION, target))
         return RETURN_CONTINUE;
 
     return RETURN_NO_ACTION_UNKNOWN;
@@ -495,11 +480,11 @@ CombatManeuverReturns PlayerbotDruidAI::ResurrectPlayer(Player* target)
     if (r != RETURN_NO_ACTION_OK)
         return r;
 
-    if (REBIRTH > 0 && m_ai->In_Reach(target, REBIRTH) && m_bot->IsSpellReady(REBIRTH) && m_ai->CastSpell(REBIRTH, *target) == SPELL_CAST_OK)
+    if (REBIRTH > 0 && m_ai.In_Reach(target, REBIRTH) && m_bot.IsSpellReady(REBIRTH) && m_ai.CastSpell(REBIRTH, *target) == SPELL_CAST_OK)
     {
         std::string msg = "Resurrecting ";
         msg += target->GetName();
-        m_bot->Say(msg, LANG_UNIVERSAL);
+        m_bot.Say(msg, LANG_UNIVERSAL);
         return RETURN_CONTINUE;
     }
     return RETURN_NO_ACTION_ERROR; // not error per se - possibly just OOM
@@ -539,39 +524,36 @@ CombatManeuverReturns PlayerbotDruidAI::DispelPlayer(Player* /*target*/)
 */
 uint8 PlayerbotDruidAI::CheckForms()
 {
-    if (!m_ai)  return RETURN_FAIL;
-    if (!m_bot) return RETURN_FAIL;
-
-    uint32 spec = m_bot->GetSpec();
+    uint32 spec = m_bot.GetSpec();
     uint32 BEAR = (DIRE_BEAR_FORM > 0 ? DIRE_BEAR_FORM : BEAR_FORM);
 
     // if bot has healing orders always shift to humanoid form
     // regardless of spec
-    if (m_ai->IsHealer() || spec == DRUID_SPEC_RESTORATION)
+    if (m_ai.IsHealer() || spec == DRUID_SPEC_RESTORATION)
     {
-        if (m_bot->HasAura(CAT_FORM, EFFECT_INDEX_0))
+        if (m_bot.HasAura(CAT_FORM, EFFECT_INDEX_0))
         {
-            m_bot->RemoveAurasDueToSpell(CAT_FORM_1);
-            //m_ai->TellMaster("FormClearCat");
+            m_bot.RemoveAurasDueToSpell(CAT_FORM_1);
+            //m_ai.TellMaster("FormClearCat");
             return RETURN_OK_SHIFTING;
         }
-        if (m_bot->HasAura(BEAR_FORM, EFFECT_INDEX_0))
+        if (m_bot.HasAura(BEAR_FORM, EFFECT_INDEX_0))
         {
-            m_bot->RemoveAurasDueToSpell(BEAR_FORM_1);
-            //m_ai->TellMaster("FormClearBear");
+            m_bot.RemoveAurasDueToSpell(BEAR_FORM_1);
+            //m_ai.TellMaster("FormClearBear");
             return RETURN_OK_SHIFTING;
         }
-        if (m_bot->HasAura(DIRE_BEAR_FORM, EFFECT_INDEX_0))
+        if (m_bot.HasAura(DIRE_BEAR_FORM, EFFECT_INDEX_0))
         {
-            m_bot->RemoveAurasDueToSpell(DIRE_BEAR_FORM_1);
-            //m_ai->TellMaster("FormClearDireBear");
+            m_bot.RemoveAurasDueToSpell(DIRE_BEAR_FORM_1);
+            //m_ai.TellMaster("FormClearDireBear");
             return RETURN_OK_SHIFTING;
         }
         // spellcasting form, but disables healing spells so it's got to go
-        if (m_bot->HasAura(MOONKIN_FORM, EFFECT_INDEX_0))
+        if (m_bot.HasAura(MOONKIN_FORM, EFFECT_INDEX_0))
         {
-            m_bot->RemoveAurasDueToSpell(MOONKIN_FORM_1);
-            //m_ai->TellMaster("FormClearMoonkin");
+            m_bot.RemoveAurasDueToSpell(MOONKIN_FORM_1);
+            //m_ai.TellMaster("FormClearMoonkin");
             return RETURN_OK_SHIFTING;
         }
 
@@ -580,7 +562,7 @@ uint8 PlayerbotDruidAI::CheckForms()
 
     if (spec == DRUID_SPEC_BALANCE)
     {
-        if (m_bot->HasAura(MOONKIN_FORM))
+        if (m_bot.HasAura(MOONKIN_FORM))
             return RETURN_OK_NOCHANGE;
 
         if (!MOONKIN_FORM)
@@ -595,15 +577,15 @@ uint8 PlayerbotDruidAI::CheckForms()
     if (spec == DRUID_SPEC_FERAL)
     {
         // Use Bear form only if we are told we're a tank and have thorns up
-        if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TANK)
+        if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TANK)
         {
-            if (m_bot->HasAura(BEAR))
+            if (m_bot.HasAura(BEAR))
                 return RETURN_OK_NOCHANGE;
 
             if (!BEAR)
                 return RETURN_OK_CANNOTSHIFT;
 
-            if (!m_bot->HasAura(THORNS))
+            if (!m_bot.HasAura(THORNS))
                 return RETURN_FAIL_WAITINGONSELFBUFF;
 
             if (CastSpell(BEAR))
@@ -615,7 +597,7 @@ uint8 PlayerbotDruidAI::CheckForms()
         {
             if (CAT_FORM > 0)
             {
-                if (m_bot->HasAura(CAT_FORM))
+                if (m_bot.HasAura(CAT_FORM))
                     return RETURN_OK_NOCHANGE;
 
                 if (CastSpell(CAT_FORM))
@@ -626,7 +608,7 @@ uint8 PlayerbotDruidAI::CheckForms()
 
             if (BEAR > 0)
             {
-                if (m_bot->HasAura(BEAR))
+                if (m_bot.HasAura(BEAR))
                     return RETURN_OK_NOCHANGE;
 
                 if (CastSpell(BEAR))
@@ -645,20 +627,17 @@ uint8 PlayerbotDruidAI::CheckForms()
 
 void PlayerbotDruidAI::DoNonCombatActions()
 {
-    if (!m_ai)   return;
-    if (!m_bot)  return;
-
-    if (!m_bot->IsAlive() || m_bot->IsInDuel()) return;
+    if (!m_bot.IsAlive() || m_bot.IsInDuel()) return;
 
     // Revive
     // No auto-revive out of combat to preserve cooldown. Let master explicitly ask bot to cast Rebirth if needed
 
     // Dispel curse/poison
-    if (m_ai->HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
+    if (m_ai.HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
         return;
 
     // Heal
-    if (m_ai->IsHealer())
+    if (m_ai.IsHealer())
     {
         if (HealPlayer(GetHealTarget()) & RETURN_CONTINUE)
             return;// RETURN_CONTINUE;
@@ -667,40 +646,40 @@ void PlayerbotDruidAI::DoNonCombatActions()
     {
         // Is this desirable? Debatable.
         // TODO: In a group/raid with a healer you'd want this bot to focus on DPS (it's not specced/geared for healing either)
-        if (HealPlayer(m_bot) & RETURN_CONTINUE)
+        if (HealPlayer(&m_bot) & RETURN_CONTINUE)
             return;// RETURN_CONTINUE;
     }
 
     // Buff group
     // the check for group targets is performed by NeedGroupBuff (if group is found for bots by the function)
-    if (NeedGroupBuff(GIFT_OF_THE_WILD, MARK_OF_THE_WILD) && m_ai->HasSpellReagents(GIFT_OF_THE_WILD))
+    if (NeedGroupBuff(GIFT_OF_THE_WILD, MARK_OF_THE_WILD) && m_ai.HasSpellReagents(GIFT_OF_THE_WILD))
     {
         if (Buff(&PlayerbotDruidAI::BuffHelper, GIFT_OF_THE_WILD) & RETURN_CONTINUE)
             return;
     }
     else if (Buff(&PlayerbotDruidAI::BuffHelper, MARK_OF_THE_WILD) & RETURN_CONTINUE)
         return;
-    if (Buff(&PlayerbotDruidAI::BuffHelper, THORNS, (m_bot->GetGroup() ? JOB_TANK | JOB_MAIN_TANK : JOB_ALL)) & RETURN_CONTINUE)
+    if (Buff(&PlayerbotDruidAI::BuffHelper, THORNS, (m_bot.GetGroup() ? JOB_TANK | JOB_MAIN_TANK : JOB_ALL)) & RETURN_CONTINUE)
         return;
-    if (OMEN_OF_CLARITY > 0 && !m_bot->HasAura(OMEN_OF_CLARITY) && CastSpell(OMEN_OF_CLARITY, m_bot))
+    if (OMEN_OF_CLARITY > 0 && !m_bot.HasAura(OMEN_OF_CLARITY) && CastSpell(OMEN_OF_CLARITY, &m_bot))
         return;
 
     // hp/mana check
     if (EatDrinkBandage())
         return;
 
-    if (INNERVATE > 0 && m_ai->In_Reach(m_bot, INNERVATE) && !m_bot->HasAura(INNERVATE) && m_ai->GetManaPercent() <= 20 && CastSpell(INNERVATE, m_bot))
+    if (INNERVATE > 0 && m_ai.In_Reach(&m_bot, INNERVATE) && !m_bot.HasAura(INNERVATE) && m_ai.GetManaPercent() <= 20 && CastSpell(INNERVATE, &m_bot))
         return;
 
     // Return to fighting form AFTER reviving, healing, buffing
     CheckForms();
 
     // Nothing else to do, Night Elves will cast Shadowmeld to reduce their aggro versus patrols or nearby mobs
-    if (SHADOWMELD > 0 && !m_bot->isMovingOrTurning()
-        && !m_bot->IsMounted()
-        && !m_bot->HasAura(SHADOWMELD, EFFECT_INDEX_0))
+    if (SHADOWMELD > 0 && !m_bot.isMovingOrTurning()
+        && !m_bot.IsMounted()
+        && !m_bot.HasAura(SHADOWMELD, EFFECT_INDEX_0))
     {
-        m_ai->CastSpell(SHADOWMELD, *m_bot);
+        m_ai.CastSpell(SHADOWMELD, m_bot);
     }
 } // end DoNonCombatActions
 
@@ -747,13 +726,11 @@ bool PlayerbotDruidAI::Pull()
 
 bool PlayerbotDruidAI::CastHoTOnTank()
 {
-    if (!m_ai) return false;
-
-    if ((PlayerbotAI::ORDERS_HEAL & m_ai->GetCombatOrder()) == 0) return false;
+    if ((PlayerbotAI::ORDERS_HEAL & m_ai.GetCombatOrder()) == 0) return false;
 
     // Druid HoTs: Rejuvenation, Regrowth, Tranquility (channeled, AoE)
     if (REJUVENATION > 0)
-        return (RETURN_CONTINUE & CastSpell(REJUVENATION, m_ai->GetGroupTank()));
+        return (RETURN_CONTINUE & CastSpell(REJUVENATION, m_ai.GetGroupTank()));
 
     return false;
 }
@@ -761,13 +738,11 @@ bool PlayerbotDruidAI::CastHoTOnTank()
 // Return to UpdateAI the spellId usable to neutralize a target with creaturetype
 uint32 PlayerbotDruidAI::Neutralize(uint8 creatureType)
 {
-    if (!m_bot)         return 0;
-    if (!m_ai)          return 0;
     if (!creatureType)  return 0;
 
     if (creatureType != CREATURE_TYPE_DRAGONKIN && creatureType != CREATURE_TYPE_BEAST)
     {
-        m_ai->TellMaster("I can't make that target hibernate.");
+        m_ai.TellMaster("I can't make that target hibernate.");
         return 0;
     }
 

--- a/src/game/PlayerBot/AI/PlayerbotDruidAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotDruidAI.h
@@ -87,23 +87,23 @@ class MANGOS_DLL_SPEC PlayerbotDruidAI : PlayerbotClassAI
         virtual ~PlayerbotDruidAI();
 
         // all combat actions go here
-        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget);
-        bool CanPull();
-        bool Pull();
-        uint32 Neutralize(uint8 creatureType);
+        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget) override;
+        bool CanPull() override;
+        bool Pull() override;
+        uint32 Neutralize(uint8 creatureType) override;
 
         // all non combat actions go here, ex buffs, heals, rezzes
-        void DoNonCombatActions();
+        void DoNonCombatActions() override;
 
         // Utility Functions
         bool CastHoTOnTank();
 
     private:
-        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget);
+        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget) override;
 
         CombatManeuverReturns CastSpell(uint32 nextAction, Unit* pTarget = nullptr) { return CastSpellNoRanged(nextAction, pTarget); }
 
@@ -114,9 +114,9 @@ class MANGOS_DLL_SPEC PlayerbotDruidAI : PlayerbotClassAI
         CombatManeuverReturns _DoNextPVECombatManeuverHeal();
 
         // Heals the target based off its hps
-        CombatManeuverReturns HealPlayer(Player* target);
+        CombatManeuverReturns HealPlayer(Player* target) override;
         // Resurrects the target
-        CombatManeuverReturns ResurrectPlayer(Player* target);
+        CombatManeuverReturns ResurrectPlayer(Player* target) override;
         // Dispel disease or negative magic effects from an internally selected target
         CombatManeuverReturns DispelPlayer(Player* target = nullptr);
 

--- a/src/game/PlayerBot/AI/PlayerbotDruidAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotDruidAI.h
@@ -83,7 +83,7 @@ enum DruidSpells
 class MANGOS_DLL_SPEC PlayerbotDruidAI : PlayerbotClassAI
 {
     public:
-        PlayerbotDruidAI(Player* const master, Player* const bot, PlayerbotAI* const ai);
+        PlayerbotDruidAI(Player& master, Player& bot, PlayerbotAI& ai);
         virtual ~PlayerbotDruidAI();
 
         // all combat actions go here

--- a/src/game/PlayerBot/AI/PlayerbotHunterAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotHunterAI.cpp
@@ -21,7 +21,7 @@
 
 class PlayerbotAI;
 
-PlayerbotHunterAI::PlayerbotHunterAI(Player* const master, Player* const bot, PlayerbotAI* const ai) : PlayerbotClassAI(master, bot, ai)
+PlayerbotHunterAI::PlayerbotHunterAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
 {
     // PET CTRL
     PET_SUMMON                    = m_ai->initSpell(CALL_PET_1);

--- a/src/game/PlayerBot/AI/PlayerbotHunterAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotHunterAI.cpp
@@ -21,17 +21,17 @@
 
 class PlayerbotAI;
 
-PlayerbotHunterAI::PlayerbotHunterAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
+PlayerbotHunterAI::PlayerbotHunterAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(master, bot, ai)
 {
     // PET CTRL
-    PET_SUMMON                    = m_ai->initSpell(CALL_PET_1);
-    PET_DISMISS                   = m_ai->initSpell(DISMISS_PET_1);
-    PET_REVIVE                    = m_ai->initSpell(REVIVE_PET_1);
-    PET_MEND                      = m_ai->initSpell(MEND_PET_1);
+    PET_SUMMON                    = m_ai.initSpell(CALL_PET_1);
+    PET_DISMISS                   = m_ai.initSpell(DISMISS_PET_1);
+    PET_REVIVE                    = m_ai.initSpell(REVIVE_PET_1);
+    PET_MEND                      = m_ai.initSpell(MEND_PET_1);
     PET_FEED                      = 1539;
-    BESTIAL_WRATH                 = m_ai->initSpell(BESTIAL_WRATH_1);
+    BESTIAL_WRATH                 = m_ai.initSpell(BESTIAL_WRATH_1);
 
-    INTIMIDATION                  = m_ai->initSpell(INTIMIDATION_1); // (generic)
+    INTIMIDATION                  = m_ai.initSpell(INTIMIDATION_1); // (generic)
 
     // PET SKILLS must be initialized by pets
     SONIC_BLAST                   = 0; // bat
@@ -39,49 +39,49 @@ PlayerbotHunterAI::PlayerbotHunterAI(Player& master, Player& bot, PlayerbotAI& a
     BAD_ATTITUDE                  = 0; // crocolisk
 
     // RANGED COMBAT
-    AUTO_SHOT                     = m_ai->initSpell(AUTO_SHOT_1);
-    HUNTERS_MARK                  = m_ai->initSpell(HUNTERS_MARK_1);
-    ARCANE_SHOT                   = m_ai->initSpell(ARCANE_SHOT_1);
-    CONCUSSIVE_SHOT               = m_ai->initSpell(CONCUSSIVE_SHOT_1);
-    DISTRACTING_SHOT              = m_ai->initSpell(DISTRACTING_SHOT_1);
-    MULTI_SHOT                    = m_ai->initSpell(MULTISHOT_1);
-    SERPENT_STING                 = m_ai->initSpell(SERPENT_STING_1);
-    SCORPID_STING                 = m_ai->initSpell(SCORPID_STING_1);
-    WYVERN_STING                  = m_ai->initSpell(WYVERN_STING_1);
-    VIPER_STING                   = m_ai->initSpell(VIPER_STING_1);
-    AIMED_SHOT                    = m_ai->initSpell(AIMED_SHOT_1);
-    VOLLEY                        = m_ai->initSpell(VOLLEY_1);
-    BLACK_ARROW                   = m_ai->initSpell(BLACK_ARROW_1);
-    TRANQUILIZING_SHOT            = m_ai->initSpell(TRANQUILIZING_SHOT_1);
+    AUTO_SHOT                     = m_ai.initSpell(AUTO_SHOT_1);
+    HUNTERS_MARK                  = m_ai.initSpell(HUNTERS_MARK_1);
+    ARCANE_SHOT                   = m_ai.initSpell(ARCANE_SHOT_1);
+    CONCUSSIVE_SHOT               = m_ai.initSpell(CONCUSSIVE_SHOT_1);
+    DISTRACTING_SHOT              = m_ai.initSpell(DISTRACTING_SHOT_1);
+    MULTI_SHOT                    = m_ai.initSpell(MULTISHOT_1);
+    SERPENT_STING                 = m_ai.initSpell(SERPENT_STING_1);
+    SCORPID_STING                 = m_ai.initSpell(SCORPID_STING_1);
+    WYVERN_STING                  = m_ai.initSpell(WYVERN_STING_1);
+    VIPER_STING                   = m_ai.initSpell(VIPER_STING_1);
+    AIMED_SHOT                    = m_ai.initSpell(AIMED_SHOT_1);
+    VOLLEY                        = m_ai.initSpell(VOLLEY_1);
+    BLACK_ARROW                   = m_ai.initSpell(BLACK_ARROW_1);
+    TRANQUILIZING_SHOT            = m_ai.initSpell(TRANQUILIZING_SHOT_1);
 
     // MELEE
-    RAPTOR_STRIKE                 = m_ai->initSpell(RAPTOR_STRIKE_1);
-    WING_CLIP                     = m_ai->initSpell(WING_CLIP_1);
-    MONGOOSE_BITE                 = m_ai->initSpell(MONGOOSE_BITE_1);
-    DISENGAGE                     = m_ai->initSpell(DISENGAGE_1);
-    DETERRENCE                    = m_ai->initSpell(DETERRENCE_1);
-    FEIGN_DEATH                   = m_ai->initSpell(FEIGN_DEATH_1);
+    RAPTOR_STRIKE                 = m_ai.initSpell(RAPTOR_STRIKE_1);
+    WING_CLIP                     = m_ai.initSpell(WING_CLIP_1);
+    MONGOOSE_BITE                 = m_ai.initSpell(MONGOOSE_BITE_1);
+    DISENGAGE                     = m_ai.initSpell(DISENGAGE_1);
+    DETERRENCE                    = m_ai.initSpell(DETERRENCE_1);
+    FEIGN_DEATH                   = m_ai.initSpell(FEIGN_DEATH_1);
 
     // TRAPS
-    FREEZING_TRAP                 = m_ai->initSpell(FREEZING_TRAP_1);
-    IMMOLATION_TRAP               = m_ai->initSpell(IMMOLATION_TRAP_1);
-    FROST_TRAP                    = m_ai->initSpell(FROST_TRAP_1);
-    EXPLOSIVE_TRAP                = m_ai->initSpell(EXPLOSIVE_TRAP_1);
+    FREEZING_TRAP                 = m_ai.initSpell(FREEZING_TRAP_1);
+    IMMOLATION_TRAP               = m_ai.initSpell(IMMOLATION_TRAP_1);
+    FROST_TRAP                    = m_ai.initSpell(FROST_TRAP_1);
+    EXPLOSIVE_TRAP                = m_ai.initSpell(EXPLOSIVE_TRAP_1);
 
     // BUFFS
-    ASPECT_OF_THE_HAWK            = m_ai->initSpell(ASPECT_OF_THE_HAWK_1);
-    ASPECT_OF_THE_MONKEY          = m_ai->initSpell(ASPECT_OF_THE_MONKEY_1);
-    RAPID_FIRE                    = m_ai->initSpell(RAPID_FIRE_1);
-    TRUESHOT_AURA                 = m_ai->initSpell(TRUESHOT_AURA_1);
+    ASPECT_OF_THE_HAWK            = m_ai.initSpell(ASPECT_OF_THE_HAWK_1);
+    ASPECT_OF_THE_MONKEY          = m_ai.initSpell(ASPECT_OF_THE_MONKEY_1);
+    RAPID_FIRE                    = m_ai.initSpell(RAPID_FIRE_1);
+    TRUESHOT_AURA                 = m_ai.initSpell(TRUESHOT_AURA_1);
 
     RECENTLY_BANDAGED             = 11196; // first aid check
 
     // racial
-    STONEFORM                     = m_ai->initSpell(STONEFORM_ALL); // dwarf
-    SHADOWMELD                    = m_ai->initSpell(SHADOWMELD_ALL);
-    BLOOD_FURY                    = m_ai->initSpell(BLOOD_FURY_ALL); // orc
-    WAR_STOMP                     = m_ai->initSpell(WAR_STOMP_ALL); // tauren
-    BERSERKING                    = m_ai->initSpell(BERSERKING_ALL); // troll
+    STONEFORM                     = m_ai.initSpell(STONEFORM_ALL); // dwarf
+    SHADOWMELD                    = m_ai.initSpell(SHADOWMELD_ALL);
+    BLOOD_FURY                    = m_ai.initSpell(BLOOD_FURY_ALL); // orc
+    WAR_STOMP                     = m_ai.initSpell(WAR_STOMP_ALL); // tauren
+    BERSERKING                    = m_ai.initSpell(BERSERKING_ALL); // troll
 
     m_petSummonFailed = false;
     m_rangedCombat = true;
@@ -91,39 +91,38 @@ PlayerbotHunterAI::~PlayerbotHunterAI() {}
 
 CombatManeuverReturns PlayerbotHunterAI::DoFirstCombatManeuver(Unit* pTarget)
 {
-    Player* m_bot = GetPlayerBot();
-    m_has_ammo = m_bot->HasItemCount(m_bot->GetUInt32Value(PLAYER_AMMO_ID), 1);
-    DEBUG_LOG("current ammo (%u)", m_bot->GetUInt32Value(PLAYER_AMMO_ID));
-    m_bot->setAttackTimer(RANGED_ATTACK, 0);
+    m_has_ammo = m_bot.HasItemCount(m_bot.GetUInt32Value(PLAYER_AMMO_ID), 1);
+    DEBUG_LOG("current ammo (%u)", m_bot.GetUInt32Value(PLAYER_AMMO_ID));
+    m_bot.setAttackTimer(RANGED_ATTACK, 0);
     if (!m_has_ammo)
     {
-        m_ai->FindAmmo();
-        //DEBUG_LOG("new ammo (%u)",m_bot->GetUInt32Value(PLAYER_AMMO_ID));
-        m_has_ammo = m_bot->HasItemCount(m_bot->GetUInt32Value(PLAYER_AMMO_ID), 1);
+        m_ai.FindAmmo();
+        //DEBUG_LOG("new ammo (%u)",m_bot.GetUInt32Value(PLAYER_AMMO_ID));
+        m_has_ammo = m_bot.HasItemCount(m_bot.GetUInt32Value(PLAYER_AMMO_ID), 1);
     }
     // There are NPCs in BGs and Open World PvP, so don't filter this on PvP scenarios (of course if PvP targets anyone but tank, all bets are off anyway)
     // Wait until the tank says so, until any non-tank gains aggro or X seconds - whichever is shortest
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->GroupTankHoldsAggro())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.GroupTankHoldsAggro())
         {
             return RETURN_NO_ACTION_OK; // wait it out
         }
         else
         {
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
         }
     }
 
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->IsGroupReady())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.IsGroupReady())
             return RETURN_NO_ACTION_OK; // wait it out
         else
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
     }
 
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -158,9 +157,9 @@ CombatManeuverReturns PlayerbotHunterAI::DoFirstCombatManeuverPVP(Unit* /*pTarge
 CombatManeuverReturns PlayerbotHunterAI::DoNextCombatManeuver(Unit* pTarget)
 {
     // Face enemy, make sure bot is attacking
-    m_ai->FaceTarget(pTarget);
+    m_ai.FaceTarget(pTarget);
 
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -177,77 +176,75 @@ CombatManeuverReturns PlayerbotHunterAI::DoNextCombatManeuver(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotHunterAI::DoNextCombatManeuverPVE(Unit* pTarget)
 {
-    if (!m_ai)    return RETURN_NO_ACTION_ERROR;
-    if (!m_bot)   return RETURN_NO_ACTION_ERROR;
     if (!pTarget) return RETURN_NO_ACTION_ERROR;
 
     Unit* pVictim = pTarget->GetVictim();
 
     // check for pet and heal if neccessary
-    Pet* pet = m_bot->GetPet();
+    Pet* pet = m_bot.GetPet();
     // TODO: clarify/simplify: !pet->GetDeathState() != ALIVE
-    if (pet && PET_MEND > 0 && pet->IsAlive() && pet->GetHealthPercent() < 50 && pVictim != m_bot && !pet->HasAura(PET_MEND, EFFECT_INDEX_0) && m_ai->CastSpell(PET_MEND, *m_bot) == SPELL_CAST_OK)
+    if (pet && PET_MEND > 0 && pet->IsAlive() && pet->GetHealthPercent() < 50 && pVictim != &m_bot && !pet->HasAura(PET_MEND, EFFECT_INDEX_0) && m_ai.CastSpell(PET_MEND, m_bot) == SPELL_CAST_OK)
     {
-        m_ai->TellMaster("healing pet.");
+        m_ai.TellMaster("healing pet.");
         return RETURN_CONTINUE;
     }
-    else if (pet && INTIMIDATION > 0 && pVictim == pet && !pet->HasAura(INTIMIDATION, EFFECT_INDEX_0) && m_ai->CastSpell(INTIMIDATION, *m_bot) == SPELL_CAST_OK)
+    else if (pet && INTIMIDATION > 0 && pVictim == pet && !pet->HasAura(INTIMIDATION, EFFECT_INDEX_0) && m_ai.CastSpell(INTIMIDATION, m_bot) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
     /*    // racial traits
-        if (m_bot->getRace() == RACE_ORC && !m_bot->HasAura(BLOOD_FURY, EFFECT_INDEX_0))
-            m_ai->CastSpell(BLOOD_FURY, *m_bot);
-        else if (m_bot->getRace() == RACE_TROLL && !m_bot->HasAura(BERSERKING, EFFECT_INDEX_0))
-            m_ai->CastSpell(BERSERKING, *m_bot);
+        if (m_bot.getRace() == RACE_ORC && !m_bot.HasAura(BLOOD_FURY, EFFECT_INDEX_0))
+            m_ai.CastSpell(BLOOD_FURY, m_bot);
+        else if (m_bot.getRace() == RACE_TROLL && !m_bot.HasAura(BERSERKING, EFFECT_INDEX_0))
+            m_ai.CastSpell(BERSERKING, m_bot);
     */
     // check if ranged combat is possible: by default chose ranged combat
-    bool meleeReach = m_bot->CanReachWithMeleeAttack(pTarget);
+    bool meleeReach = m_bot.CanReachWithMeleeAttack(pTarget);
 
     if (!meleeReach && m_has_ammo)
     {
         // switch to ranged combat
         m_rangedCombat = true;
-        m_ai->SetCombatStyle(PlayerbotAI::COMBAT_RANGED);
+        m_ai.SetCombatStyle(PlayerbotAI::COMBAT_RANGED);
 
         // increase ranged attack power...
-        if (ASPECT_OF_THE_HAWK > 0 && !m_bot->HasAura(ASPECT_OF_THE_HAWK, EFFECT_INDEX_0))
-            m_ai->CastSpell(ASPECT_OF_THE_HAWK, *m_bot);
+        if (ASPECT_OF_THE_HAWK > 0 && !m_bot.HasAura(ASPECT_OF_THE_HAWK, EFFECT_INDEX_0))
+            m_ai.CastSpell(ASPECT_OF_THE_HAWK, m_bot);
     }
     else
     {
         // switch to melee combat (target in melee range, out of ammo)
         m_rangedCombat = false;
-        m_ai->SetCombatStyle(PlayerbotAI::COMBAT_MELEE);
-        if (!m_bot->GetUInt32Value(PLAYER_AMMO_ID))
-            m_ai->TellMaster("Out of ammo!");
+        m_ai.SetCombatStyle(PlayerbotAI::COMBAT_MELEE);
+        if (!m_bot.GetUInt32Value(PLAYER_AMMO_ID))
+            m_ai.TellMaster("Out of ammo!");
 
         // become monkey (increases dodge chance)...
-        if (ASPECT_OF_THE_MONKEY > 0 && !m_bot->HasAura(ASPECT_OF_THE_MONKEY, EFFECT_INDEX_0))
-            m_ai->CastSpell(ASPECT_OF_THE_MONKEY, *m_bot);
+        if (ASPECT_OF_THE_MONKEY > 0 && !m_bot.HasAura(ASPECT_OF_THE_MONKEY, EFFECT_INDEX_0))
+            m_ai.CastSpell(ASPECT_OF_THE_MONKEY, m_bot);
     }
 
-    if (TRANQUILIZING_SHOT > 0 && IsTargetEnraged(pTarget) && m_bot->IsSpellReady(TRANQUILIZING_SHOT) && m_ai->CastSpell(TRANQUILIZING_SHOT, *pTarget) == SPELL_CAST_OK)
+    if (TRANQUILIZING_SHOT > 0 && IsTargetEnraged(pTarget) && m_bot.IsSpellReady(TRANQUILIZING_SHOT) && m_ai.CastSpell(TRANQUILIZING_SHOT, *pTarget) == SPELL_CAST_OK)
     {
-        m_ai->TellMaster("Casting TRANQUILIZING SHOT onto %s", pTarget->GetName());
+        m_ai.TellMaster("Casting TRANQUILIZING SHOT onto %s", pTarget->GetName());
         return RETURN_CONTINUE;
     }
 
     //Used to determine if this bot has highest threat
-    Unit* newTarget = m_ai->FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), m_bot);
+    Unit* newTarget = m_ai.FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), &m_bot);
     // Aggro management
     if (newTarget && !PlayerbotAI::IsNeutralized(newTarget)) // TODO: && party has a tank
     {
         // Aggroed by an elite
-        if (m_ai->IsElite(newTarget))
+        if (m_ai.IsElite(newTarget))
         {
             // Try to disengage
-            if (DISENGAGE > 0 && m_bot->IsSpellReady(DISENGAGE) && m_ai->In_Reach(newTarget, DISENGAGE) && m_ai->CastSpell(DISENGAGE, *newTarget) == SPELL_CAST_OK)
+            if (DISENGAGE > 0 && m_bot.IsSpellReady(DISENGAGE) && m_ai.In_Reach(newTarget, DISENGAGE) && m_ai.CastSpell(DISENGAGE, *newTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
             // Increase dodge and parry chance
-            if (DETERRENCE > 0 && m_bot->IsSpellReady(DETERRENCE) && !m_bot->HasAura(DETERRENCE, EFFECT_INDEX_0) && m_ai->CastSpell(DETERRENCE, *m_bot) == SPELL_CAST_OK)
+            if (DETERRENCE > 0 && m_bot.IsSpellReady(DETERRENCE) && !m_bot.HasAura(DETERRENCE, EFFECT_INDEX_0) && m_ai.CastSpell(DETERRENCE, m_bot) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
             // Else feign death if low on health or attacked by a worldboss
-            if (FEIGN_DEATH > 0 && (m_ai->GetHealthPercent() <= 20 || m_ai->IsElite(pTarget, true)) && m_bot->IsSpellReady(FEIGN_DEATH) && !m_bot->HasAura(FEIGN_DEATH, EFFECT_INDEX_0) && m_ai->CastSpell(FEIGN_DEATH, *m_bot) == SPELL_CAST_OK)
+            if (FEIGN_DEATH > 0 && (m_ai.GetHealthPercent() <= 20 || m_ai.IsElite(pTarget, true)) && m_bot.IsSpellReady(FEIGN_DEATH) && !m_bot.HasAura(FEIGN_DEATH, EFFECT_INDEX_0) && m_ai.CastSpell(FEIGN_DEATH, m_bot) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
         }
     }
@@ -255,78 +252,78 @@ CombatManeuverReturns PlayerbotHunterAI::DoNextCombatManeuverPVE(Unit* pTarget)
     // Distance management: avoid to be in the dead zone where neither melee nor range can be used: keep distance whenever possible
     // If not in range: come closer
     // Do not do it if passive or stay orders.
-    if (!m_ai->In_Reach(pTarget, AUTO_SHOT) &&
-            !(m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_PASSIVE) &&
-            (m_bot->GetPlayerbotAI()->GetMovementOrder() != PlayerbotAI::MOVEMENT_STAY))
+    if (!m_ai.In_Reach(pTarget, AUTO_SHOT) &&
+            !(m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_PASSIVE) &&
+            (m_bot.GetPlayerbotAI()->GetMovementOrder() != PlayerbotAI::MOVEMENT_STAY))
     {
-        m_ai->InterruptCurrentCastingSpell();
-        m_bot->GetMotionMaster()->MoveFollow(pTarget, 20.0f, m_bot->GetOrientation());
+        m_ai.InterruptCurrentCastingSpell();
+        m_bot.GetMotionMaster()->MoveFollow(pTarget, 20.0f, m_bot.GetOrientation());
         return RETURN_CONTINUE;
     }
     // If below ranged combat distance and bot is not attacked by target
     // make it flee from target for a few seconds to get in ranged distance again
     // Do not do it if passive or stay orders.
-    if (pVictim != m_bot && m_bot->GetDistance(pTarget, true, DIST_CALC_COMBAT_REACH_WITH_MELEE) <= 8.0f &&
-            !(m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_PASSIVE) &&
-            (m_bot->GetPlayerbotAI()->GetMovementOrder() != PlayerbotAI::MOVEMENT_STAY))
+    if (pVictim != &m_bot && m_bot.GetDistance(pTarget, true, DIST_CALC_COMBAT_REACH_WITH_MELEE) <= 8.0f &&
+            !(m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_PASSIVE) &&
+            (m_bot.GetPlayerbotAI()->GetMovementOrder() != PlayerbotAI::MOVEMENT_STAY))
     {
-        m_ai->InterruptCurrentCastingSpell();
-        m_ai->SetIgnoreUpdateTime(2);
-        m_bot->GetMotionMaster()->Clear(false);
-        m_bot->GetMotionMaster()->MoveFleeing(pTarget, 2);
+        m_ai.InterruptCurrentCastingSpell();
+        m_ai.SetIgnoreUpdateTime(2);
+        m_bot.GetMotionMaster()->Clear(false);
+        m_bot.GetMotionMaster()->MoveFleeing(pTarget, 2);
         return RETURN_CONTINUE;
     }
 
     // damage spells
-    if (m_ai->GetCombatStyle() == PlayerbotAI::COMBAT_RANGED)
+    if (m_ai.GetCombatStyle() == PlayerbotAI::COMBAT_RANGED)
     {
         // Debuff target
-        if (HUNTERS_MARK > 0 && m_ai->In_Reach(pTarget, HUNTERS_MARK) && !pTarget->HasAura(HUNTERS_MARK, EFFECT_INDEX_0) && m_ai->CastSpell(HUNTERS_MARK, *pTarget) == SPELL_CAST_OK)
+        if (HUNTERS_MARK > 0 && m_ai.In_Reach(pTarget, HUNTERS_MARK) && !pTarget->HasAura(HUNTERS_MARK, EFFECT_INDEX_0) && m_ai.CastSpell(HUNTERS_MARK, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
         // Buff self
-        if (RAPID_FIRE > 0 && !m_bot->HasAura(RAPID_FIRE, EFFECT_INDEX_0) && m_bot->IsSpellReady(RAPID_FIRE) && m_ai->CastSpell(RAPID_FIRE, *m_bot) == SPELL_CAST_OK)
+        if (RAPID_FIRE > 0 && !m_bot.HasAura(RAPID_FIRE, EFFECT_INDEX_0) && m_bot.IsSpellReady(RAPID_FIRE) && m_ai.CastSpell(RAPID_FIRE, m_bot) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (ARCANE_SHOT > 0 && m_bot->IsSpellReady(ARCANE_SHOT) && m_ai->In_Range(pTarget, ARCANE_SHOT) && m_ai->CastSpell(ARCANE_SHOT, *pTarget) == SPELL_CAST_OK)
+        if (ARCANE_SHOT > 0 && m_bot.IsSpellReady(ARCANE_SHOT) && m_ai.In_Range(pTarget, ARCANE_SHOT) && m_ai.CastSpell(ARCANE_SHOT, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
         // Stings: only use Viper and Serpent sting. Stats decrease (Scorpid Sting) is useless in PvE
         // and as the bot is obviously not alone and assisting someone, no need to put the target to sleep (Wyvern Sting)
         // Viper sting for non-worldboss mana users
-        if (pTarget->GetPower(POWER_MANA) > 0 && !m_ai->IsElite(pTarget, true))
+        if (pTarget->GetPower(POWER_MANA) > 0 && !m_ai.IsElite(pTarget, true))
         {
-            if (VIPER_STING > 0 && m_ai->In_Range(pTarget, VIPER_STING) && !pTarget->HasAura(VIPER_STING, EFFECT_INDEX_0) && m_ai->CastSpell(VIPER_STING, *pTarget) == SPELL_CAST_OK)
+            if (VIPER_STING > 0 && m_ai.In_Range(pTarget, VIPER_STING) && !pTarget->HasAura(VIPER_STING, EFFECT_INDEX_0) && m_ai.CastSpell(VIPER_STING, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
         }
         // Serpent sting for everyone else
         else
         {
-            if (SERPENT_STING > 0 && m_ai->In_Range(pTarget, SERPENT_STING) && !pTarget->HasAura(SERPENT_STING, EFFECT_INDEX_0) && m_ai->CastSpell(SERPENT_STING, *pTarget) == SPELL_CAST_OK)
+            if (SERPENT_STING > 0 && m_ai.In_Range(pTarget, SERPENT_STING) && !pTarget->HasAura(SERPENT_STING, EFFECT_INDEX_0) && m_ai.CastSpell(SERPENT_STING, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
         }
-        if (CONCUSSIVE_SHOT > 0 && m_ai->In_Range(pTarget, CONCUSSIVE_SHOT) && !pTarget->HasAura(CONCUSSIVE_SHOT, EFFECT_INDEX_0) && m_ai->CastSpell(CONCUSSIVE_SHOT, *pTarget) == SPELL_CAST_OK)
+        if (CONCUSSIVE_SHOT > 0 && m_ai.In_Range(pTarget, CONCUSSIVE_SHOT) && !pTarget->HasAura(CONCUSSIVE_SHOT, EFFECT_INDEX_0) && m_ai.CastSpell(CONCUSSIVE_SHOT, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (BLACK_ARROW > 0 && m_ai->In_Range(pTarget, BLACK_ARROW) && !pTarget->HasAura(BLACK_ARROW, EFFECT_INDEX_0) && m_ai->CastSpell(BLACK_ARROW, *pTarget) == SPELL_CAST_OK)
+        if (BLACK_ARROW > 0 && m_ai.In_Range(pTarget, BLACK_ARROW) && !pTarget->HasAura(BLACK_ARROW, EFFECT_INDEX_0) && m_ai.CastSpell(BLACK_ARROW, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (AIMED_SHOT > 0 && m_bot->IsSpellReady(AIMED_SHOT) && m_ai->In_Range(pTarget, AIMED_SHOT) && m_ai->CastSpell(AIMED_SHOT, *pTarget) == SPELL_CAST_OK)
+        if (AIMED_SHOT > 0 && m_bot.IsSpellReady(AIMED_SHOT) && m_ai.In_Range(pTarget, AIMED_SHOT) && m_ai.CastSpell(AIMED_SHOT, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
 
-//       if (MULTI_SHOT > 0 && m_bot->IsSpellReady(MULTI_SHOT) && m_ai->In_Range(pTarget,MULTI_SHOT) && m_ai->GetAttackerCount() >= 3 && m_ai->CastSpell(MULTI_SHOT, *pTarget) == SPELL_CAST_OK)
+//       if (MULTI_SHOT > 0 && m_bot.IsSpellReady(MULTI_SHOT) && m_ai.In_Range(pTarget,MULTI_SHOT) && m_ai.GetAttackerCount() >= 3 && m_ai.CastSpell(MULTI_SHOT, *pTarget) == SPELL_CAST_OK)
 //            return RETURN_CONTINUE;
-//       if (VOLLEY > 0 && m_ai->In_Range(pTarget,VOLLEY) && m_ai->GetAttackerCount() >= 3 && m_ai->CastSpell(VOLLEY, *pTarget) == SPELL_CAST_OK)
+//       if (VOLLEY > 0 && m_ai.In_Range(pTarget,VOLLEY) && m_ai.GetAttackerCount() >= 3 && m_ai.CastSpell(VOLLEY, *pTarget) == SPELL_CAST_OK)
 //           return RETURN_CONTINUE;
 
         // Auto shot
-        // m_ai->TellMaster("target dist %f",m_bot->GetCombatDistance(pTarget,true));
+        // m_ai.TellMaster("target dist %f",m_bot.GetCombatDistance(pTarget,true));
         if (AUTO_SHOT > 0)
         {
-            if (m_bot->isAttackReady(RANGED_ATTACK))
-                m_bot->CastSpell(pTarget, AUTO_SHOT, TRIGGERED_OLD_TRIGGERED);
+            if (m_bot.isAttackReady(RANGED_ATTACK))
+                m_bot.CastSpell(pTarget, AUTO_SHOT, TRIGGERED_OLD_TRIGGERED);
 
             const SpellEntry* spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(AUTO_SHOT);
             if (!spellInfo)
                 return RETURN_CONTINUE;
 
-            if (!(m_ai->CheckBotCast(spellInfo) == SPELL_CAST_OK))
-                m_bot->InterruptNonMeleeSpells(true, AUTO_SHOT);
+            if (!(m_ai.CheckBotCast(spellInfo) == SPELL_CAST_OK))
+                m_bot.InterruptNonMeleeSpells(true, AUTO_SHOT);
 
             return RETURN_CONTINUE;
         }
@@ -335,25 +332,25 @@ CombatManeuverReturns PlayerbotHunterAI::DoNextCombatManeuverPVE(Unit* pTarget)
     }
     else
     {
-        if (MONGOOSE_BITE > 0 && m_bot->RollMeleeOutcomeAgainst(pTarget, BASE_ATTACK, SPELL_SCHOOL_MASK_NORMAL) == MELEE_HIT_DODGE && m_ai->CastSpell(MONGOOSE_BITE, *pTarget) == SPELL_CAST_OK)
+        if (MONGOOSE_BITE > 0 && m_bot.RollMeleeOutcomeAgainst(pTarget, BASE_ATTACK, SPELL_SCHOOL_MASK_NORMAL) == MELEE_HIT_DODGE && m_ai.CastSpell(MONGOOSE_BITE, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (RAPTOR_STRIKE > 0 && m_bot->IsSpellReady(RAPTOR_STRIKE) && m_ai->In_Reach(pTarget, RAPTOR_STRIKE) && m_ai->CastSpell(RAPTOR_STRIKE, *pTarget) == SPELL_CAST_OK)
+        if (RAPTOR_STRIKE > 0 && m_bot.IsSpellReady(RAPTOR_STRIKE) && m_ai.In_Reach(pTarget, RAPTOR_STRIKE) && m_ai.CastSpell(RAPTOR_STRIKE, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (EXPLOSIVE_TRAP > 0 && !pTarget->HasAura(EXPLOSIVE_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(IMMOLATION_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(FROST_TRAP, EFFECT_INDEX_0) && m_ai->CastSpell(EXPLOSIVE_TRAP, *pTarget) == SPELL_CAST_OK)
+        if (EXPLOSIVE_TRAP > 0 && !pTarget->HasAura(EXPLOSIVE_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(IMMOLATION_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(FROST_TRAP, EFFECT_INDEX_0) && m_ai.CastSpell(EXPLOSIVE_TRAP, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (WING_CLIP > 0 && m_bot->IsSpellReady(WING_CLIP) && m_ai->In_Reach(pTarget, WING_CLIP) && !pTarget->HasAura(WING_CLIP, EFFECT_INDEX_0) && m_ai->CastSpell(WING_CLIP, *pTarget) == SPELL_CAST_OK)
+        if (WING_CLIP > 0 && m_bot.IsSpellReady(WING_CLIP) && m_ai.In_Reach(pTarget, WING_CLIP) && !pTarget->HasAura(WING_CLIP, EFFECT_INDEX_0) && m_ai.CastSpell(WING_CLIP, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (IMMOLATION_TRAP > 0 && !pTarget->HasAura(IMMOLATION_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(EXPLOSIVE_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(FROST_TRAP, EFFECT_INDEX_0) && m_ai->CastSpell(IMMOLATION_TRAP, *pTarget) == SPELL_CAST_OK)
+        if (IMMOLATION_TRAP > 0 && !pTarget->HasAura(IMMOLATION_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(EXPLOSIVE_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(FROST_TRAP, EFFECT_INDEX_0) && m_ai.CastSpell(IMMOLATION_TRAP, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (FROST_TRAP > 0 && !pTarget->HasAura(FROST_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(IMMOLATION_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(EXPLOSIVE_TRAP, EFFECT_INDEX_0) && m_ai->CastSpell(FROST_TRAP, *pTarget) == SPELL_CAST_OK)
+        if (FROST_TRAP > 0 && !pTarget->HasAura(FROST_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(IMMOLATION_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(EXPLOSIVE_TRAP, EFFECT_INDEX_0) && m_ai.CastSpell(FROST_TRAP, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
 
-//        if (m_bot->getRace() == RACE_TAUREN && !pTarget->HasAura(WAR_STOMP, EFFECT_INDEX_0) && m_ai->CastSpell(WAR_STOMP, *pTarget) == SPELL_CAST_OK)
+//        if (m_bot.getRace() == RACE_TAUREN && !pTarget->HasAura(WAR_STOMP, EFFECT_INDEX_0) && m_ai.CastSpell(WAR_STOMP, *pTarget) == SPELL_CAST_OK)
 //            return RETURN_CONTINUE;
-//        else if (m_bot->getRace() == RACE_DWARF && m_bot->HasAuraState(AURA_STATE_DEADLY_POISON) && m_ai->CastSpell(STONEFORM, *m_bot) == SPELL_CAST_OK)
+//        else if (m_bot.getRace() == RACE_DWARF && m_bot.HasAuraState(AURA_STATE_DEADLY_POISON) && m_ai.CastSpell(STONEFORM, m_bot) == SPELL_CAST_OK)
 //            return RETURN_CONTINUE;
 
-        /*else if(FREEZING_TRAP > 0 && !pTarget->HasAura(FREEZING_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(ARCANE_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(EXPLOSIVE_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(BEAR_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(IMMOLATION_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(FROST_TRAP, EFFECT_INDEX_0) && m_ai->CastSpell(FREEZING_TRAP,*pTarget) == SPELL_CAST_OK)
+        /*else if(FREEZING_TRAP > 0 && !pTarget->HasAura(FREEZING_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(ARCANE_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(EXPLOSIVE_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(BEAR_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(IMMOLATION_TRAP, EFFECT_INDEX_0) && !pTarget->HasAura(FROST_TRAP, EFFECT_INDEX_0) && m_ai.CastSpell(FREEZING_TRAP,*pTarget) == SPELL_CAST_OK)
             out << " > Freezing Trap"; // this can trap your bots too
         */
     }
@@ -363,7 +360,7 @@ CombatManeuverReturns PlayerbotHunterAI::DoNextCombatManeuverPVE(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotHunterAI::DoNextCombatManeuverPVP(Unit* pTarget)
 {
-    if (m_ai->CastSpell(RAPTOR_STRIKE) == SPELL_CAST_OK)
+    if (m_ai.CastSpell(RAPTOR_STRIKE) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
     return DoNextCombatManeuverPVE(pTarget); // TODO: bad idea perhaps, but better than the alternative
@@ -371,8 +368,6 @@ CombatManeuverReturns PlayerbotHunterAI::DoNextCombatManeuverPVP(Unit* pTarget)
 
 bool PlayerbotHunterAI::IsTargetEnraged(Unit* pTarget)
 {
-    if (!m_ai)  return false;
-    if (!m_bot) return false;
     if (!pTarget) return false;
 
     Unit::SpellAuraHolderMap const& auras = pTarget->GetSpellAuraHolderMap();
@@ -389,84 +384,81 @@ bool PlayerbotHunterAI::IsTargetEnraged(Unit* pTarget)
 
 void PlayerbotHunterAI::DoNonCombatActions()
 {
-    if (!m_ai)  return;
-    if (!m_bot) return;
-
-    if (!m_rangedCombat || m_ai->GetCombatStyle() == PlayerbotAI::COMBAT_MELEE)
+    if (!m_rangedCombat || m_ai.GetCombatStyle() == PlayerbotAI::COMBAT_MELEE)
     {
         m_rangedCombat = true;
-        m_ai->SetCombatStyle(PlayerbotAI::COMBAT_RANGED);
+        m_ai.SetCombatStyle(PlayerbotAI::COMBAT_RANGED);
     }
 
     // buff group
-    if (TRUESHOT_AURA > 0 && !m_bot->HasAura(TRUESHOT_AURA, EFFECT_INDEX_0))
-        m_ai->CastSpell(TRUESHOT_AURA, *m_bot);
+    if (TRUESHOT_AURA > 0 && !m_bot.HasAura(TRUESHOT_AURA, EFFECT_INDEX_0))
+        m_ai.CastSpell(TRUESHOT_AURA, m_bot);
 
     // buff myself
-    if (ASPECT_OF_THE_HAWK > 0 && !m_bot->HasAura(ASPECT_OF_THE_HAWK, EFFECT_INDEX_0))
-        m_ai->CastSpell(ASPECT_OF_THE_HAWK, *m_bot);
+    if (ASPECT_OF_THE_HAWK > 0 && !m_bot.HasAura(ASPECT_OF_THE_HAWK, EFFECT_INDEX_0))
+        m_ai.CastSpell(ASPECT_OF_THE_HAWK, m_bot);
 
     // hp/mana check
     if (EatDrinkBandage())
         return;
 
     // check for pet
-    if (PET_SUMMON > 0 && !m_petSummonFailed && HasPet(m_bot))
+    if (PET_SUMMON > 0 && !m_petSummonFailed && HasPet(&m_bot))
     {
         // we can summon pet, and no critical summon errors before
-        Pet* pet = m_bot->GetPet();
+        Pet* pet = m_bot.GetPet();
         if (!pet)    // Hunter has pet but it is not found: dismissed or dead and corpse was removed
         {
             // summon pet
-            SpellCastResult res = m_ai->CastSpell(PET_SUMMON, *m_bot);
+            SpellCastResult res = m_ai.CastSpell(PET_SUMMON, m_bot);
             switch (res)
             {
                 case SPELL_CAST_OK:
-                    m_ai->TellMaster("summoning pet.");
+                    m_ai.TellMaster("summoning pet.");
                     break;
                 case SPELL_FAILED_DONT_REPORT:
                     if (PET_REVIVE > 0)
                     {
-                        switch (m_ai->CastSpell(PET_REVIVE, *m_bot))
+                        switch (m_ai.CastSpell(PET_REVIVE, m_bot))
                         {
                             case SPELL_CAST_OK:
-                                m_ai->TellMaster("Pet is dead, reviving it.");
+                                m_ai.TellMaster("Pet is dead, reviving it.");
                                 break;
                             case SPELL_FAILED_NO_POWER: // Not enough mana, just wait for it
                                 break;
                             default:
                                 m_petSummonFailed = true;
-                                m_ai->TellMaster("summon pet failed!");
+                                m_ai.TellMaster("summon pet failed!");
                         }
                     }
                     break;
                 case SPELL_FAILED_NO_PET:   // This should not happen as if we went this far, there is a pet entry in the DB
                     m_petSummonFailed = true;
-                    m_ai->TellMaster("I don't appear to have a pet. Weird...");
+                    m_ai.TellMaster("I don't appear to have a pet. Weird...");
                     break;
                 default:                    // Also, pure sanity check: should never happen unless there is an error elsewhere
                     m_petSummonFailed = true;
-                    m_ai->TellMaster("summon pet failed!");
+                    m_ai.TellMaster("summon pet failed!");
                     break;
             }
         }
         else if (!(pet->IsAlive()))
         {
-            if (PET_REVIVE > 0 && m_ai->CastSpell(PET_REVIVE, *m_bot) == SPELL_CAST_OK)
-                m_ai->TellMaster("reviving pet.");
+            if (PET_REVIVE > 0 && m_ai.CastSpell(PET_REVIVE, m_bot) == SPELL_CAST_OK)
+                m_ai.TellMaster("reviving pet.");
         }
         else if (pet->GetHealthPercent() < 50)
         {
-            if (PET_MEND > 0 && pet->IsAlive() && !pet->HasAura(PET_MEND, EFFECT_INDEX_0) && m_ai->CastSpell(PET_MEND, *m_bot) == SPELL_CAST_OK)
-                m_ai->TellMaster("healing pet.");
+            if (PET_MEND > 0 && pet->IsAlive() && !pet->HasAura(PET_MEND, EFFECT_INDEX_0) && m_ai.CastSpell(PET_MEND, m_bot) == SPELL_CAST_OK)
+                m_ai.TellMaster("healing pet.");
         }
         else if (pet->GetHappinessState() != HAPPY) // if pet is hungry
         {
-            Unit* caster = (Unit*) m_bot;
+            Unit& caster = m_bot;
             // list out items in main backpack
             for (uint8 slot = INVENTORY_SLOT_ITEM_START; slot < INVENTORY_SLOT_ITEM_END; slot++)
             {
-                Item* const pItem = m_bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+                Item* const pItem = m_bot.GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
                 if (pItem)
                 {
                     const ItemPrototype* const pItemProto = pItem->GetProto();
@@ -476,13 +468,13 @@ void PlayerbotHunterAI::DoNonCombatActions()
                     if (pet->HaveInDiet(pItemProto)) // is pItem in pets diet
                     {
                         // DEBUG_LOG ("[PlayerbotHunterAI]: DoNonCombatActions - Food for pet: %s",pItemProto->Name1);
-                        caster->CastSpell(caster, 23355, TRIGGERED_OLD_TRIGGERED); // pet feed visual
+                        caster.CastSpell(&caster, 23355, TRIGGERED_OLD_TRIGGERED); // pet feed visual
                         uint32 count = 1; // number of items used
                         int32 benefit = pet->GetCurrentFoodBenefitLevel(pItemProto->ItemLevel); // nutritional value of food
-                        m_bot->DestroyItemCount(pItem, count, true); // remove item from inventory
-                        m_bot->CastCustomSpell(m_bot, PET_FEED, &benefit, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED); // feed pet
-                        m_ai->TellMaster("feeding pet.");
-                        m_ai->SetIgnoreUpdateTime(10);
+                        m_bot.DestroyItemCount(pItem, count, true); // remove item from inventory
+                        m_bot.CastCustomSpell(&m_bot, PET_FEED, &benefit, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED); // feed pet
+                        m_ai.TellMaster("feeding pet.");
+                        m_ai.SetIgnoreUpdateTime(10);
                         return;
                     }
                 }
@@ -490,11 +482,11 @@ void PlayerbotHunterAI::DoNonCombatActions()
             // list out items in other removable backpacks
             for (uint8 bag = INVENTORY_SLOT_BAG_START; bag < INVENTORY_SLOT_BAG_END; ++bag)
             {
-                const Bag* const pBag = (Bag*) m_bot->GetItemByPos(INVENTORY_SLOT_BAG_0, bag);
+                const Bag* const pBag = (Bag*) m_bot.GetItemByPos(INVENTORY_SLOT_BAG_0, bag);
                 if (pBag)
                     for (uint8 slot = 0; slot < pBag->GetBagSize(); ++slot)
                     {
-                        Item* const pItem = m_bot->GetItemByPos(bag, slot);
+                        Item* const pItem = m_bot.GetItemByPos(bag, slot);
                         if (pItem)
                         {
                             const ItemPrototype* const pItemProto = pItem->GetProto();
@@ -504,29 +496,29 @@ void PlayerbotHunterAI::DoNonCombatActions()
                             if (pet->HaveInDiet(pItemProto)) // is pItem in pets diet
                             {
                                 // DEBUG_LOG ("[PlayerbotHunterAI]: DoNonCombatActions - Food for pet: %s",pItemProto->Name1);
-                                caster->CastSpell(caster, 23355, TRIGGERED_OLD_TRIGGERED); // pet feed visual
+                                caster.CastSpell(&caster, 23355, TRIGGERED_OLD_TRIGGERED); // pet feed visual
                                 uint32 count = 1; // number of items used
                                 int32 benefit = pet->GetCurrentFoodBenefitLevel(pItemProto->ItemLevel); // nutritional value of food
-                                m_bot->DestroyItemCount(pItem, count, true); // remove item from inventory
-                                m_bot->CastCustomSpell(m_bot, PET_FEED, &benefit, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED); // feed pet
-                                m_ai->TellMaster("feeding pet.");
-                                m_ai->SetIgnoreUpdateTime(10);
+                                m_bot.DestroyItemCount(pItem, count, true); // remove item from inventory
+                                m_bot.CastCustomSpell(&m_bot, PET_FEED, &benefit, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED); // feed pet
+                                m_ai.TellMaster("feeding pet.");
+                                m_ai.SetIgnoreUpdateTime(10);
                                 return;
                             }
                         }
                     }
             }
             if (pet->HasAura(PET_MEND, EFFECT_INDEX_0) && !pet->HasAura(PET_FEED, EFFECT_INDEX_0))
-                m_ai->TellMaster("..no pet food!");
-            m_ai->SetIgnoreUpdateTime(7);
+                m_ai.TellMaster("..no pet food!");
+            m_ai.SetIgnoreUpdateTime(7);
         }
     }
 
     // Nothing else to do, Night Elves will cast Shadowmeld to reduce their aggro versus patrols or nearby mobs
-    if (SHADOWMELD > 0 && !m_bot->isMovingOrTurning()
-        && !m_bot->IsMounted()
-        && !m_bot->HasAura(SHADOWMELD, EFFECT_INDEX_0))
+    if (SHADOWMELD > 0 && !m_bot.isMovingOrTurning()
+        && !m_bot.IsMounted()
+        && !m_bot.HasAura(SHADOWMELD, EFFECT_INDEX_0))
     {
-        m_ai->CastSpell(SHADOWMELD, *m_bot);
+        m_ai.CastSpell(SHADOWMELD, m_bot);
     }
 } // end DoNonCombatActions

--- a/src/game/PlayerBot/AI/PlayerbotHunterAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotHunterAI.h
@@ -96,20 +96,20 @@ class MANGOS_DLL_SPEC PlayerbotHunterAI : PlayerbotClassAI
         static bool HasPet(Player* bot);
 
         // all combat actions go here
-        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget);
+        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget) override;
 
         // all non combat actions go here, ex buffs, heals, rezzes
-        void DoNonCombatActions();
+        void DoNonCombatActions() override;
 
         // buff a specific player, usually a real PC who is not in group
         //void BuffPlayer(Player *target);
 
     private:
-        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget);
+        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget) override;
 
         // Hunter
         bool IsTargetEnraged(Unit* pTarget);

--- a/src/game/PlayerBot/AI/PlayerbotHunterAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotHunterAI.h
@@ -91,7 +91,7 @@ enum HunterSpells
 class MANGOS_DLL_SPEC PlayerbotHunterAI : PlayerbotClassAI
 {
     public:
-        PlayerbotHunterAI(Player* const master, Player* const bot, PlayerbotAI* const ai);
+        PlayerbotHunterAI(Player& master, Player& bot, PlayerbotAI& ai);
         virtual ~PlayerbotHunterAI();
         static bool HasPet(Player* bot);
 

--- a/src/game/PlayerBot/AI/PlayerbotMageAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotMageAI.cpp
@@ -20,7 +20,7 @@
 
 class PlayerbotAI;
 
-PlayerbotMageAI::PlayerbotMageAI(Player* const master, Player* const bot, PlayerbotAI* const ai) : PlayerbotClassAI(master, bot, ai)
+PlayerbotMageAI::PlayerbotMageAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
 {
     ARCANE_MISSILES         = m_ai->initSpell(ARCANE_MISSILES_1);
     ARCANE_EXPLOSION        = m_ai->initSpell(ARCANE_EXPLOSION_1);

--- a/src/game/PlayerBot/AI/PlayerbotMageAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotMageAI.cpp
@@ -20,63 +20,63 @@
 
 class PlayerbotAI;
 
-PlayerbotMageAI::PlayerbotMageAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
+PlayerbotMageAI::PlayerbotMageAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(master, bot, ai)
 {
-    ARCANE_MISSILES         = m_ai->initSpell(ARCANE_MISSILES_1);
-    ARCANE_EXPLOSION        = m_ai->initSpell(ARCANE_EXPLOSION_1);
-    COUNTERSPELL            = m_ai->initSpell(COUNTERSPELL_1);
-    ARCANE_POWER            = m_ai->initSpell(ARCANE_POWER_1);
-    DAMPEN_MAGIC            = m_ai->initSpell(DAMPEN_MAGIC_1);
-    AMPLIFY_MAGIC           = m_ai->initSpell(AMPLIFY_MAGIC_1);
-    MAGE_ARMOR              = m_ai->initSpell(MAGE_ARMOR_1);
-    ARCANE_INTELLECT        = m_ai->initSpell(ARCANE_INTELLECT_1);
-    ARCANE_BRILLIANCE       = m_ai->initSpell(ARCANE_BRILLIANCE_1);
-    MANA_SHIELD             = m_ai->initSpell(MANA_SHIELD_1);
-    CONJURE_WATER           = m_ai->initSpell(CONJURE_WATER_1);
-    CONJURE_FOOD            = m_ai->initSpell(CONJURE_FOOD_1);
-    CONJURE_MANA_GEM        = m_ai->initSpell(CONJURE_MANA_GEM_1);
-    EVOCATION               = m_ai->initSpell(EVOCATION_1);
-    FIREBALL                = m_ai->initSpell(FIREBALL_1);
-    FIRE_BLAST              = m_ai->initSpell(FIRE_BLAST_1);
-    FLAMESTRIKE             = m_ai->initSpell(FLAMESTRIKE_1);
-    SCORCH                  = m_ai->initSpell(SCORCH_1);
-    POLYMORPH               = m_ai->initSpell(POLYMORPH_1);
-    PRESENCE_OF_MIND        = m_ai->initSpell(PRESENCE_OF_MIND_1);
-    PYROBLAST               = m_ai->initSpell(PYROBLAST_1);
-    BLAST_WAVE              = m_ai->initSpell(BLAST_WAVE_1);
-    COMBUSTION              = m_ai->initSpell(COMBUSTION_1);
-    FIRE_WARD               = m_ai->initSpell(FIRE_WARD_1);
-    FROSTBOLT               = m_ai->initSpell(FROSTBOLT_1);
-    FROST_NOVA              = m_ai->initSpell(FROST_NOVA_1);
-    BLIZZARD                = m_ai->initSpell(BLIZZARD_1);
-    CONE_OF_COLD            = m_ai->initSpell(CONE_OF_COLD_1);
-    ICE_BARRIER             = m_ai->initSpell(ICE_BARRIER_1);
-    FROST_WARD              = m_ai->initSpell(FROST_WARD_1);
-    FROST_ARMOR             = m_ai->initSpell(FROST_ARMOR_1);
-    ICE_ARMOR               = m_ai->initSpell(ICE_ARMOR_1);
-    ICE_BLOCK               = m_ai->initSpell(ICE_BLOCK_1);
-    COLD_SNAP               = m_ai->initSpell(COLD_SNAP_1);
-    MAGE_REMOVE_CURSE       = m_ai->initSpell(REMOVE_CURSE_MAGE_1);
+    ARCANE_MISSILES         = m_ai.initSpell(ARCANE_MISSILES_1);
+    ARCANE_EXPLOSION        = m_ai.initSpell(ARCANE_EXPLOSION_1);
+    COUNTERSPELL            = m_ai.initSpell(COUNTERSPELL_1);
+    ARCANE_POWER            = m_ai.initSpell(ARCANE_POWER_1);
+    DAMPEN_MAGIC            = m_ai.initSpell(DAMPEN_MAGIC_1);
+    AMPLIFY_MAGIC           = m_ai.initSpell(AMPLIFY_MAGIC_1);
+    MAGE_ARMOR              = m_ai.initSpell(MAGE_ARMOR_1);
+    ARCANE_INTELLECT        = m_ai.initSpell(ARCANE_INTELLECT_1);
+    ARCANE_BRILLIANCE       = m_ai.initSpell(ARCANE_BRILLIANCE_1);
+    MANA_SHIELD             = m_ai.initSpell(MANA_SHIELD_1);
+    CONJURE_WATER           = m_ai.initSpell(CONJURE_WATER_1);
+    CONJURE_FOOD            = m_ai.initSpell(CONJURE_FOOD_1);
+    CONJURE_MANA_GEM        = m_ai.initSpell(CONJURE_MANA_GEM_1);
+    EVOCATION               = m_ai.initSpell(EVOCATION_1);
+    FIREBALL                = m_ai.initSpell(FIREBALL_1);
+    FIRE_BLAST              = m_ai.initSpell(FIRE_BLAST_1);
+    FLAMESTRIKE             = m_ai.initSpell(FLAMESTRIKE_1);
+    SCORCH                  = m_ai.initSpell(SCORCH_1);
+    POLYMORPH               = m_ai.initSpell(POLYMORPH_1);
+    PRESENCE_OF_MIND        = m_ai.initSpell(PRESENCE_OF_MIND_1);
+    PYROBLAST               = m_ai.initSpell(PYROBLAST_1);
+    BLAST_WAVE              = m_ai.initSpell(BLAST_WAVE_1);
+    COMBUSTION              = m_ai.initSpell(COMBUSTION_1);
+    FIRE_WARD               = m_ai.initSpell(FIRE_WARD_1);
+    FROSTBOLT               = m_ai.initSpell(FROSTBOLT_1);
+    FROST_NOVA              = m_ai.initSpell(FROST_NOVA_1);
+    BLIZZARD                = m_ai.initSpell(BLIZZARD_1);
+    CONE_OF_COLD            = m_ai.initSpell(CONE_OF_COLD_1);
+    ICE_BARRIER             = m_ai.initSpell(ICE_BARRIER_1);
+    FROST_WARD              = m_ai.initSpell(FROST_WARD_1);
+    FROST_ARMOR             = m_ai.initSpell(FROST_ARMOR_1);
+    ICE_ARMOR               = m_ai.initSpell(ICE_ARMOR_1);
+    ICE_BLOCK               = m_ai.initSpell(ICE_BLOCK_1);
+    COLD_SNAP               = m_ai.initSpell(COLD_SNAP_1);
+    MAGE_REMOVE_CURSE       = m_ai.initSpell(REMOVE_CURSE_MAGE_1);
 
     // TALENTS
     IMPROVED_SCORCH         = 0;
     for (unsigned int i : uiImprovedScorch)
     {
-        if (m_ai->initSpell(i))
-            IMPROVED_SCORCH = m_ai->initSpell(i);
+        if (m_ai.initSpell(i))
+            IMPROVED_SCORCH = m_ai.initSpell(i);
     }
     FIRE_VULNERABILITY      = 22959;
 
     // RANGED COMBAT
-    SHOOT                   = m_ai->initSpell(SHOOT_2);
+    SHOOT                   = m_ai.initSpell(SHOOT_2);
 
     RECENTLY_BANDAGED       = 11196; // first aid check
 
     // racial
-    ESCAPE_ARTIST           = m_ai->initSpell(ESCAPE_ARTIST_ALL); // gnome
-    PERCEPTION              = m_ai->initSpell(PERCEPTION_ALL); // human
-    BERSERKING              = m_ai->initSpell(BERSERKING_ALL); // troll
-    WILL_OF_THE_FORSAKEN    = m_ai->initSpell(WILL_OF_THE_FORSAKEN_ALL); // undead
+    ESCAPE_ARTIST           = m_ai.initSpell(ESCAPE_ARTIST_ALL); // gnome
+    PERCEPTION              = m_ai.initSpell(PERCEPTION_ALL); // human
+    BERSERKING              = m_ai.initSpell(BERSERKING_ALL); // troll
+    WILL_OF_THE_FORSAKEN    = m_ai.initSpell(WILL_OF_THE_FORSAKEN_ALL); // undead
 }
 
 PlayerbotMageAI::~PlayerbotMageAI() {}
@@ -85,27 +85,27 @@ CombatManeuverReturns PlayerbotMageAI::DoFirstCombatManeuver(Unit* pTarget)
 {
     // There are NPCs in BGs and Open World PvP, so don't filter this on PvP scenarios (of course if PvP targets anyone but tank, all bets are off anyway)
     // Wait until the tank says so, until any non-tank gains aggro or X seconds - whichever is shortest
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->GroupTankHoldsAggro())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.GroupTankHoldsAggro())
         {
             return RETURN_NO_ACTION_OK; // wait it out
         }
         else
         {
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
         }
     }
 
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->IsGroupReady())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.IsGroupReady())
             return RETURN_NO_ACTION_OK; // wait it out
         else
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
     }
 
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -133,9 +133,9 @@ CombatManeuverReturns PlayerbotMageAI::DoFirstCombatManeuverPVP(Unit* /*pTarget*
 CombatManeuverReturns PlayerbotMageAI::DoNextCombatManeuver(Unit* pTarget)
 {
     // Face enemy, make sure bot is attacking
-    m_ai->FaceTarget(pTarget);
+    m_ai.FaceTarget(pTarget);
 
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -152,27 +152,24 @@ CombatManeuverReturns PlayerbotMageAI::DoNextCombatManeuver(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotMageAI::DoNextCombatManeuverPVE(Unit* pTarget)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
     Unit* pVictim = pTarget->GetVictim();
-    bool meleeReach = m_bot->CanReachWithMeleeAttack(pTarget);
+    bool meleeReach = m_bot.CanReachWithMeleeAttack(pTarget);
 
-    uint32 spec = m_bot->GetSpec();
+    uint32 spec = m_bot.GetSpec();
 
-    if (m_ai->GetCombatStyle() != PlayerbotAI::COMBAT_RANGED && !meleeReach)
-        m_ai->SetCombatStyle(PlayerbotAI::COMBAT_RANGED);
+    if (m_ai.GetCombatStyle() != PlayerbotAI::COMBAT_RANGED && !meleeReach)
+        m_ai.SetCombatStyle(PlayerbotAI::COMBAT_RANGED);
     // switch to melee if in melee range AND can't shoot OR have no ranged (wand) equipped
-    else if (m_ai->GetCombatStyle() != PlayerbotAI::COMBAT_MELEE
+    else if (m_ai.GetCombatStyle() != PlayerbotAI::COMBAT_MELEE
              && meleeReach
-             && (SHOOT == 0 || !m_bot->GetWeaponForAttack(RANGED_ATTACK, true, true)))
-        m_ai->SetCombatStyle(PlayerbotAI::COMBAT_MELEE);
+             && (SHOOT == 0 || !m_bot.GetWeaponForAttack(RANGED_ATTACK, true, true)))
+        m_ai.SetCombatStyle(PlayerbotAI::COMBAT_MELEE);
 
     //Used to determine if this bot is highest on threat
-    Unit* newTarget = m_ai->FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), m_bot);
+    Unit* newTarget = m_ai.FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), &m_bot);
 
     // Remove curse on group members
-    if (m_ai->HasDispelOrder() && DispelPlayer(GetDispelTarget(DISPEL_CURSE)) & RETURN_CONTINUE)
+    if (m_ai.HasDispelOrder() && DispelPlayer(GetDispelTarget(DISPEL_CURSE)) & RETURN_CONTINUE)
         return RETURN_CONTINUE;
 
     if (newTarget && !PlayerbotAI::IsNeutralized(newTarget)) // Bot has aggro and the mob is not already crowd controled
@@ -180,7 +177,7 @@ CombatManeuverReturns PlayerbotMageAI::DoNextCombatManeuverPVE(Unit* pTarget)
         if (newTarget->GetHealthPercent() > 25)
         {
             // If elite
-            if (m_ai->IsElite(newTarget))
+            if (m_ai.IsElite(newTarget))
             {
                 // If the attacker is a beast or humanoid, let's the bot give it a form more suited to the low intellect of something fool enough to attack a mage
                 // No need to check if target is a player as IsElite() returns false for players
@@ -192,11 +189,11 @@ CombatManeuverReturns PlayerbotMageAI::DoNextCombatManeuverPVE(Unit* pTarget)
                 }
 
                 // Things are getting dire: cast Ice block
-                if (ICE_BLOCK > 0 && m_bot->IsSpellReady(ICE_BLOCK) && m_ai->GetHealthPercent() < 30 && !m_bot->HasAura(ICE_BLOCK, EFFECT_INDEX_0) && m_ai->CastSpell(ICE_BLOCK) == SPELL_CAST_OK)
+                if (ICE_BLOCK > 0 && m_bot.IsSpellReady(ICE_BLOCK) && m_ai.GetHealthPercent() < 30 && !m_bot.HasAura(ICE_BLOCK, EFFECT_INDEX_0) && m_ai.CastSpell(ICE_BLOCK) == SPELL_CAST_OK)
                     return RETURN_CONTINUE;
 
                 // Cast Ice Barrier if health starts to goes low
-                if (ICE_BARRIER > 0 && m_bot->IsSpellReady(ICE_BARRIER) && m_ai->GetHealthPercent() < 50 && !m_bot->HasAura(ICE_BARRIER) && m_ai->SelfBuff(ICE_BARRIER) == SPELL_CAST_OK)
+                if (ICE_BARRIER > 0 && m_bot.IsSpellReady(ICE_BARRIER) && m_ai.GetHealthPercent() < 50 && !m_bot.HasAura(ICE_BARRIER) && m_ai.SelfBuff(ICE_BARRIER) == SPELL_CAST_OK)
                     return RETURN_CONTINUE;
 
                 // Have threat, can't quickly lower it. 3 options remain: Stop attacking, lowlevel damage (wand), keep on keeping on.
@@ -205,72 +202,72 @@ CombatManeuverReturns PlayerbotMageAI::DoNextCombatManeuverPVE(Unit* pTarget)
             else // not elite
             {
                 // Cast mana shield if no shield is already up
-                if (MANA_SHIELD > 0 && m_ai->GetHealthPercent() < 70 && !m_bot->HasAura(MANA_SHIELD) && !m_bot->HasAura(ICE_BARRIER) && m_ai->SelfBuff(MANA_SHIELD) == SPELL_CAST_OK)
+                if (MANA_SHIELD > 0 && m_ai.GetHealthPercent() < 70 && !m_bot.HasAura(MANA_SHIELD) && !m_bot.HasAura(ICE_BARRIER) && m_ai.SelfBuff(MANA_SHIELD) == SPELL_CAST_OK)
                     return RETURN_CONTINUE;
             }
         }
     }
 
     // Mana check and replenishment
-    if (EVOCATION && m_ai->GetManaPercent() <= 10 && m_bot->IsSpellReady(EVOCATION) && !newTarget && m_ai->SelfBuff(EVOCATION) == SPELL_CAST_OK)
+    if (EVOCATION && m_ai.GetManaPercent() <= 10 && m_bot.IsSpellReady(EVOCATION) && !newTarget && m_ai.SelfBuff(EVOCATION) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
-    if (m_ai->GetManaPercent() <= 20)
+    if (m_ai.GetManaPercent() <= 20)
     {
         Item* gem = FindManaGem();
         if (gem)
-            m_ai->UseItem(gem);
+            m_ai.UseItem(gem);
     }
 
     // If bot has frost/fire resist order use Frost/Fire Ward when available
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_FROST && FROST_WARD && m_bot->IsSpellReady(FROST_WARD) && m_ai->SelfBuff(FROST_WARD) == SPELL_CAST_OK)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_FROST && FROST_WARD && m_bot.IsSpellReady(FROST_WARD) && m_ai.SelfBuff(FROST_WARD) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_FIRE && FIRE_WARD && m_bot->IsSpellReady(FIRE_WARD) && m_ai->SelfBuff(FIRE_WARD) == SPELL_CAST_OK)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_FIRE && FIRE_WARD && m_bot.IsSpellReady(FIRE_WARD) && m_ai.SelfBuff(FIRE_WARD) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
-    if (COUNTERSPELL > 0 && m_bot->IsSpellReady(COUNTERSPELL) && pTarget->IsNonMeleeSpellCasted(true) && CastSpell(COUNTERSPELL, pTarget))
+    if (COUNTERSPELL > 0 && m_bot.IsSpellReady(COUNTERSPELL) && pTarget->IsNonMeleeSpellCasted(true) && CastSpell(COUNTERSPELL, pTarget))
         return RETURN_CONTINUE;
 
     // If Clearcasting is active, cast arcane missiles
     // Bot could also cast flamestrike or blizzard for free, but the AoE could break some crowd control
     // or add threat on mobs ignoring the bot currently, so only focus on the bot's current target
-    if (m_bot->HasAura(CLEARCASTING_1) && ARCANE_MISSILES > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_ARCANE) && CastSpell(ARCANE_MISSILES, pTarget))
+    if (m_bot.HasAura(CLEARCASTING_1) && ARCANE_MISSILES > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_ARCANE) && CastSpell(ARCANE_MISSILES, pTarget))
     {
-        m_ai->SetIgnoreUpdateTime(3);
+        m_ai.SetIgnoreUpdateTime(3);
         return RETURN_CONTINUE;
     }
 
     switch (spec)
     {
         case MAGE_SPEC_FROST:
-            if (COLD_SNAP && m_bot->IsSpellReady(COLD_SNAP) && CheckFrostCooldowns() > 2 && m_ai->SelfBuff(COLD_SNAP) == SPELL_CAST_OK)  // Clear frost spell cooldowns if bot has more than 2 active
+            if (COLD_SNAP && m_bot.IsSpellReady(COLD_SNAP) && CheckFrostCooldowns() > 2 && m_ai.SelfBuff(COLD_SNAP) == SPELL_CAST_OK)  // Clear frost spell cooldowns if bot has more than 2 active
                 return RETURN_CONTINUE;
-            if (CONE_OF_COLD > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FROST) && m_bot->IsSpellReady(CONE_OF_COLD) && meleeReach)
+            if (CONE_OF_COLD > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FROST) && m_bot.IsSpellReady(CONE_OF_COLD) && meleeReach)
             {
                 // Cone of Cold does not require a target, so ensure that the bot faces the current one before casting
-                m_ai->FaceTarget(pTarget);
-                if (m_ai->CastSpell(CONE_OF_COLD) == SPELL_CAST_OK)
+                m_ai.FaceTarget(pTarget);
+                if (m_ai.CastSpell(CONE_OF_COLD) == SPELL_CAST_OK)
                     return RETURN_CONTINUE;
             }
-            if (FROSTBOLT > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FROST) && m_ai->In_Reach(pTarget, FROSTBOLT) && !pTarget->HasAura(FROSTBOLT, EFFECT_INDEX_0) && CastSpell(FROSTBOLT, pTarget))
+            if (FROSTBOLT > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FROST) && m_ai.In_Reach(pTarget, FROSTBOLT) && !pTarget->HasAura(FROSTBOLT, EFFECT_INDEX_0) && CastSpell(FROSTBOLT, pTarget))
                 return RETURN_CONTINUE;
-            if (FROST_NOVA > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FROST) && m_bot->IsSpellReady(FROST_NOVA) && meleeReach && !pTarget->HasAura(FROST_NOVA, EFFECT_INDEX_0) && CastSpell(FROST_NOVA, pTarget))
+            if (FROST_NOVA > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FROST) && m_bot.IsSpellReady(FROST_NOVA) && meleeReach && !pTarget->HasAura(FROST_NOVA, EFFECT_INDEX_0) && CastSpell(FROST_NOVA, pTarget))
                 return RETURN_CONTINUE;
             // Default frost spec action
-            if (FROSTBOLT > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FROST) && m_ai->In_Reach(pTarget, FROSTBOLT))
+            if (FROSTBOLT > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FROST) && m_ai.In_Reach(pTarget, FROSTBOLT))
                 return CastSpell(FROSTBOLT, pTarget);
             /*
-            if (BLIZZARD > 0 && !m_ai->IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FROST) && m_ai->In_Reach(pTarget,BLIZZARD) && m_ai->GetAttackerCount() >= 5 && CastSpell(BLIZZARD, pTarget))
+            if (BLIZZARD > 0 && !m_ai.IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FROST) && m_ai.In_Reach(pTarget,BLIZZARD) && m_ai.GetAttackerCount() >= 5 && CastSpell(BLIZZARD, pTarget))
             {
-                m_ai->SetIgnoreUpdateTime(8);
+                m_ai.SetIgnoreUpdateTime(8);
                 return RETURN_CONTINUE;
             }
             */
             break;
 
         case MAGE_SPEC_FIRE:
-            if (COMBUSTION > 0 && m_ai->SelfBuff(COMBUSTION) == SPELL_CAST_OK)
+            if (COMBUSTION > 0 && m_ai.SelfBuff(COMBUSTION) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (BLAST_WAVE > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai->GetAttackerCount() >= 3 && meleeReach && CastSpell(BLAST_WAVE, pTarget))
+            if (BLAST_WAVE > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai.GetAttackerCount() >= 3 && meleeReach && CastSpell(BLAST_WAVE, pTarget))
                 return RETURN_CONTINUE;
             // Try to have 3 scorch stacks to let tank build aggro while getting a nice crit% bonus
             if (IMPROVED_SCORCH > 0 && SCORCH > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE))
@@ -288,7 +285,7 @@ CombatManeuverReturns PlayerbotMageAI::DoNextCombatManeuverPVE(Unit* pTarget)
             if (FIREBALL > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && !pTarget->HasAura(FIREBALL, EFFECT_INDEX_1) && CastSpell(FIREBALL, pTarget))
                 return RETURN_CONTINUE;
             // 3 stacks of Scorch and fireball DoT: use fire blast if available
-            if (FIRE_BLAST > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_bot->IsSpellReady(FIRE_BLAST) && CastSpell(FIRE_BLAST, pTarget))
+            if (FIRE_BLAST > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_bot.IsSpellReady(FIRE_BLAST) && CastSpell(FIRE_BLAST, pTarget))
                 return RETURN_CONTINUE;
             // All DoTs, cooldowns used, try to maximise scorch stacks (5) to get a even nicer crit% bonus
             if (IMPROVED_SCORCH > 0 && SCORCH > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE))
@@ -298,21 +295,21 @@ CombatManeuverReturns PlayerbotMageAI::DoNextCombatManeuverPVE(Unit* pTarget)
                     return RETURN_CONTINUE;
             }
             // Default fire spec action
-            if (FIREBALL > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai->In_Reach(pTarget, FIREBALL))
+            if (FIREBALL > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai.In_Reach(pTarget, FIREBALL))
                 return CastSpell(FIREBALL, pTarget);
             /*
-            if (FLAMESTRIKE > 0 && !m_ai->IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai->In_Reach(pTarget,FLAMESTRIKE) && CastSpell(FLAMESTRIKE, pTarget))
+            if (FLAMESTRIKE > 0 && !m_ai.IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai.In_Reach(pTarget,FLAMESTRIKE) && CastSpell(FLAMESTRIKE, pTarget))
                 return RETURN_CONTINUE;
             */
             break;
 
         case MAGE_SPEC_ARCANE:
-            if (ARCANE_POWER > 0 && m_bot->IsSpellReady(ARCANE_POWER) && m_ai->IsElite(pTarget) && m_ai->CastSpell(ARCANE_POWER) == SPELL_CAST_OK)    // Do not waste Arcane Power on normal NPCs as the bot is likely in a group
+            if (ARCANE_POWER > 0 && m_bot.IsSpellReady(ARCANE_POWER) && m_ai.IsElite(pTarget) && m_ai.CastSpell(ARCANE_POWER) == SPELL_CAST_OK)    // Do not waste Arcane Power on normal NPCs as the bot is likely in a group
                 return RETURN_CONTINUE;
-            if (PRESENCE_OF_MIND > 0 && !m_bot->HasAura(PRESENCE_OF_MIND) && m_bot->IsSpellReady(PRESENCE_OF_MIND) && m_ai->IsElite(pTarget) && m_ai->SelfBuff(PRESENCE_OF_MIND) == SPELL_CAST_OK)
+            if (PRESENCE_OF_MIND > 0 && !m_bot.HasAura(PRESENCE_OF_MIND) && m_bot.IsSpellReady(PRESENCE_OF_MIND) && m_ai.IsElite(pTarget) && m_ai.SelfBuff(PRESENCE_OF_MIND) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
             // If bot has presence of mind active, cast long casting time spells
-            if (PRESENCE_OF_MIND && m_bot->HasAura(PRESENCE_OF_MIND))
+            if (PRESENCE_OF_MIND && m_bot.HasAura(PRESENCE_OF_MIND))
             {
                 // Instant Pyroblast, yeah! Tanks will probably hate this, but what do they know about power? Nothing...
                 if (PYROBLAST > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && CastSpell(PYROBLAST, pTarget))
@@ -320,26 +317,26 @@ CombatManeuverReturns PlayerbotMageAI::DoNextCombatManeuverPVE(Unit* pTarget)
                 if (FIREBALL > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && CastSpell(FIREBALL, pTarget))
                     return RETURN_CONTINUE;
             }
-            if (ARCANE_EXPLOSION > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_ARCANE) && m_ai->GetAttackerCount() >= 3 && meleeReach && CastSpell(ARCANE_EXPLOSION, pTarget))
+            if (ARCANE_EXPLOSION > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_ARCANE) && m_ai.GetAttackerCount() >= 3 && meleeReach && CastSpell(ARCANE_EXPLOSION, pTarget))
                 return RETURN_CONTINUE;
             // Default arcane spec actions (yes, two fire spells)
-            if (FIRE_BLAST > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_bot->IsSpellReady(FIRE_BLAST) && CastSpell(FIRE_BLAST, pTarget))
+            if (FIRE_BLAST > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_bot.IsSpellReady(FIRE_BLAST) && CastSpell(FIRE_BLAST, pTarget))
                 return RETURN_CONTINUE;
-            if (FIREBALL > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai->In_Reach(pTarget, FIREBALL))
+            if (FIREBALL > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai.In_Reach(pTarget, FIREBALL))
                 return CastSpell(FIREBALL, pTarget);
             // If no fireball, arcane missiles
             if (ARCANE_MISSILES > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_ARCANE) && CastSpell(ARCANE_MISSILES, pTarget))
             {
-                m_ai->SetIgnoreUpdateTime(3);
+                m_ai.SetIgnoreUpdateTime(3);
                 return RETURN_CONTINUE;
             }
             break;
     }
 
     // No spec due to low level OR no spell found yet
-    if (FROSTBOLT > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FROST) && m_ai->In_Reach(pTarget, FROSTBOLT) && !pTarget->HasAura(FROSTBOLT, EFFECT_INDEX_0) && CastSpell(FROSTBOLT, pTarget))
+    if (FROSTBOLT > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FROST) && m_ai.In_Reach(pTarget, FROSTBOLT) && !pTarget->HasAura(FROSTBOLT, EFFECT_INDEX_0) && CastSpell(FROSTBOLT, pTarget))
         return RETURN_CONTINUE;
-    if (FIREBALL > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai->In_Reach(pTarget, FIREBALL) && CastSpell(FIREBALL, pTarget)) // Very low levels
+    if (FIREBALL > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai.In_Reach(pTarget, FIREBALL) && CastSpell(FIREBALL, pTarget)) // Very low levels
         return RETURN_CONTINUE;
 
     // Default: shoot with wand
@@ -348,7 +345,7 @@ CombatManeuverReturns PlayerbotMageAI::DoNextCombatManeuverPVE(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotMageAI::DoNextCombatManeuverPVP(Unit* pTarget)
 {
-    if (FIREBALL && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai->In_Reach(pTarget, FIREBALL) && m_ai->CastSpell(FIREBALL) == SPELL_CAST_OK)
+    if (FIREBALL && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai.In_Reach(pTarget, FIREBALL) && m_ai.CastSpell(FIREBALL) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
     return DoNextCombatManeuverPVE(pTarget); // TODO: bad idea perhaps, but better than the alternative
@@ -358,15 +355,15 @@ CombatManeuverReturns PlayerbotMageAI::DoNextCombatManeuverPVP(Unit* pTarget)
 uint8 PlayerbotMageAI::CheckFrostCooldowns()
 {
     uint8 uiFrostActiveCooldown = 0;
-    if (FROST_NOVA && !m_bot->IsSpellReady(FROST_NOVA))
+    if (FROST_NOVA && !m_bot.IsSpellReady(FROST_NOVA))
         uiFrostActiveCooldown++;
-    if (ICE_BARRIER && !m_bot->IsSpellReady(ICE_BARRIER))
+    if (ICE_BARRIER && !m_bot.IsSpellReady(ICE_BARRIER))
         uiFrostActiveCooldown++;
-    if (CONE_OF_COLD && !m_bot->IsSpellReady(CONE_OF_COLD))
+    if (CONE_OF_COLD && !m_bot.IsSpellReady(CONE_OF_COLD))
         uiFrostActiveCooldown++;
-    if (ICE_BLOCK && !m_bot->IsSpellReady(ICE_BLOCK))
+    if (ICE_BLOCK && !m_bot.IsSpellReady(ICE_BLOCK))
         uiFrostActiveCooldown++;
-    if (FROST_WARD && !m_bot->IsSpellReady(FROST_WARD))
+    if (FROST_WARD && !m_bot.IsSpellReady(FROST_WARD))
         uiFrostActiveCooldown++;
 
     return uiFrostActiveCooldown;
@@ -383,7 +380,7 @@ Item* PlayerbotMageAI::FindManaGem() const
     Item* gem;
     for (unsigned int priorizedManaGemId : uPriorizedManaGemIds)
     {
-        gem = m_ai->FindConsumable(priorizedManaGemId);
+        gem = m_ai.FindConsumable(priorizedManaGemId);
         if (gem)
             return gem;
     }
@@ -404,38 +401,33 @@ CombatManeuverReturns PlayerbotMageAI::DispelPlayer(Player* cursedTarget)
 
 void PlayerbotMageAI::DoNonCombatActions()
 {
-    Player* master = GetMaster();
-
-    if (!m_bot || !master)
-        return;
-
     // Remove curse on group members
-    if (m_ai->HasDispelOrder() && DispelPlayer(GetDispelTarget(DISPEL_CURSE)) & RETURN_CONTINUE)
+    if (m_ai.HasDispelOrder() && DispelPlayer(GetDispelTarget(DISPEL_CURSE)) & RETURN_CONTINUE)
         return;
 
     // Buff armor
     if (MAGE_ARMOR)
     {
-        if (m_ai->SelfBuff(MAGE_ARMOR) == SPELL_CAST_OK)
+        if (m_ai.SelfBuff(MAGE_ARMOR) == SPELL_CAST_OK)
             return;
     }
     else if (ICE_ARMOR)
     {
-        if (m_ai->SelfBuff(ICE_ARMOR) == SPELL_CAST_OK)
+        if (m_ai.SelfBuff(ICE_ARMOR) == SPELL_CAST_OK)
             return;
     }
     else if (FROST_ARMOR)
     {
-        if (m_ai->SelfBuff(FROST_ARMOR) == SPELL_CAST_OK)
+        if (m_ai.SelfBuff(FROST_ARMOR) == SPELL_CAST_OK)
             return;
     }
 
-    if (COMBUSTION && m_bot->IsSpellReady(COMBUSTION) && m_ai->SelfBuff(COMBUSTION) == SPELL_CAST_OK)
+    if (COMBUSTION && m_bot.IsSpellReady(COMBUSTION) && m_ai.SelfBuff(COMBUSTION) == SPELL_CAST_OK)
         return;
 
     // buff group
     // the check for group targets is performed by NeedGroupBuff (if group is found for bots by the function)
-    if (NeedGroupBuff(ARCANE_BRILLIANCE, ARCANE_INTELLECT) && m_ai->HasSpellReagents(ARCANE_BRILLIANCE))
+    if (NeedGroupBuff(ARCANE_BRILLIANCE, ARCANE_INTELLECT) && m_ai.HasSpellReagents(ARCANE_BRILLIANCE))
     {
         if (Buff(&PlayerbotMageAI::BuffHelper, ARCANE_BRILLIANCE) & RETURN_CONTINUE)
             return;
@@ -444,27 +436,27 @@ void PlayerbotMageAI::DoNonCombatActions()
         return;
 
     // if there is space on bag try to conjure some consumables
-    if (m_ai->CanStore())
+    if (m_ai.CanStore())
     {
         Item* gem = FindManaGem();
-        if (!gem && CONJURE_MANA_GEM && m_ai->CastSpell(CONJURE_MANA_GEM, *m_bot) == SPELL_CAST_OK)
+        if (!gem && CONJURE_MANA_GEM && m_ai.CastSpell(CONJURE_MANA_GEM, m_bot) == SPELL_CAST_OK)
         {
-            m_ai->SetIgnoreUpdateTime(3);
+            m_ai.SetIgnoreUpdateTime(3);
             return;
         }
 
         // TODO: The beauty of a mage is not only its ability to supply itself with water, but to share its water
         // So, conjure at *least* 1.25 stacks, ready to trade a stack and still have some left for self
-        if (m_ai->FindDrink() == nullptr && CONJURE_WATER && m_ai->CastSpell(CONJURE_WATER, *m_bot) == SPELL_CAST_OK)
+        if (m_ai.FindDrink() == nullptr && CONJURE_WATER && m_ai.CastSpell(CONJURE_WATER, m_bot) == SPELL_CAST_OK)
         {
-            m_ai->TellMaster("I'm conjuring some water.");
-            m_ai->SetIgnoreUpdateTime(3);
+            m_ai.TellMaster("I'm conjuring some water.");
+            m_ai.SetIgnoreUpdateTime(3);
             return;
         }
-        if (m_ai->FindFood() == nullptr && CONJURE_FOOD && m_ai->CastSpell(CONJURE_FOOD, *m_bot) == SPELL_CAST_OK)
+        if (m_ai.FindFood() == nullptr && CONJURE_FOOD && m_ai.CastSpell(CONJURE_FOOD, m_bot) == SPELL_CAST_OK)
         {
-            m_ai->TellMaster("I'm conjuring some food.");
-            m_ai->SetIgnoreUpdateTime(3);
+            m_ai.TellMaster("I'm conjuring some food.");
+            m_ai.SetIgnoreUpdateTime(3);
             return;
         }
     }
@@ -490,13 +482,11 @@ bool PlayerbotMageAI::BuffHelper(PlayerbotAI* ai, uint32 spellId, Unit* target)
 // Return to UpdateAI the spellId usable to neutralize a target with creaturetype
 uint32 PlayerbotMageAI::Neutralize(uint8 creatureType)
 {
-    if (!m_bot)         return 0;
-    if (!m_ai)          return 0;
     if (!creatureType)  return 0;
 
     if (creatureType != CREATURE_TYPE_HUMANOID && creatureType != CREATURE_TYPE_BEAST)
     {
-        m_ai->TellMaster("I can't polymorph that target.");
+        m_ai.TellMaster("I can't polymorph that target.");
         return 0;
     }
 

--- a/src/game/PlayerBot/AI/PlayerbotMageAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotMageAI.h
@@ -100,24 +100,24 @@ class MANGOS_DLL_SPEC PlayerbotMageAI : PlayerbotClassAI
         virtual ~PlayerbotMageAI();
 
         // all combat actions go here
-        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget);
-        uint32 Neutralize(uint8 creatureType);
+        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget) override;
+        uint32 Neutralize(uint8 creatureType) override;
 
         // all non combat actions go here, ex buffs, heals, rezzes
-        void DoNonCombatActions();
+        void DoNonCombatActions() override;
 
     private:
-        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget);
+        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget) override;
         Item* FindManaGem() const;
 
         CombatManeuverReturns CastSpell(uint32 nextAction, Unit* pTarget = nullptr) { return CastSpellWand(nextAction, pTarget, SHOOT); }
 
         // Dispel disease or negative magic effects from the target
-        CombatManeuverReturns DispelPlayer(Player* target);
+        CombatManeuverReturns DispelPlayer(Player* target) override;
 
         static bool BuffHelper(PlayerbotAI* ai, uint32 spellId, Unit* target);
 

--- a/src/game/PlayerBot/AI/PlayerbotMageAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotMageAI.h
@@ -96,7 +96,7 @@ static const uint32 uiImprovedScorch[3] =
 class MANGOS_DLL_SPEC PlayerbotMageAI : PlayerbotClassAI
 {
     public:
-        PlayerbotMageAI(Player* const master, Player* const bot, PlayerbotAI* const ai);
+        PlayerbotMageAI(Player& master, Player& bot, PlayerbotAI& ai);
         virtual ~PlayerbotMageAI();
 
         // all combat actions go here

--- a/src/game/PlayerBot/AI/PlayerbotPaladinAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotPaladinAI.cpp
@@ -21,60 +21,60 @@
 
 class PlayerbotAI;
 
-PlayerbotPaladinAI::PlayerbotPaladinAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
+PlayerbotPaladinAI::PlayerbotPaladinAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(master, bot, ai)
 {
-    RETRIBUTION_AURA              = m_ai->initSpell(RETRIBUTION_AURA_1);
-    SEAL_OF_COMMAND               = m_ai->initSpell(SEAL_OF_COMMAND_1);
-    SEAL_OF_RIGHTEOUSNESS         = m_ai->initSpell(SEAL_OF_RIGHTEOUSNESS_1);
-    SEAL_OF_JUSTICE               = m_ai->initSpell(SEAL_OF_JUSTICE_1);
-    SEAL_OF_LIGHT                 = m_ai->initSpell(SEAL_OF_LIGHT_1);
-    SEAL_OF_WISDOM                = m_ai->initSpell(SEAL_OF_WISDOM_1);
-    SEAL_OF_THE_CRUSADER          = m_ai->initSpell(SEAL_OF_THE_CRUSADER_1);
-    JUDGEMENT                     = m_ai->initSpell(JUDGEMENT_1);
-    BLESSING_OF_MIGHT             = m_ai->initSpell(BLESSING_OF_MIGHT_1);
-    GREATER_BLESSING_OF_MIGHT     = m_ai->initSpell(GREATER_BLESSING_OF_MIGHT_1);
-    HAMMER_OF_WRATH               = m_ai->initSpell(HAMMER_OF_WRATH_1);
-    FLASH_OF_LIGHT                = m_ai->initSpell(FLASH_OF_LIGHT_1); // Holy
-    HOLY_LIGHT                    = m_ai->initSpell(HOLY_LIGHT_1);
-    HOLY_SHOCK                    = m_ai->initSpell(HOLY_SHOCK_1);
-    HOLY_WRATH                    = m_ai->initSpell(HOLY_WRATH_1);
-    DIVINE_FAVOR                  = m_ai->initSpell(DIVINE_FAVOR_1);
-    CONCENTRATION_AURA            = m_ai->initSpell(CONCENTRATION_AURA_1);
-    BLESSING_OF_WISDOM            = m_ai->initSpell(BLESSING_OF_WISDOM_1);
-    GREATER_BLESSING_OF_WISDOM    = m_ai->initSpell(GREATER_BLESSING_OF_WISDOM_1);
-    CONSECRATION                  = m_ai->initSpell(CONSECRATION_1);
-    LAY_ON_HANDS                  = m_ai->initSpell(LAY_ON_HANDS_1);
-    EXORCISM                      = m_ai->initSpell(EXORCISM_1);
-    BLESSING_OF_KINGS             = m_ai->initSpell(BLESSING_OF_KINGS_1);
-    GREATER_BLESSING_OF_KINGS     = m_ai->initSpell(GREATER_BLESSING_OF_KINGS_1);
-    BLESSING_OF_SANCTUARY         = m_ai->initSpell(BLESSING_OF_SANCTUARY_1);
-    GREATER_BLESSING_OF_SANCTUARY = m_ai->initSpell(GREATER_BLESSING_OF_SANCTUARY_1);
-    HAMMER_OF_JUSTICE             = m_ai->initSpell(HAMMER_OF_JUSTICE_1);
-    RIGHTEOUS_FURY                = m_ai->initSpell(RIGHTEOUS_FURY_1);
-    SHADOW_RESISTANCE_AURA        = m_ai->initSpell(SHADOW_RESISTANCE_AURA_1);
-    DEVOTION_AURA                 = m_ai->initSpell(DEVOTION_AURA_1);
-    FIRE_RESISTANCE_AURA          = m_ai->initSpell(FIRE_RESISTANCE_AURA_1);
-    FROST_RESISTANCE_AURA         = m_ai->initSpell(FROST_RESISTANCE_AURA_1);
-    BLESSING_OF_PROTECTION        = m_ai->initSpell(BLESSING_OF_PROTECTION_1);
-    DIVINE_PROTECTION             = m_ai->initSpell(DIVINE_PROTECTION_1);
-    DIVINE_INTERVENTION           = m_ai->initSpell(DIVINE_INTERVENTION_1);
-    DIVINE_SHIELD                 = m_ai->initSpell(DIVINE_SHIELD_1);
-    HOLY_SHIELD                   = m_ai->initSpell(HOLY_SHIELD_1);
-    BLESSING_OF_SACRIFICE         = m_ai->initSpell(BLESSING_OF_SACRIFICE_1);
-    REDEMPTION                    = m_ai->initSpell(REDEMPTION_1);
-    PURIFY                        = m_ai->initSpell(PURIFY_1);
-    CLEANSE                       = m_ai->initSpell(CLEANSE_1);
+    RETRIBUTION_AURA              = m_ai.initSpell(RETRIBUTION_AURA_1);
+    SEAL_OF_COMMAND               = m_ai.initSpell(SEAL_OF_COMMAND_1);
+    SEAL_OF_RIGHTEOUSNESS         = m_ai.initSpell(SEAL_OF_RIGHTEOUSNESS_1);
+    SEAL_OF_JUSTICE               = m_ai.initSpell(SEAL_OF_JUSTICE_1);
+    SEAL_OF_LIGHT                 = m_ai.initSpell(SEAL_OF_LIGHT_1);
+    SEAL_OF_WISDOM                = m_ai.initSpell(SEAL_OF_WISDOM_1);
+    SEAL_OF_THE_CRUSADER          = m_ai.initSpell(SEAL_OF_THE_CRUSADER_1);
+    JUDGEMENT                     = m_ai.initSpell(JUDGEMENT_1);
+    BLESSING_OF_MIGHT             = m_ai.initSpell(BLESSING_OF_MIGHT_1);
+    GREATER_BLESSING_OF_MIGHT     = m_ai.initSpell(GREATER_BLESSING_OF_MIGHT_1);
+    HAMMER_OF_WRATH               = m_ai.initSpell(HAMMER_OF_WRATH_1);
+    FLASH_OF_LIGHT                = m_ai.initSpell(FLASH_OF_LIGHT_1); // Holy
+    HOLY_LIGHT                    = m_ai.initSpell(HOLY_LIGHT_1);
+    HOLY_SHOCK                    = m_ai.initSpell(HOLY_SHOCK_1);
+    HOLY_WRATH                    = m_ai.initSpell(HOLY_WRATH_1);
+    DIVINE_FAVOR                  = m_ai.initSpell(DIVINE_FAVOR_1);
+    CONCENTRATION_AURA            = m_ai.initSpell(CONCENTRATION_AURA_1);
+    BLESSING_OF_WISDOM            = m_ai.initSpell(BLESSING_OF_WISDOM_1);
+    GREATER_BLESSING_OF_WISDOM    = m_ai.initSpell(GREATER_BLESSING_OF_WISDOM_1);
+    CONSECRATION                  = m_ai.initSpell(CONSECRATION_1);
+    LAY_ON_HANDS                  = m_ai.initSpell(LAY_ON_HANDS_1);
+    EXORCISM                      = m_ai.initSpell(EXORCISM_1);
+    BLESSING_OF_KINGS             = m_ai.initSpell(BLESSING_OF_KINGS_1);
+    GREATER_BLESSING_OF_KINGS     = m_ai.initSpell(GREATER_BLESSING_OF_KINGS_1);
+    BLESSING_OF_SANCTUARY         = m_ai.initSpell(BLESSING_OF_SANCTUARY_1);
+    GREATER_BLESSING_OF_SANCTUARY = m_ai.initSpell(GREATER_BLESSING_OF_SANCTUARY_1);
+    HAMMER_OF_JUSTICE             = m_ai.initSpell(HAMMER_OF_JUSTICE_1);
+    RIGHTEOUS_FURY                = m_ai.initSpell(RIGHTEOUS_FURY_1);
+    SHADOW_RESISTANCE_AURA        = m_ai.initSpell(SHADOW_RESISTANCE_AURA_1);
+    DEVOTION_AURA                 = m_ai.initSpell(DEVOTION_AURA_1);
+    FIRE_RESISTANCE_AURA          = m_ai.initSpell(FIRE_RESISTANCE_AURA_1);
+    FROST_RESISTANCE_AURA         = m_ai.initSpell(FROST_RESISTANCE_AURA_1);
+    BLESSING_OF_PROTECTION        = m_ai.initSpell(BLESSING_OF_PROTECTION_1);
+    DIVINE_PROTECTION             = m_ai.initSpell(DIVINE_PROTECTION_1);
+    DIVINE_INTERVENTION           = m_ai.initSpell(DIVINE_INTERVENTION_1);
+    DIVINE_SHIELD                 = m_ai.initSpell(DIVINE_SHIELD_1);
+    HOLY_SHIELD                   = m_ai.initSpell(HOLY_SHIELD_1);
+    BLESSING_OF_SACRIFICE         = m_ai.initSpell(BLESSING_OF_SACRIFICE_1);
+    REDEMPTION                    = m_ai.initSpell(REDEMPTION_1);
+    PURIFY                        = m_ai.initSpell(PURIFY_1);
+    CLEANSE                       = m_ai.initSpell(CLEANSE_1);
 
     FORBEARANCE                   = 25771; // cannot be protected
 
     RECENTLY_BANDAGED             = 11196; // first aid check
 
     // racial
-    STONEFORM                     = m_ai->initSpell(STONEFORM_ALL); // dwarf
-    PERCEPTION                    = m_ai->initSpell(PERCEPTION_ALL); // human
+    STONEFORM                     = m_ai.initSpell(STONEFORM_ALL); // dwarf
+    PERCEPTION                    = m_ai.initSpell(PERCEPTION_ALL); // human
 
     //The check doesn't work for now
-    //PRAYER_OF_SHADOW_PROTECTION   = m_ai->initSpell(PriestSpells::PRAYER_OF_SHADOW_PROTECTION_1);
+    //PRAYER_OF_SHADOW_PROTECTION   = m_ai.initSpell(PriestSpells::PRAYER_OF_SHADOW_PROTECTION_1);
 }
 
 PlayerbotPaladinAI::~PlayerbotPaladinAI() {}
@@ -83,20 +83,20 @@ CombatManeuverReturns PlayerbotPaladinAI::DoFirstCombatManeuver(Unit* pTarget)
 {
     // There are NPCs in BGs and Open World PvP, so don't filter this on PvP scenarios (of course if PvP targets anyone but tank, all bets are off anyway)
     // Wait until the tank says so, until any non-tank gains aggro or X seconds - whichever is shortest
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->GroupTankHoldsAggro())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.GroupTankHoldsAggro())
         {
-            if (PlayerbotAI::ORDERS_TANK & m_ai->GetCombatOrder())
+            if (PlayerbotAI::ORDERS_TANK & m_ai.GetCombatOrder())
             {
-                if (m_bot->CanReachWithMeleeAttack(pTarget))
+                if (m_bot.CanReachWithMeleeAttack(pTarget))
                 {
                     // Set everyone's UpdateAI() waiting to 2 seconds
-                    m_ai->SetGroupIgnoreUpdateTime(2);
+                    m_ai.SetGroupIgnoreUpdateTime(2);
                     // Clear their TEMP_WAIT_TANKAGGRO flag
-                    m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
+                    m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
                     // Start attacking, force target on current target
-                    m_ai->Attack(m_ai->GetCurrentTarget());
+                    m_ai.Attack(m_ai.GetCurrentTarget());
 
                     // While everyone else is waiting 2 second, we need to build up aggro, so don't return
                 }
@@ -106,30 +106,30 @@ CombatManeuverReturns PlayerbotPaladinAI::DoFirstCombatManeuver(Unit* pTarget)
                     return RETURN_NO_ACTION_OK; // wait for target to get nearer
                 }
             }
-            else if (PlayerbotAI::ORDERS_HEAL & m_ai->GetCombatOrder())
+            else if (PlayerbotAI::ORDERS_HEAL & m_ai.GetCombatOrder())
                 return HealPlayer(GetHealTarget());
             else
                 return RETURN_NO_ACTION_OK; // wait it out
         }
         else
         {
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
         }
     }
 
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->IsGroupReady())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.IsGroupReady())
             return RETURN_NO_ACTION_OK; // wait it out
         else
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
     }
 
     // Check if bot needs to cast seal on self
     m_CurrentSeal      = 0;
     m_CurrentJudgement = 0;
 
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -157,9 +157,9 @@ CombatManeuverReturns PlayerbotPaladinAI::DoFirstCombatManeuverPVP(Unit* /*pTarg
 CombatManeuverReturns PlayerbotPaladinAI::DoNextCombatManeuver(Unit* pTarget)
 {
     // Face enemy, make sure bot is attacking
-    m_ai->FaceTarget(pTarget);
+    m_ai.FaceTarget(pTarget);
 
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -176,34 +176,32 @@ CombatManeuverReturns PlayerbotPaladinAI::DoNextCombatManeuver(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotPaladinAI::DoNextCombatManeuverPVE(Unit* pTarget)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
     if (!pTarget) return RETURN_NO_ACTION_INVALIDTARGET;
 
     // damage spells
-    uint32 spec = m_bot->GetSpec();
+    uint32 spec = m_bot.GetSpec();
     std::ostringstream out;
 
     // Make sure healer stays put, don't even melee (aggro) if in range.
-    if (m_ai->IsHealer() && m_ai->GetCombatStyle() != PlayerbotAI::COMBAT_RANGED)
-        m_ai->SetCombatStyle(PlayerbotAI::COMBAT_RANGED);
-    else if (!m_ai->IsHealer() && m_ai->GetCombatStyle() != PlayerbotAI::COMBAT_MELEE)
-        m_ai->SetCombatStyle(PlayerbotAI::COMBAT_MELEE);
+    if (m_ai.IsHealer() && m_ai.GetCombatStyle() != PlayerbotAI::COMBAT_RANGED)
+        m_ai.SetCombatStyle(PlayerbotAI::COMBAT_RANGED);
+    else if (!m_ai.IsHealer() && m_ai.GetCombatStyle() != PlayerbotAI::COMBAT_MELEE)
+        m_ai.SetCombatStyle(PlayerbotAI::COMBAT_MELEE);
 
     // Emergency check: bot is about to die: use Divine Shield (first)
     // Use Divine Protection if Divine Shield is not available and bot is not tanking because of the pacify effect
     // TODO adjust treshold (may be too low)
-    if (m_ai->GetHealthPercent() < 8)
+    if (m_ai.GetHealthPercent() < 8)
     {
-        if (DIVINE_SHIELD > 0 && m_bot->IsSpellReady(DIVINE_SHIELD) && !m_bot->HasAura(DIVINE_SHIELD, EFFECT_INDEX_0) && !m_bot->HasAura(DIVINE_PROTECTION, EFFECT_INDEX_0) && !m_bot->HasAura(FORBEARANCE, EFFECT_INDEX_0) && m_ai->CastSpell(DIVINE_SHIELD, *m_bot) == SPELL_CAST_OK)
+        if (DIVINE_SHIELD > 0 && m_bot.IsSpellReady(DIVINE_SHIELD) && !m_bot.HasAura(DIVINE_SHIELD, EFFECT_INDEX_0) && !m_bot.HasAura(DIVINE_PROTECTION, EFFECT_INDEX_0) && !m_bot.HasAura(FORBEARANCE, EFFECT_INDEX_0) && m_ai.CastSpell(DIVINE_SHIELD, m_bot) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
 
-        if (DIVINE_PROTECTION > 0 && !(m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TANK) && m_bot->IsSpellReady(DIVINE_PROTECTION) && !m_bot->HasAura(DIVINE_SHIELD, EFFECT_INDEX_0) && !m_bot->HasAura(DIVINE_PROTECTION, EFFECT_INDEX_0) && !m_bot->HasAura(FORBEARANCE, EFFECT_INDEX_0) && m_ai->CastSpell(DIVINE_PROTECTION, *m_bot) == SPELL_CAST_OK)
+        if (DIVINE_PROTECTION > 0 && !(m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TANK) && m_bot.IsSpellReady(DIVINE_PROTECTION) && !m_bot.HasAura(DIVINE_SHIELD, EFFECT_INDEX_0) && !m_bot.HasAura(DIVINE_PROTECTION, EFFECT_INDEX_0) && !m_bot.HasAura(FORBEARANCE, EFFECT_INDEX_0) && m_ai.CastSpell(DIVINE_PROTECTION, m_bot) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
     }
 
     // Dispel magic/disease/poison
-    if (m_ai->HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
+    if (m_ai.HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
         return RETURN_CONTINUE;
 
     // Check if bot needs to cast a seal on self or judge the target
@@ -215,23 +213,23 @@ CombatManeuverReturns PlayerbotPaladinAI::DoNextCombatManeuverPVE(Unit* pTarget)
         return RETURN_CONTINUE;
 
     //Used to determine if this bot has highest threat
-    Unit* newTarget = m_ai->FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), m_bot);
-    if (newTarget && !(m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TANK) && !m_ai->IsNeutralized(newTarget)) // TODO: && party has a tank
+    Unit* newTarget = m_ai.FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), &m_bot);
+    if (newTarget && !(m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TANK) && !m_ai.IsNeutralized(newTarget)) // TODO: && party has a tank
     {
         // Aggroed by an elite
-        if (m_ai->IsElite(newTarget))
+        if (m_ai.IsElite(newTarget))
         {
             // Try to stun the mob
-            if (HAMMER_OF_JUSTICE > 0 && m_ai->In_Reach(newTarget, HAMMER_OF_JUSTICE) && m_bot->IsSpellReady(HAMMER_OF_JUSTICE) && !newTarget->HasAura(HAMMER_OF_JUSTICE) && m_ai->CastSpell(HAMMER_OF_JUSTICE, *newTarget) == SPELL_CAST_OK)
+            if (HAMMER_OF_JUSTICE > 0 && m_ai.In_Reach(newTarget, HAMMER_OF_JUSTICE) && m_bot.IsSpellReady(HAMMER_OF_JUSTICE) && !newTarget->HasAura(HAMMER_OF_JUSTICE) && m_ai.CastSpell(HAMMER_OF_JUSTICE, *newTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
 
             // Bot has low life: use divine powers to protect him/herself
-            if (m_ai->GetHealthPercent() < 15)
+            if (m_ai.GetHealthPercent() < 15)
             {
-                if (DIVINE_SHIELD > 0 && m_bot->IsSpellReady(DIVINE_SHIELD) && !m_bot->HasAura(DIVINE_SHIELD, EFFECT_INDEX_0) && !m_bot->HasAura(DIVINE_PROTECTION, EFFECT_INDEX_0) && !m_bot->HasAura(FORBEARANCE, EFFECT_INDEX_0) && m_ai->CastSpell(DIVINE_SHIELD, *m_bot) == SPELL_CAST_OK)
+                if (DIVINE_SHIELD > 0 && m_bot.IsSpellReady(DIVINE_SHIELD) && !m_bot.HasAura(DIVINE_SHIELD, EFFECT_INDEX_0) && !m_bot.HasAura(DIVINE_PROTECTION, EFFECT_INDEX_0) && !m_bot.HasAura(FORBEARANCE, EFFECT_INDEX_0) && m_ai.CastSpell(DIVINE_SHIELD, m_bot) == SPELL_CAST_OK)
                     return RETURN_CONTINUE;
 
-                if (DIVINE_PROTECTION > 0 && m_bot->IsSpellReady(DIVINE_PROTECTION) && !m_bot->HasAura(DIVINE_SHIELD, EFFECT_INDEX_0) && !m_bot->HasAura(DIVINE_PROTECTION, EFFECT_INDEX_0) && !m_bot->HasAura(FORBEARANCE, EFFECT_INDEX_0) && m_ai->CastSpell(DIVINE_PROTECTION, *m_bot) == SPELL_CAST_OK)
+                if (DIVINE_PROTECTION > 0 && m_bot.IsSpellReady(DIVINE_PROTECTION) && !m_bot.HasAura(DIVINE_SHIELD, EFFECT_INDEX_0) && !m_bot.HasAura(DIVINE_PROTECTION, EFFECT_INDEX_0) && !m_bot.HasAura(FORBEARANCE, EFFECT_INDEX_0) && m_ai.CastSpell(DIVINE_PROTECTION, m_bot) == SPELL_CAST_OK)
                     return RETURN_CONTINUE;
             }
 
@@ -244,22 +242,22 @@ CombatManeuverReturns PlayerbotPaladinAI::DoNextCombatManeuverPVE(Unit* pTarget)
     switch (spec)
     {
         case PALADIN_SPEC_HOLY:
-            if (m_ai->IsHealer())
+            if (m_ai.IsHealer())
                 return RETURN_NO_ACTION_OK;
         // else: DPS (retribution, NEVER protection)
 
         case PALADIN_SPEC_RETRIBUTION:
-            if (HAMMER_OF_WRATH > 0 && pTarget->GetHealth() < pTarget->GetMaxHealth() * 0.20 && m_ai->CastSpell(HAMMER_OF_WRATH, *pTarget) == SPELL_CAST_OK)
+            if (HAMMER_OF_WRATH > 0 && pTarget->GetHealth() < pTarget->GetMaxHealth() * 0.20 && m_ai.CastSpell(HAMMER_OF_WRATH, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
             return RETURN_CONTINUE;
 
         case PALADIN_SPEC_PROTECTION:
             //Taunt if orders specify
-            if (CONSECRATION > 0 && m_bot->IsSpellReady(CONSECRATION) && m_ai->CastSpell(CONSECRATION, *pTarget) == SPELL_CAST_OK)
+            if (CONSECRATION > 0 && m_bot.IsSpellReady(CONSECRATION) && m_ai.CastSpell(CONSECRATION, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (HOLY_SHIELD > 0 && !m_bot->HasAura(HOLY_SHIELD) && m_ai->CastSpell(HOLY_SHIELD, *m_bot) == SPELL_CAST_OK)
+            if (HOLY_SHIELD > 0 && !m_bot.HasAura(HOLY_SHIELD) && m_ai.CastSpell(HOLY_SHIELD, m_bot) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (SHIELD_OF_RIGHTEOUSNESS > 0 && m_bot->IsSpellReady(SHIELD_OF_RIGHTEOUSNESS) && m_ai->CastSpell(SHIELD_OF_RIGHTEOUSNESS, *pTarget) == SPELL_CAST_OK)
+            if (SHIELD_OF_RIGHTEOUSNESS > 0 && m_bot.IsSpellReady(SHIELD_OF_RIGHTEOUSNESS) && m_ai.CastSpell(SHIELD_OF_RIGHTEOUSNESS, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
             return RETURN_NO_ACTION_OK;
     }
@@ -269,7 +267,7 @@ CombatManeuverReturns PlayerbotPaladinAI::DoNextCombatManeuverPVE(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotPaladinAI::DoNextCombatManeuverPVP(Unit* pTarget)
 {
-    if (m_ai->CastSpell(HAMMER_OF_JUSTICE) == SPELL_CAST_OK)
+    if (m_ai.CastSpell(HAMMER_OF_JUSTICE) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
     return DoNextCombatManeuverPVE(pTarget); // TODO: bad idea perhaps, but better than the alternative
@@ -287,10 +285,10 @@ CombatManeuverReturns PlayerbotPaladinAI::HealPlayer(Player* target)
     // TODO: This code should be common to all healers and will probably
     // move to a more suitable place like PlayerbotAI::DoCombatMovement()
     if ((GetTargetJob(target) == JOB_TANK || GetTargetJob(target) == JOB_MAIN_TANK)
-            && m_bot->GetPlayerbotAI()->GetMovementOrder() != PlayerbotAI::MOVEMENT_STAY
-            && !m_ai->In_Reach(target, FLASH_OF_LIGHT))
+            && m_bot.GetPlayerbotAI()->GetMovementOrder() != PlayerbotAI::MOVEMENT_STAY
+            && !m_ai.In_Reach(target, FLASH_OF_LIGHT))
     {
-        m_bot->GetMotionMaster()->MoveFollow(target, 39.0f, m_bot->GetOrientation());
+        m_bot.GetMotionMaster()->MoveFollow(target, 39.0f, m_bot.GetOrientation());
         return RETURN_CONTINUE;
     }
 
@@ -300,31 +298,31 @@ CombatManeuverReturns PlayerbotPaladinAI::HealPlayer(Player* target)
     if (hp >= 80)
         return RETURN_NO_ACTION_OK;
 
-    if (hp < 10 && LAY_ON_HANDS && m_bot->IsSpellReady(LAY_ON_HANDS) && m_ai->In_Reach(target, LAY_ON_HANDS) && m_ai->CastSpell(LAY_ON_HANDS, *target) == SPELL_CAST_OK)
+    if (hp < 10 && LAY_ON_HANDS && m_bot.IsSpellReady(LAY_ON_HANDS) && m_ai.In_Reach(target, LAY_ON_HANDS) && m_ai.CastSpell(LAY_ON_HANDS, *target) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
     // Target is a moderately wounded healer or a badly wounded not tank? Blessing of Protection!
     if (BLESSING_OF_PROTECTION > 0
             && ((hp < 25 && (GetTargetJob(target) & JOB_HEAL || GetTargetJob(target) & JOB_MAIN_HEAL))
             || (hp < 15 && !(GetTargetJob(target) & JOB_TANK) && !(GetTargetJob(target) & JOB_MAIN_TANK)))
-            && m_bot->IsSpellReady(BLESSING_OF_PROTECTION) && m_ai->In_Reach(target, BLESSING_OF_PROTECTION)
+            && m_bot.IsSpellReady(BLESSING_OF_PROTECTION) && m_ai.In_Reach(target, BLESSING_OF_PROTECTION)
             && !target->HasAura(FORBEARANCE, EFFECT_INDEX_0)
             && !target->HasAura(BLESSING_OF_PROTECTION, EFFECT_INDEX_0) && !target->HasAura(DIVINE_PROTECTION, EFFECT_INDEX_0)
             && !target->HasAura(DIVINE_SHIELD, EFFECT_INDEX_0)
-            && m_ai->CastSpell(BLESSING_OF_PROTECTION, *target) == SPELL_CAST_OK)
+            && m_ai.CastSpell(BLESSING_OF_PROTECTION, *target) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
     // Low HP : activate Divine Favor to make next heal a critical heal
-    if (hp < 25 && DIVINE_FAVOR > 0 && !m_bot->HasAura(DIVINE_FAVOR, EFFECT_INDEX_0) && m_bot->IsSpellReady(DIVINE_FAVOR))
-        m_ai->CastSpell(DIVINE_FAVOR, *m_bot);
+    if (hp < 25 && DIVINE_FAVOR > 0 && !m_bot.HasAura(DIVINE_FAVOR, EFFECT_INDEX_0) && m_bot.IsSpellReady(DIVINE_FAVOR))
+        m_ai.CastSpell(DIVINE_FAVOR, m_bot);
 
-    if (hp < 40 && HOLY_LIGHT > 0 && m_ai->In_Reach(target, HOLY_LIGHT) && m_ai->CastSpell(HOLY_LIGHT, *target) == SPELL_CAST_OK)
+    if (hp < 40 && HOLY_LIGHT > 0 && m_ai.In_Reach(target, HOLY_LIGHT) && m_ai.CastSpell(HOLY_LIGHT, *target) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
-    if (hp < 60 && HOLY_SHOCK > 0 && m_ai->In_Reach(target, HOLY_SHOCK) && m_ai->CastSpell(HOLY_SHOCK, *target) == SPELL_CAST_OK)
+    if (hp < 60 && HOLY_SHOCK > 0 && m_ai.In_Reach(target, HOLY_SHOCK) && m_ai.CastSpell(HOLY_SHOCK, *target) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
-    if (hp < 80 && FLASH_OF_LIGHT > 0 && m_ai->In_Reach(target, FLASH_OF_LIGHT) && m_ai->CastSpell(FLASH_OF_LIGHT, *target) == SPELL_CAST_OK)
+    if (hp < 80 && FLASH_OF_LIGHT > 0 && m_ai.In_Reach(target, FLASH_OF_LIGHT) && m_ai.CastSpell(FLASH_OF_LIGHT, *target) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
     return RETURN_NO_ACTION_UNKNOWN;
@@ -336,14 +334,14 @@ CombatManeuverReturns PlayerbotPaladinAI::ResurrectPlayer(Player* target)
     if (r != RETURN_NO_ACTION_OK)
         return r;
 
-    if (m_ai->IsInCombat())     // Just in case as this was supposedly checked before calling this function
+    if (m_ai.IsInCombat())     // Just in case as this was supposedly checked before calling this function
         return RETURN_NO_ACTION_ERROR;
 
-    if (REDEMPTION > 0 && m_ai->In_Reach(target, REDEMPTION) && m_ai->CastSpell(REDEMPTION, *target) == SPELL_CAST_OK)
+    if (REDEMPTION > 0 && m_ai.In_Reach(target, REDEMPTION) && m_ai.CastSpell(REDEMPTION, *target) == SPELL_CAST_OK)
     {
         std::string msg = "Resurrecting ";
         msg += target->GetName();
-        m_bot->Say(msg, LANG_UNIVERSAL);
+        m_bot.Say(msg, LANG_UNIVERSAL);
         return RETURN_CONTINUE;
     }
     return RETURN_NO_ACTION_ERROR; // not error per se - possibly just OOM
@@ -359,7 +357,7 @@ CombatManeuverReturns PlayerbotPaladinAI::DispelPlayer(Player* /*target*/)
         if (r != RETURN_NO_ACTION_OK)
             return r;
 
-        if (dispel > 0 && m_ai->CastSpell(dispel, *cursedTarget) == SPELL_CAST_OK)
+        if (dispel > 0 && m_ai.CastSpell(dispel, *cursedTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
     }
 
@@ -370,7 +368,7 @@ CombatManeuverReturns PlayerbotPaladinAI::DispelPlayer(Player* /*target*/)
         if (r != RETURN_NO_ACTION_OK)
             return r;
 
-        if (dispel > 0 && m_ai->CastSpell(dispel, *poisonedTarget) == SPELL_CAST_OK)
+        if (dispel > 0 && m_ai.CastSpell(dispel, *poisonedTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
     }
 
@@ -381,7 +379,7 @@ CombatManeuverReturns PlayerbotPaladinAI::DispelPlayer(Player* /*target*/)
         if (r != RETURN_NO_ACTION_OK)
             return r;
 
-        if (dispel > 0 && m_ai->CastSpell(dispel, *diseasedTarget) == SPELL_CAST_OK)
+        if (dispel > 0 && m_ai.CastSpell(dispel, *diseasedTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
     }
     return RETURN_NO_ACTION_OK;
@@ -389,37 +387,34 @@ CombatManeuverReturns PlayerbotPaladinAI::DispelPlayer(Player* /*target*/)
 
 void PlayerbotPaladinAI::CheckAuras()
 {
-    if (!m_ai)  return;
-    if (!m_bot) return;
-
-    uint32 spec = m_bot->GetSpec();
+    uint32 spec = m_bot.GetSpec();
 
     // If we have resist orders, adjust accordingly
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_FROST)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_FROST)
     {
-        if (!m_bot->HasAura(FROST_RESISTANCE_AURA) && FROST_RESISTANCE_AURA > 0 && !m_bot->HasAura(FROST_RESISTANCE_AURA))
-            m_ai->CastSpell(FROST_RESISTANCE_AURA);
+        if (!m_bot.HasAura(FROST_RESISTANCE_AURA) && FROST_RESISTANCE_AURA > 0 && !m_bot.HasAura(FROST_RESISTANCE_AURA))
+            m_ai.CastSpell(FROST_RESISTANCE_AURA);
         return;
     }
-    else if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_FIRE)
+    else if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_FIRE)
     {
-        if (!m_bot->HasAura(FIRE_RESISTANCE_AURA) && FIRE_RESISTANCE_AURA > 0 && !m_bot->HasAura(FIRE_RESISTANCE_AURA))
-            m_ai->CastSpell(FIRE_RESISTANCE_AURA);
+        if (!m_bot.HasAura(FIRE_RESISTANCE_AURA) && FIRE_RESISTANCE_AURA > 0 && !m_bot.HasAura(FIRE_RESISTANCE_AURA))
+            m_ai.CastSpell(FIRE_RESISTANCE_AURA);
         return;
     }
-    else if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_SHADOW)
+    else if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_SHADOW)
     {
         // Shadow protection check is broken, they stack!
-        if (!m_bot->HasAura(SHADOW_RESISTANCE_AURA) && SHADOW_RESISTANCE_AURA > 0 && !m_bot->HasAura(SHADOW_RESISTANCE_AURA)) // /*&& !m_bot->HasAura(PRAYER_OF_SHADOW_PROTECTION)*/ /*&& !m_bot->HasAura(PRAYER_OF_SHADOW_PROTECTION)*/
-            m_ai->CastSpell(SHADOW_RESISTANCE_AURA);
+        if (!m_bot.HasAura(SHADOW_RESISTANCE_AURA) && SHADOW_RESISTANCE_AURA > 0 && !m_bot.HasAura(SHADOW_RESISTANCE_AURA)) // /*&& !m_bot.HasAura(PRAYER_OF_SHADOW_PROTECTION)*/ /*&& !m_bot.HasAura(PRAYER_OF_SHADOW_PROTECTION)*/
+            m_ai.CastSpell(SHADOW_RESISTANCE_AURA);
         return;
     }
 
     // if there is a tank in the group, use concentration aura
     bool tankInGroup = false;
-    if (m_bot->GetGroup())
+    if (m_bot.GetGroup())
     {
-        Group::MemberSlotList const& groupSlot = m_bot->GetGroup()->GetMemberSlots();
+        Group::MemberSlotList const& groupSlot = m_bot.GetGroup()->GetMemberSlots();
         for (auto itr = groupSlot.begin(); itr != groupSlot.end(); itr++)
         {
             Player* groupMember = sObjectMgr.GetPlayer(itr->guid);
@@ -437,20 +432,20 @@ void PlayerbotPaladinAI::CheckAuras()
     // If we have no resist orders, adjust aura based on spec or tank
     if (spec == PALADIN_SPEC_PROTECTION || tankInGroup)
     {
-        if (DEVOTION_AURA > 0 && !m_bot->HasAura(DEVOTION_AURA))
-            m_ai->CastSpell(DEVOTION_AURA);
+        if (DEVOTION_AURA > 0 && !m_bot.HasAura(DEVOTION_AURA))
+            m_ai.CastSpell(DEVOTION_AURA);
         return;
     }
     else if (spec == PALADIN_SPEC_HOLY)
     {
-        if (CONCENTRATION_AURA > 0 && !m_bot->HasAura(CONCENTRATION_AURA))
-            m_ai->CastSpell(CONCENTRATION_AURA);
+        if (CONCENTRATION_AURA > 0 && !m_bot.HasAura(CONCENTRATION_AURA))
+            m_ai.CastSpell(CONCENTRATION_AURA);
         return;
     }
     else if (spec == PALADIN_SPEC_RETRIBUTION)
     {
-        if (RETRIBUTION_AURA > 0 && !m_bot->HasAura(RETRIBUTION_AURA))
-            m_ai->CastSpell(RETRIBUTION_AURA);
+        if (RETRIBUTION_AURA > 0 && !m_bot.HasAura(RETRIBUTION_AURA))
+            m_ai.CastSpell(RETRIBUTION_AURA);
         return;
     }
 }
@@ -461,8 +456,6 @@ void PlayerbotPaladinAI::CheckAuras()
 // TODO: handle other paladins in group/raid, for example to cast Seal/Judgement of Light
 bool PlayerbotPaladinAI::CheckSealAndJudgement(Unit* target)
 {
-    if (!m_ai)     return false;
-    if (!m_bot)    return false;
     if (!target)   return false;
 
     if (target->GetTypeId() == TYPEID_UNIT)
@@ -471,7 +464,7 @@ bool PlayerbotPaladinAI::CheckSealAndJudgement(Unit* target)
         // Prevent low health humanoid from fleeing by judging them with Seal of Justice
         if (creature->GetCreatureInfo()->CreatureType == CREATURE_TYPE_HUMANOID && target->GetHealthPercent() < 20 && !creature->IsWorldBoss())
         {
-            if (SEAL_OF_JUSTICE > 0 && !m_bot->HasAura(SEAL_OF_JUSTICE, EFFECT_INDEX_0) && m_ai->CastSpell(SEAL_OF_JUSTICE, *m_bot) == SPELL_CAST_OK)
+            if (SEAL_OF_JUSTICE > 0 && !m_bot.HasAura(SEAL_OF_JUSTICE, EFFECT_INDEX_0) && m_ai.CastSpell(SEAL_OF_JUSTICE, m_bot) == SPELL_CAST_OK)
             {
                 m_CurrentSeal = SEAL_OF_JUSTICE;
                 m_CurrentJudgement = 0;
@@ -481,17 +474,17 @@ bool PlayerbotPaladinAI::CheckSealAndJudgement(Unit* target)
     }
 
     // Bot already defined a seal and a judgement and each is active on bot and target: don't waste time to go further
-    if (m_CurrentSeal > 0 && m_bot->HasAura(m_CurrentSeal, EFFECT_INDEX_0) && m_CurrentJudgement > 0 && target->HasAura(m_CurrentJudgement, EFFECT_INDEX_0))
+    if (m_CurrentSeal > 0 && m_bot.HasAura(m_CurrentSeal, EFFECT_INDEX_0) && m_CurrentJudgement > 0 && target->HasAura(m_CurrentJudgement, EFFECT_INDEX_0))
         return false;
 
     // Refresh judgement if needed by forcing paladin bot to cast seal and judgement anew
     // But first, unleash current seal if bot can do extra damage to the target in the process
     if (m_CurrentJudgement > 0 && !target->HasAura(m_CurrentJudgement, EFFECT_INDEX_0))
     {
-        if (m_bot->HasAura(SEAL_OF_COMMAND, EFFECT_INDEX_0) || m_bot->HasAura(SEAL_OF_RIGHTEOUSNESS, EFFECT_INDEX_0))
+        if (m_bot.HasAura(SEAL_OF_COMMAND, EFFECT_INDEX_0) || m_bot.HasAura(SEAL_OF_RIGHTEOUSNESS, EFFECT_INDEX_0))
         {
-            if (JUDGEMENT > 0 && m_bot->IsSpellReady(JUDGEMENT) && m_ai->In_Reach(target, JUDGEMENT))
-                m_ai->CastSpell(JUDGEMENT, *target);
+            if (JUDGEMENT > 0 && m_bot.IsSpellReady(JUDGEMENT) && m_ai.In_Reach(target, JUDGEMENT))
+                m_ai.CastSpell(JUDGEMENT, *target);
         }
 
         m_CurrentJudgement = 0;
@@ -500,16 +493,16 @@ bool PlayerbotPaladinAI::CheckSealAndJudgement(Unit* target)
     }
 
     // Judgement is still active on target: refresh seal on bot if needed
-    if (m_CurrentJudgement > 0 && m_CurrentSeal > 0 && !m_bot->HasAura(m_CurrentSeal, EFFECT_INDEX_0))
+    if (m_CurrentJudgement > 0 && m_CurrentSeal > 0 && !m_bot.HasAura(m_CurrentSeal, EFFECT_INDEX_0))
     {
-        if (m_ai->CastSpell(m_CurrentSeal, *m_bot) == SPELL_CAST_OK)
+        if (m_ai.CastSpell(m_CurrentSeal, m_bot) == SPELL_CAST_OK)
             return true;
     }
 
     // No judgement on target but bot has seal active: time to judge the target
-    if (m_CurrentJudgement == 0 && m_CurrentSeal > 0 && m_bot->HasAura(m_CurrentSeal, EFFECT_INDEX_0))
+    if (m_CurrentJudgement == 0 && m_CurrentSeal > 0 && m_bot.HasAura(m_CurrentSeal, EFFECT_INDEX_0))
     {
-        if (JUDGEMENT > 0 && m_bot->IsSpellReady(JUDGEMENT) && m_ai->In_Reach(target, JUDGEMENT) && m_ai->CastSpell(JUDGEMENT, *target) == SPELL_CAST_OK)
+        if (JUDGEMENT > 0 && m_bot.IsSpellReady(JUDGEMENT) && m_ai.In_Reach(target, JUDGEMENT) && m_ai.CastSpell(JUDGEMENT, *target) == SPELL_CAST_OK)
         {
             if (m_CurrentSeal == SEAL_OF_JUSTICE)
                 m_CurrentJudgement = JUDGEMENT_OF_JUSTICE;
@@ -531,12 +524,12 @@ bool PlayerbotPaladinAI::CheckSealAndJudgement(Unit* target)
     // Now bot casts seal on him/herself
     // No judgement on target: look for best seal to judge target next
     // Target already judged: bot will buff him/herself for combat according to spec/orders
-    uint32 spec = m_bot->GetSpec();
+    uint32 spec = m_bot.GetSpec();
 
     // Bypass spec if combat orders were given
-    if (m_ai->IsHealer()) spec = PALADIN_SPEC_HOLY;
-    if (m_ai->IsTank()) spec = PALADIN_SPEC_PROTECTION;
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_ASSIST) spec = PALADIN_SPEC_RETRIBUTION;
+    if (m_ai.IsHealer()) spec = PALADIN_SPEC_HOLY;
+    if (m_ai.IsTank()) spec = PALADIN_SPEC_PROTECTION;
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_ASSIST) spec = PALADIN_SPEC_RETRIBUTION;
 
     if (m_CurrentJudgement == 0)
     {
@@ -564,27 +557,24 @@ bool PlayerbotPaladinAI::CheckSealAndJudgement(Unit* target)
         }
     }
 
-    return m_CurrentSeal > 0 && !m_bot->HasAura(m_CurrentSeal, EFFECT_INDEX_0) && m_ai->CastSpell(m_CurrentSeal, *m_bot) == SPELL_CAST_OK;
+    return m_CurrentSeal > 0 && !m_bot.HasAura(m_CurrentSeal, EFFECT_INDEX_0) && m_ai.CastSpell(m_CurrentSeal, m_bot) == SPELL_CAST_OK;
 }
 
 void PlayerbotPaladinAI::DoNonCombatActions()
 {
-    if (!m_ai)   return;
-    if (!m_bot)  return;
-
-    if (!m_bot->IsAlive() || m_bot->IsInDuel()) return;
+    if (!m_bot.IsAlive() || m_bot.IsInDuel()) return;
 
     CheckAuras();
 
     //Put up RF if tank
-    if (m_ai->IsTank())
-        m_ai->SelfBuff(RIGHTEOUS_FURY);
+    if (m_ai.IsTank())
+        m_ai.SelfBuff(RIGHTEOUS_FURY);
     //Disable RF if not tank
-    else if (m_bot->HasAura(RIGHTEOUS_FURY))
-        m_bot->RemoveAurasDueToSpell(RIGHTEOUS_FURY);
+    else if (m_bot.HasAura(RIGHTEOUS_FURY))
+        m_bot.RemoveAurasDueToSpell(RIGHTEOUS_FURY);
 
     // Dispel magic/disease/poison
-    if (m_ai->HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
+    if (m_ai.HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
         return;
 
     // Revive
@@ -592,7 +582,7 @@ void PlayerbotPaladinAI::DoNonCombatActions()
         return;
 
     // Heal
-    if (m_ai->IsHealer())
+    if (m_ai.IsHealer())
     {
         if (HealPlayer(GetHealTarget()) & RETURN_CONTINUE)
             return; // RETURN_CONTINUE;
@@ -601,7 +591,7 @@ void PlayerbotPaladinAI::DoNonCombatActions()
     {
         // Is this desirable? Debatable.
         // TODO: In a group/raid with a healer you'd want this bot to focus on DPS (it's not specced/geared for healing either)
-        if (HealPlayer(m_bot) & RETURN_CONTINUE)
+        if (HealPlayer(&m_bot) & RETURN_CONTINUE)
             return; // RETURN_CONTINUE;
     }
 
@@ -616,14 +606,14 @@ void PlayerbotPaladinAI::DoNonCombatActions()
     // Search and apply stones to weapons
     // Mainhand ...
     Item* stone, * weapon;
-    weapon = m_bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+    weapon = m_bot.GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
     if (weapon && weapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0)
     {
-        stone = m_ai->FindStoneFor(weapon);
+        stone = m_ai.FindStoneFor(weapon);
         if (stone)
         {
-            m_ai->UseItem(stone, EQUIPMENT_SLOT_MAINHAND);
-            m_ai->SetIgnoreUpdateTime(5);
+            m_ai.UseItem(stone, EQUIPMENT_SLOT_MAINHAND);
+            m_ai.SetIgnoreUpdateTime(5);
         }
     }
 }
@@ -754,22 +744,20 @@ bool PlayerbotPaladinAI::BuffHelper(PlayerbotAI* ai, uint32 spellId, Unit* targe
 // Match up with "Pull()" below
 bool PlayerbotPaladinAI::CanPull()
 {
-    if (HAND_OF_RECKONING > 0 && m_bot->IsSpellReady(HAND_OF_RECKONING))
+    if (HAND_OF_RECKONING > 0 && m_bot.IsSpellReady(HAND_OF_RECKONING))
         return true;
-    return EXORCISM > 0 && m_bot->IsSpellReady(EXORCISM);
+    return EXORCISM > 0 && m_bot.IsSpellReady(EXORCISM);
 }
 
 // Match up with "CanPull()" above
 bool PlayerbotPaladinAI::Pull()
 {
-    return EXORCISM > 0 && m_ai->CastSpell(EXORCISM) == SPELL_CAST_OK;
+    return EXORCISM > 0 && m_ai.CastSpell(EXORCISM) == SPELL_CAST_OK;
 }
 
 bool PlayerbotPaladinAI::CastHoTOnTank()
 {
-    if (!m_ai) return false;
-
-    if (!m_ai->IsHealer()) return false;
+    if (!m_ai.IsHealer()) return false;
 
     // Paladin: Sheath of Light (with talents), Flash of Light (with Infusion of Light talent and only on a target with the Sacred Shield buff),
     //          Holy Shock (with Tier 8 set bonus)

--- a/src/game/PlayerBot/AI/PlayerbotPaladinAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotPaladinAI.cpp
@@ -21,7 +21,7 @@
 
 class PlayerbotAI;
 
-PlayerbotPaladinAI::PlayerbotPaladinAI(Player* const master, Player* const bot, PlayerbotAI* const ai) : PlayerbotClassAI(master, bot, ai)
+PlayerbotPaladinAI::PlayerbotPaladinAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
 {
     RETRIBUTION_AURA              = m_ai->initSpell(RETRIBUTION_AURA_1);
     SEAL_OF_COMMAND               = m_ai->initSpell(SEAL_OF_COMMAND_1);

--- a/src/game/PlayerBot/AI/PlayerbotPaladinAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotPaladinAI.h
@@ -68,7 +68,7 @@ enum PaladinSpells
 class MANGOS_DLL_SPEC PlayerbotPaladinAI : PlayerbotClassAI
 {
     public:
-        PlayerbotPaladinAI(Player* const master, Player* const bot, PlayerbotAI* const ai);
+        PlayerbotPaladinAI(Player& master, Player& bot, PlayerbotAI& ai);
         virtual ~PlayerbotPaladinAI();
 
         // all combat actions go here

--- a/src/game/PlayerBot/AI/PlayerbotPaladinAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotPaladinAI.h
@@ -72,27 +72,27 @@ class MANGOS_DLL_SPEC PlayerbotPaladinAI : PlayerbotClassAI
         virtual ~PlayerbotPaladinAI();
 
         // all combat actions go here
-        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget);
-        bool CanPull();
-        bool Pull();
+        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget) override;
+        bool CanPull() override;
+        bool Pull() override;
 
         // all non combat actions go here, ex buffs, heals, rezzes
-        void DoNonCombatActions();
+        void DoNonCombatActions() override;
 
         // Utility Functions
         bool CastHoTOnTank();
 
     private:
-        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget);
+        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget) override;
 
         // Heals the target based off its hps
-        CombatManeuverReturns HealPlayer(Player* target);
+        CombatManeuverReturns HealPlayer(Player* target) override;
         // Resurrects the target
-        CombatManeuverReturns ResurrectPlayer(Player* target);
+        CombatManeuverReturns ResurrectPlayer(Player* target) override;
         // Dispel disease or negative magic effects from an internally selected target
         CombatManeuverReturns DispelPlayer(Player* target = nullptr);
 

--- a/src/game/PlayerBot/AI/PlayerbotPriestAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotPriestAI.cpp
@@ -20,7 +20,7 @@
 
 class PlayerbotAI;
 
-PlayerbotPriestAI::PlayerbotPriestAI(Player* const master, Player* const bot, PlayerbotAI* const ai) : PlayerbotClassAI(master, bot, ai)
+PlayerbotPriestAI::PlayerbotPriestAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
 {
     RENEW                         = m_ai->initSpell(RENEW_1);
     LESSER_HEAL                   = m_ai->initSpell(LESSER_HEAL_1);

--- a/src/game/PlayerBot/AI/PlayerbotPriestAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotPriestAI.cpp
@@ -20,63 +20,63 @@
 
 class PlayerbotAI;
 
-PlayerbotPriestAI::PlayerbotPriestAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
+PlayerbotPriestAI::PlayerbotPriestAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(master, bot, ai)
 {
-    RENEW                         = m_ai->initSpell(RENEW_1);
-    LESSER_HEAL                   = m_ai->initSpell(LESSER_HEAL_1);
-    FLASH_HEAL                    = m_ai->initSpell(FLASH_HEAL_1);
+    RENEW                         = m_ai.initSpell(RENEW_1);
+    LESSER_HEAL                   = m_ai.initSpell(LESSER_HEAL_1);
+    FLASH_HEAL                    = m_ai.initSpell(FLASH_HEAL_1);
     (FLASH_HEAL > 0) ? FLASH_HEAL : FLASH_HEAL = LESSER_HEAL;
-    HEAL                          = m_ai->initSpell(HEAL_1);
+    HEAL                          = m_ai.initSpell(HEAL_1);
     (HEAL > 0) ? HEAL : HEAL = FLASH_HEAL;
-    GREATER_HEAL                  = m_ai->initSpell(GREATER_HEAL_1);
+    GREATER_HEAL                  = m_ai.initSpell(GREATER_HEAL_1);
     (GREATER_HEAL > 0) ? GREATER_HEAL : GREATER_HEAL = HEAL;
-    RESURRECTION                  = m_ai->initSpell(RESURRECTION_1);
-    SMITE                         = m_ai->initSpell(SMITE_1);
-    MANA_BURN                     = m_ai->initSpell(MANA_BURN_1);
-    HOLY_NOVA                     = m_ai->initSpell(HOLY_NOVA_1);
-    HOLY_FIRE                     = m_ai->initSpell(HOLY_FIRE_1);
-    DESPERATE_PRAYER              = m_ai->initSpell(DESPERATE_PRAYER_1);
-    PRAYER_OF_HEALING             = m_ai->initSpell(PRAYER_OF_HEALING_1);
-    CURE_DISEASE                  = m_ai->initSpell(CURE_DISEASE_1);
-    ABOLISH_DISEASE               = m_ai->initSpell(ABOLISH_DISEASE_1);
-    SHACKLE_UNDEAD                = m_ai->initSpell(SHACKLE_UNDEAD_1);
+    RESURRECTION                  = m_ai.initSpell(RESURRECTION_1);
+    SMITE                         = m_ai.initSpell(SMITE_1);
+    MANA_BURN                     = m_ai.initSpell(MANA_BURN_1);
+    HOLY_NOVA                     = m_ai.initSpell(HOLY_NOVA_1);
+    HOLY_FIRE                     = m_ai.initSpell(HOLY_FIRE_1);
+    DESPERATE_PRAYER              = m_ai.initSpell(DESPERATE_PRAYER_1);
+    PRAYER_OF_HEALING             = m_ai.initSpell(PRAYER_OF_HEALING_1);
+    CURE_DISEASE                  = m_ai.initSpell(CURE_DISEASE_1);
+    ABOLISH_DISEASE               = m_ai.initSpell(ABOLISH_DISEASE_1);
+    SHACKLE_UNDEAD                = m_ai.initSpell(SHACKLE_UNDEAD_1);
 
     // SHADOW
-    FADE                          = m_ai->initSpell(FADE_1);
-    SHADOW_WORD_PAIN              = m_ai->initSpell(SHADOW_WORD_PAIN_1);
-    MIND_BLAST                    = m_ai->initSpell(MIND_BLAST_1);
-    SCREAM                        = m_ai->initSpell(PSYCHIC_SCREAM_1);
-    MIND_FLAY                     = m_ai->initSpell(MIND_FLAY_1);
-    DEVOURING_PLAGUE              = m_ai->initSpell(DEVOURING_PLAGUE_1);
-    SHADOW_PROTECTION             = m_ai->initSpell(SHADOW_PROTECTION_1);
-    PRAYER_OF_SHADOW_PROTECTION   = m_ai->initSpell(PRAYER_OF_SHADOW_PROTECTION_1);
-    SHADOWFORM                    = m_ai->initSpell(SHADOWFORM_1);
-    VAMPIRIC_EMBRACE              = m_ai->initSpell(VAMPIRIC_EMBRACE_1);
+    FADE                          = m_ai.initSpell(FADE_1);
+    SHADOW_WORD_PAIN              = m_ai.initSpell(SHADOW_WORD_PAIN_1);
+    MIND_BLAST                    = m_ai.initSpell(MIND_BLAST_1);
+    SCREAM                        = m_ai.initSpell(PSYCHIC_SCREAM_1);
+    MIND_FLAY                     = m_ai.initSpell(MIND_FLAY_1);
+    DEVOURING_PLAGUE              = m_ai.initSpell(DEVOURING_PLAGUE_1);
+    SHADOW_PROTECTION             = m_ai.initSpell(SHADOW_PROTECTION_1);
+    PRAYER_OF_SHADOW_PROTECTION   = m_ai.initSpell(PRAYER_OF_SHADOW_PROTECTION_1);
+    SHADOWFORM                    = m_ai.initSpell(SHADOWFORM_1);
+    VAMPIRIC_EMBRACE              = m_ai.initSpell(VAMPIRIC_EMBRACE_1);
 
     // RANGED COMBAT
-    SHOOT                         = m_ai->initSpell(SHOOT_1);
+    SHOOT                         = m_ai.initSpell(SHOOT_1);
 
     // DISCIPLINE
-    INNER_FIRE                    = m_ai->initSpell(INNER_FIRE_1);
-    POWER_WORD_SHIELD             = m_ai->initSpell(POWER_WORD_SHIELD_1);
-    POWER_WORD_FORTITUDE          = m_ai->initSpell(POWER_WORD_FORTITUDE_1);
-    PRAYER_OF_FORTITUDE           = m_ai->initSpell(PRAYER_OF_FORTITUDE_1);
-    FEAR_WARD                     = m_ai->initSpell(FEAR_WARD_1);
-    DIVINE_SPIRIT                 = m_ai->initSpell(DIVINE_SPIRIT_1);
-    PRAYER_OF_SPIRIT              = m_ai->initSpell(PRAYER_OF_SPIRIT_1);
-    POWER_INFUSION                = m_ai->initSpell(POWER_INFUSION_1);
-    INNER_FOCUS                   = m_ai->initSpell(INNER_FOCUS_1);
-    PRIEST_DISPEL_MAGIC           = m_ai->initSpell(DISPEL_MAGIC_1);
+    INNER_FIRE                    = m_ai.initSpell(INNER_FIRE_1);
+    POWER_WORD_SHIELD             = m_ai.initSpell(POWER_WORD_SHIELD_1);
+    POWER_WORD_FORTITUDE          = m_ai.initSpell(POWER_WORD_FORTITUDE_1);
+    PRAYER_OF_FORTITUDE           = m_ai.initSpell(PRAYER_OF_FORTITUDE_1);
+    FEAR_WARD                     = m_ai.initSpell(FEAR_WARD_1);
+    DIVINE_SPIRIT                 = m_ai.initSpell(DIVINE_SPIRIT_1);
+    PRAYER_OF_SPIRIT              = m_ai.initSpell(PRAYER_OF_SPIRIT_1);
+    POWER_INFUSION                = m_ai.initSpell(POWER_INFUSION_1);
+    INNER_FOCUS                   = m_ai.initSpell(INNER_FOCUS_1);
+    PRIEST_DISPEL_MAGIC           = m_ai.initSpell(DISPEL_MAGIC_1);
 
     RECENTLY_BANDAGED             = 11196; // first aid check
 
     // racial
-    STONEFORM                     = m_ai->initSpell(STONEFORM_ALL); // dwarf
-    ELUNES_GRACE                  = m_ai->initSpell(ELUNES_GRACE_1); // night elf
-    PERCEPTION                    = m_ai->initSpell(PERCEPTION_ALL); // human
-    SHADOWMELD                    = m_ai->initSpell(SHADOWMELD_ALL);
-    BERSERKING                    = m_ai->initSpell(BERSERKING_ALL); // troll
-    WILL_OF_THE_FORSAKEN          = m_ai->initSpell(WILL_OF_THE_FORSAKEN_ALL); // undead
+    STONEFORM                     = m_ai.initSpell(STONEFORM_ALL); // dwarf
+    ELUNES_GRACE                  = m_ai.initSpell(ELUNES_GRACE_1); // night elf
+    PERCEPTION                    = m_ai.initSpell(PERCEPTION_ALL); // human
+    SHADOWMELD                    = m_ai.initSpell(SHADOWMELD_ALL);
+    BERSERKING                    = m_ai.initSpell(BERSERKING_ALL); // troll
+    WILL_OF_THE_FORSAKEN          = m_ai.initSpell(WILL_OF_THE_FORSAKEN_ALL); // undead
 }
 
 PlayerbotPriestAI::~PlayerbotPriestAI() {}
@@ -85,30 +85,30 @@ CombatManeuverReturns PlayerbotPriestAI::DoFirstCombatManeuver(Unit* pTarget)
 {
     // There are NPCs in BGs and Open World PvP, so don't filter this on PvP scenarios (of course if PvP targets anyone but tank, all bets are off anyway)
     // Wait until the tank says so, until any non-tank gains aggro or X seconds - whichever is shortest
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->GroupTankHoldsAggro())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.GroupTankHoldsAggro())
         {
-            if (PlayerbotAI::ORDERS_HEAL & m_ai->GetCombatOrder())
+            if (PlayerbotAI::ORDERS_HEAL & m_ai.GetCombatOrder())
                 return HealPlayer(GetHealTarget());
             else
                 return RETURN_NO_ACTION_OK; // wait it out
         }
         else
         {
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
         }
     }
 
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->IsGroupReady())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.IsGroupReady())
             return RETURN_NO_ACTION_OK; // wait it out
         else
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
     }
 
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -125,10 +125,7 @@ CombatManeuverReturns PlayerbotPriestAI::DoFirstCombatManeuver(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotPriestAI::DoFirstCombatManeuverPVE(Unit* /*pTarget*/)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
-    if (m_ai->IsHealer())
+    if (m_ai.IsHealer())
     {
         // Cast renew on tank
         if (CastHoTOnTank())
@@ -145,9 +142,9 @@ CombatManeuverReturns PlayerbotPriestAI::DoFirstCombatManeuverPVP(Unit* /*pTarge
 CombatManeuverReturns PlayerbotPriestAI::DoNextCombatManeuver(Unit* pTarget)
 {
     // Face enemy, make sure bot is attacking
-    m_ai->FaceTarget(pTarget);
+    m_ai.FaceTarget(pTarget);
 
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -164,16 +161,13 @@ CombatManeuverReturns PlayerbotPriestAI::DoNextCombatManeuver(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotPriestAI::DoNextCombatManeuverPVE(Unit* pTarget)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
-    bool meleeReach = m_bot->CanReachWithMeleeAttack(pTarget);
-    uint32 spec = m_bot->GetSpec();
+    bool meleeReach = m_bot.CanReachWithMeleeAttack(pTarget);
+    uint32 spec = m_bot.GetSpec();
 
     // Define a tank bot will look at
     // or Main Tank if healer has order to do so
     Unit* mainTank;
-    if (m_ai->IsMainHealer())
+    if (m_ai.IsMainHealer())
         mainTank = GetHealTarget(JOB_MAIN_TANK);
     // Else look at tank from own group if one
     else
@@ -182,80 +176,80 @@ CombatManeuverReturns PlayerbotPriestAI::DoNextCombatManeuverPVE(Unit* pTarget)
     if (!mainTank)
         mainTank = GetHealTarget(JOB_TANK);
 
-    if (m_ai->GetCombatStyle() != PlayerbotAI::COMBAT_RANGED && !meleeReach)
-        m_ai->SetCombatStyle(PlayerbotAI::COMBAT_RANGED);
+    if (m_ai.GetCombatStyle() != PlayerbotAI::COMBAT_RANGED && !meleeReach)
+        m_ai.SetCombatStyle(PlayerbotAI::COMBAT_RANGED);
     // switch to melee if in melee range AND can't shoot OR have no ranged (wand) equipped AND is not healer
-    else if (m_ai->GetCombatStyle() != PlayerbotAI::COMBAT_MELEE
+    else if (m_ai.GetCombatStyle() != PlayerbotAI::COMBAT_MELEE
              && meleeReach
-             && (SHOOT == 0 || !m_bot->GetWeaponForAttack(RANGED_ATTACK, true, true))
-             && !m_ai->IsHealer())
-        m_ai->SetCombatStyle(PlayerbotAI::COMBAT_MELEE);
+             && (SHOOT == 0 || !m_bot.GetWeaponForAttack(RANGED_ATTACK, true, true))
+             && !m_ai.IsHealer())
+        m_ai.SetCombatStyle(PlayerbotAI::COMBAT_MELEE);
 
     // Dwarves priests will try to buff with Fear Ward
-    if (FEAR_WARD > 0 && m_bot->IsSpellReady(FEAR_WARD))
+    if (FEAR_WARD > 0 && m_bot.IsSpellReady(FEAR_WARD))
     {
         // Buff tank first
         if (mainTank)
         {
-            if (m_ai->In_Reach(mainTank, FEAR_WARD) && !mainTank->HasAura(FEAR_WARD, EFFECT_INDEX_0) && CastSpell(FEAR_WARD, mainTank))
+            if (m_ai.In_Reach(mainTank, FEAR_WARD) && !mainTank->HasAura(FEAR_WARD, EFFECT_INDEX_0) && CastSpell(FEAR_WARD, mainTank))
                 return RETURN_CONTINUE;
         }
         // Else try to buff master
         else if (GetMaster())
         {
-            if (m_ai->In_Reach(GetMaster(), FEAR_WARD) && !GetMaster()->HasAura(FEAR_WARD, EFFECT_INDEX_0) && CastSpell(FEAR_WARD, GetMaster()))
+            if (m_ai.In_Reach(GetMaster(), FEAR_WARD) && !GetMaster()->HasAura(FEAR_WARD, EFFECT_INDEX_0) && CastSpell(FEAR_WARD, GetMaster()))
                 return RETURN_CONTINUE;
         }
     }
 
     //Used to determine if this bot is highest on threat
-    Unit* newTarget = m_ai->FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), m_bot);
+    Unit* newTarget = m_ai.FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), &m_bot);
     if (newTarget && !PlayerbotAI::IsNeutralized(newTarget)) // TODO: && party has a tank
     {
-        if (FADE > 0 && !m_bot->HasAura(FADE, EFFECT_INDEX_0) && m_bot->IsSpellReady(FADE))
+        if (FADE > 0 && !m_bot.HasAura(FADE, EFFECT_INDEX_0) && m_bot.IsSpellReady(FADE))
         {
-            if (CastSpell(FADE, m_bot))
+            if (CastSpell(FADE, &m_bot))
             {
-                m_ai->TellMaster("I'm casting fade.");
+                m_ai.TellMaster("I'm casting fade.");
                 return RETURN_CONTINUE;
             }
             else
-                m_ai->TellMaster("I have AGGRO.");
+                m_ai.TellMaster("I have AGGRO.");
         }
 
         // Heal myself
         // TODO: move to HealTarget code
-        if (m_ai->GetHealthPercent() < 35 && POWER_WORD_SHIELD > 0 && !m_bot->HasAura(POWER_WORD_SHIELD, EFFECT_INDEX_0) && !m_bot->HasAura(WEAKNED_SOUL, EFFECT_INDEX_0))
+        if (m_ai.GetHealthPercent() < 35 && POWER_WORD_SHIELD > 0 && !m_bot.HasAura(POWER_WORD_SHIELD, EFFECT_INDEX_0) && !m_bot.HasAura(WEAKNED_SOUL, EFFECT_INDEX_0))
         {
             if (CastSpell(POWER_WORD_SHIELD) & RETURN_CONTINUE)
             {
-                m_ai->TellMaster("I'm casting PW:S on myself.");
+                m_ai.TellMaster("I'm casting PW:S on myself.");
                 return RETURN_CONTINUE;
             }
-            else if (m_ai->IsHealer()) // Even if any other RETURN_ANY_OK - aside from RETURN_CONTINUE
-                m_ai->TellMaster("Your healer's about TO DIE. HELP ME.");
+            else if (m_ai.IsHealer()) // Even if any other RETURN_ANY_OK - aside from RETURN_CONTINUE
+                m_ai.TellMaster("Your healer's about TO DIE. HELP ME.");
         }
-        if (m_ai->GetHealthPercent() < 35 && DESPERATE_PRAYER > 0 && m_ai->In_Reach(m_bot, DESPERATE_PRAYER) && CastSpell(DESPERATE_PRAYER, m_bot) & RETURN_CONTINUE)
+        if (m_ai.GetHealthPercent() < 35 && DESPERATE_PRAYER > 0 && m_ai.In_Reach(&m_bot, DESPERATE_PRAYER) && CastSpell(DESPERATE_PRAYER, &m_bot) & RETURN_CONTINUE)
         {
-            m_ai->TellMaster("I'm casting desperate prayer.");
+            m_ai.TellMaster("I'm casting desperate prayer.");
             return RETURN_CONTINUE;
         }
         // Night Elves priest bot can also cast Elune's Grace to improve his/her dodge rating
-        if (ELUNES_GRACE && !m_bot->HasAura(ELUNES_GRACE, EFFECT_INDEX_0) && m_bot->IsSpellReady(ELUNES_GRACE) && CastSpell(ELUNES_GRACE, m_bot))
+        if (ELUNES_GRACE && !m_bot.HasAura(ELUNES_GRACE, EFFECT_INDEX_0) && m_bot.IsSpellReady(ELUNES_GRACE) && CastSpell(ELUNES_GRACE, &m_bot))
             return RETURN_CONTINUE;
 
         // If enemy comes in melee reach
         if (meleeReach)
         {
             // Already healed self or tank. If healer, do nothing else to anger mob
-            if (m_ai->IsHealer())
+            if (m_ai.IsHealer())
                 return RETURN_NO_ACTION_OK; // In a sense, mission accomplished.
 
             // Have threat, can't quickly lower it. 3 options remain: Stop attacking, lowlevel damage (wand), keep on keeping on.
             if (newTarget->GetHealthPercent() > 25)
             {
                 // If elite, do nothing and pray tank gets aggro off you
-                if (m_ai->IsElite(newTarget))
+                if (m_ai.IsElite(newTarget))
                     return RETURN_NO_ACTION_OK;
 
                 // Not an elite. You could insert PSYCHIC SCREAM here but in any PvE situation that's 90-95% likely
@@ -266,11 +260,11 @@ CombatManeuverReturns PlayerbotPriestAI::DoNextCombatManeuverPVE(Unit* pTarget)
     }
 
     // Dispel magic/disease
-    if (m_ai->HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
+    if (m_ai.HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
         return RETURN_CONTINUE;
 
     // Damage tweaking for healers
-    if (m_ai->IsHealer())
+    if (m_ai.IsHealer())
     {
         // Heal (try to pick a target by on common rules, than heal using each PlayerbotClassAI HealPlayer() method)
         if (FindTargetAndHeal())
@@ -278,12 +272,12 @@ CombatManeuverReturns PlayerbotPriestAI::DoNextCombatManeuverPVE(Unit* pTarget)
 
         // No one needs to be healed: do small damage instead
         // If target is elite and not handled by MT: do nothing
-        if (m_ai->IsElite(pTarget) && mainTank && mainTank->GetVictim() != pTarget)
+        if (m_ai.IsElite(pTarget) && mainTank && mainTank->GetVictim() != pTarget)
             return RETURN_NO_ACTION_OK;
 
         // Cast Shadow Word:Pain on current target and keep its up (if mana >= 40% or target HP < 15%)
-        if (SHADOW_WORD_PAIN > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai->In_Reach(pTarget, SHADOW_WORD_PAIN) && !pTarget->HasAura(SHADOW_WORD_PAIN, EFFECT_INDEX_0) &&
-                (pTarget->GetHealthPercent() < 15 || m_ai->GetManaPercent() >= 40) && CastSpell(SHADOW_WORD_PAIN, pTarget))
+        if (SHADOW_WORD_PAIN > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai.In_Reach(pTarget, SHADOW_WORD_PAIN) && !pTarget->HasAura(SHADOW_WORD_PAIN, EFFECT_INDEX_0) &&
+                (pTarget->GetHealthPercent() < 15 || m_ai.GetManaPercent() >= 40) && CastSpell(SHADOW_WORD_PAIN, pTarget))
             return RETURN_CONTINUE;
         else // else shoot at it
             return CastSpell(SHOOT, pTarget);
@@ -293,51 +287,51 @@ CombatManeuverReturns PlayerbotPriestAI::DoNextCombatManeuverPVE(Unit* pTarget)
     switch (spec)
     {
         case PRIEST_SPEC_HOLY:
-            if (HOLY_FIRE > 0 && m_ai->In_Reach(pTarget, HOLY_FIRE) && !pTarget->HasAura(HOLY_FIRE, EFFECT_INDEX_0) && CastSpell(HOLY_FIRE, pTarget))
+            if (HOLY_FIRE > 0 && m_ai.In_Reach(pTarget, HOLY_FIRE) && !pTarget->HasAura(HOLY_FIRE, EFFECT_INDEX_0) && CastSpell(HOLY_FIRE, pTarget))
                 return RETURN_CONTINUE;
-            if (SMITE > 0 && m_ai->In_Reach(pTarget, SMITE) && CastSpell(SMITE, pTarget))
+            if (SMITE > 0 && m_ai.In_Reach(pTarget, SMITE) && CastSpell(SMITE, pTarget))
                 return RETURN_CONTINUE;
-            //if (HOLY_NOVA > 0 && m_ai->In_Reach(pTarget,HOLY_NOVA) && meleeReach && m_ai->CastSpell(HOLY_NOVA) == SPELL_CAST_OK)
+            //if (HOLY_NOVA > 0 && m_ai.In_Reach(pTarget,HOLY_NOVA) && meleeReach && m_ai.CastSpell(HOLY_NOVA) == SPELL_CAST_OK)
             //    return RETURN_CONTINUE;
             break;
 
         case PRIEST_SPEC_SHADOW:
-            if (DEVOURING_PLAGUE > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai->In_Reach(pTarget, DEVOURING_PLAGUE) && !pTarget->HasAura(DEVOURING_PLAGUE, EFFECT_INDEX_0) && CastSpell(DEVOURING_PLAGUE, pTarget))
+            if (DEVOURING_PLAGUE > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai.In_Reach(pTarget, DEVOURING_PLAGUE) && !pTarget->HasAura(DEVOURING_PLAGUE, EFFECT_INDEX_0) && CastSpell(DEVOURING_PLAGUE, pTarget))
                 return RETURN_CONTINUE;
-            if (SHADOW_WORD_PAIN > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai->In_Reach(pTarget, SHADOW_WORD_PAIN) && !pTarget->HasAura(SHADOW_WORD_PAIN, EFFECT_INDEX_0) && CastSpell(SHADOW_WORD_PAIN, pTarget))
+            if (SHADOW_WORD_PAIN > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai.In_Reach(pTarget, SHADOW_WORD_PAIN) && !pTarget->HasAura(SHADOW_WORD_PAIN, EFFECT_INDEX_0) && CastSpell(SHADOW_WORD_PAIN, pTarget))
                 return RETURN_CONTINUE;
-            if (MIND_BLAST > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai->In_Reach(pTarget, MIND_BLAST) && (m_bot->IsSpellReady(MIND_BLAST)) && CastSpell(MIND_BLAST, pTarget))
+            if (MIND_BLAST > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai.In_Reach(pTarget, MIND_BLAST) && (m_bot.IsSpellReady(MIND_BLAST)) && CastSpell(MIND_BLAST, pTarget))
                 return RETURN_CONTINUE;
-            if (MIND_FLAY > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai->In_Reach(pTarget, MIND_FLAY) && CastSpell(MIND_FLAY, pTarget))
+            if (MIND_FLAY > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai.In_Reach(pTarget, MIND_FLAY) && CastSpell(MIND_FLAY, pTarget))
             {
-                m_ai->SetIgnoreUpdateTime(3);
+                m_ai.SetIgnoreUpdateTime(3);
                 return RETURN_CONTINUE;
             }
-            if (SHADOWFORM == 0 && MIND_FLAY == 0 && SMITE > 0 && m_ai->In_Reach(pTarget, SMITE) && CastSpell(SMITE, pTarget)) // low levels
+            if (SHADOWFORM == 0 && MIND_FLAY == 0 && SMITE > 0 && m_ai.In_Reach(pTarget, SMITE) && CastSpell(SMITE, pTarget)) // low levels
                 return RETURN_CONTINUE;
             break;
 
         case PRIEST_SPEC_DISCIPLINE:
-            if (POWER_INFUSION > 0 && m_ai->In_Reach(GetMaster(), POWER_INFUSION) && CastSpell(POWER_INFUSION, GetMaster())) // TODO: just master?
+            if (POWER_INFUSION > 0 && m_ai.In_Reach(GetMaster(), POWER_INFUSION) && CastSpell(POWER_INFUSION, GetMaster())) // TODO: just master?
                 return RETURN_CONTINUE;
-            if (INNER_FOCUS > 0 && m_ai->In_Reach(m_bot, INNER_FOCUS) && !m_bot->HasAura(INNER_FOCUS, EFFECT_INDEX_0) && CastSpell(INNER_FOCUS, m_bot))
+            if (INNER_FOCUS > 0 && m_ai.In_Reach(&m_bot, INNER_FOCUS) && !m_bot.HasAura(INNER_FOCUS, EFFECT_INDEX_0) && CastSpell(INNER_FOCUS, &m_bot))
                 return RETURN_CONTINUE;
-            if (SMITE > 0 && m_ai->In_Reach(pTarget, SMITE) && CastSpell(SMITE, pTarget))
+            if (SMITE > 0 && m_ai.In_Reach(pTarget, SMITE) && CastSpell(SMITE, pTarget))
                 return RETURN_CONTINUE;
             break;
     }
 
     // No spec due to low level OR no spell found yet
-    if (MIND_BLAST > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai->In_Reach(pTarget, MIND_BLAST) && (m_bot->IsSpellReady(MIND_BLAST)) && CastSpell(MIND_BLAST, pTarget))
+    if (MIND_BLAST > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai.In_Reach(pTarget, MIND_BLAST) && (m_bot.IsSpellReady(MIND_BLAST)) && CastSpell(MIND_BLAST, pTarget))
         return RETURN_CONTINUE;
-    if (SHADOW_WORD_PAIN > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai->In_Reach(pTarget, SHADOW_WORD_PAIN) && !pTarget->HasAura(SHADOW_WORD_PAIN, EFFECT_INDEX_0) && CastSpell(SHADOW_WORD_PAIN, pTarget))
+    if (SHADOW_WORD_PAIN > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai.In_Reach(pTarget, SHADOW_WORD_PAIN) && !pTarget->HasAura(SHADOW_WORD_PAIN, EFFECT_INDEX_0) && CastSpell(SHADOW_WORD_PAIN, pTarget))
         return RETURN_CONTINUE;
-    if (MIND_FLAY > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai->In_Reach(pTarget, MIND_FLAY) && CastSpell(MIND_FLAY, pTarget))
+    if (MIND_FLAY > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai.In_Reach(pTarget, MIND_FLAY) && CastSpell(MIND_FLAY, pTarget))
     {
-        m_ai->SetIgnoreUpdateTime(3);
+        m_ai.SetIgnoreUpdateTime(3);
         return RETURN_CONTINUE;
     }
-    if (SHADOWFORM == 0 && SMITE > 0 && m_ai->In_Reach(pTarget, SMITE) && CastSpell(SMITE, pTarget))
+    if (SHADOWFORM == 0 && SMITE > 0 && m_ai.In_Reach(pTarget, SMITE) && CastSpell(SMITE, pTarget))
         return RETURN_CONTINUE;
 
     // Default: shoot with wand
@@ -346,32 +340,32 @@ CombatManeuverReturns PlayerbotPriestAI::DoNextCombatManeuverPVE(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotPriestAI::DoNextCombatManeuverPVP(Unit* pTarget)
 {
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
             // TODO: spec tweaking
-            if (m_ai->HasAura(SCREAM, *pTarget) && m_ai->GetHealthPercent() < 60 && HEAL && m_ai->In_Reach(pTarget, HEAL) && CastSpell(HEAL) & RETURN_ANY_OK)
+            if (m_ai.HasAura(SCREAM, *pTarget) && m_ai.GetHealthPercent() < 60 && HEAL && m_ai.In_Reach(pTarget, HEAL) && CastSpell(HEAL) & RETURN_ANY_OK)
                 return RETURN_CONTINUE;
 
-            if (SHADOW_WORD_PAIN && m_ai->In_Reach(pTarget, SHADOW_WORD_PAIN) && CastSpell(SHADOW_WORD_PAIN) & RETURN_ANY_OK) // TODO: Check whether enemy has it active yet
+            if (SHADOW_WORD_PAIN && m_ai.In_Reach(pTarget, SHADOW_WORD_PAIN) && CastSpell(SHADOW_WORD_PAIN) & RETURN_ANY_OK) // TODO: Check whether enemy has it active yet
                 return RETURN_CONTINUE;
 
-            if (m_ai->GetHealthPercent() < 80 && RENEW && m_ai->In_Reach(pTarget, RENEW) && CastSpell(RENEW) & RETURN_ANY_OK) // TODO: Check whether you have renew active on you
+            if (m_ai.GetHealthPercent() < 80 && RENEW && m_ai.In_Reach(pTarget, RENEW) && CastSpell(RENEW) & RETURN_ANY_OK) // TODO: Check whether you have renew active on you
                 return RETURN_CONTINUE;
 
-            if (SCREAM && m_ai->In_Reach(pTarget, SCREAM) && CastSpell(SCREAM) & RETURN_ANY_OK) // TODO: Check for cooldown
+            if (SCREAM && m_ai.In_Reach(pTarget, SCREAM) && CastSpell(SCREAM) & RETURN_ANY_OK) // TODO: Check for cooldown
                 return RETURN_CONTINUE;
 
-            if (MIND_BLAST && m_ai->In_Reach(pTarget, MIND_BLAST) && CastSpell(MIND_BLAST) & RETURN_ANY_OK) // TODO: Check for cooldown
+            if (MIND_BLAST && m_ai.In_Reach(pTarget, MIND_BLAST) && CastSpell(MIND_BLAST) & RETURN_ANY_OK) // TODO: Check for cooldown
                 return RETURN_CONTINUE;
 
-            if (m_ai->GetHealthPercent() < 50 && GREATER_HEAL && m_ai->In_Reach(pTarget, GREATER_HEAL) && CastSpell(GREATER_HEAL) & RETURN_ANY_OK)
+            if (m_ai.GetHealthPercent() < 50 && GREATER_HEAL && m_ai.In_Reach(pTarget, GREATER_HEAL) && CastSpell(GREATER_HEAL) & RETURN_ANY_OK)
                 return RETURN_CONTINUE;
 
-            if (SMITE && m_ai->In_Reach(pTarget, SMITE) && CastSpell(SMITE) & RETURN_ANY_OK)
+            if (SMITE && m_ai.In_Reach(pTarget, SMITE) && CastSpell(SMITE) & RETURN_ANY_OK)
                 return RETURN_CONTINUE;
 
-            m_ai->TellMaster("Couldn't find a spell to cast while dueling");
+            m_ai.TellMaster("Couldn't find a spell to cast while dueling");
         default:
             break;
     }
@@ -396,31 +390,31 @@ CombatManeuverReturns PlayerbotPriestAI::HealPlayer(Player* target)
     // TODO: This code should be common to all healers and will probably
     // move to a more suitable place like PlayerbotAI::DoCombatMovement()
     if ((GetTargetJob(target) == JOB_TANK || GetTargetJob(target) == JOB_MAIN_TANK)
-            && m_bot->GetPlayerbotAI()->GetMovementOrder() != PlayerbotAI::MOVEMENT_STAY
-            && !m_ai->In_Reach(target, FLASH_HEAL))
+            && m_bot.GetPlayerbotAI()->GetMovementOrder() != PlayerbotAI::MOVEMENT_STAY
+            && !m_ai.In_Reach(target, FLASH_HEAL))
     {
-        m_bot->GetMotionMaster()->MoveFollow(target, 39.0f, m_bot->GetOrientation());
+        m_bot.GetMotionMaster()->MoveFollow(target, 39.0f, m_bot.GetOrientation());
         return RETURN_CONTINUE;
     }
 
     // Get a free and more efficient heal if needed: low mana for bot or average health for target
-    if (m_ai->IsInCombat() && (hp < 50 || m_ai->GetManaPercent() < 40))
-        if (INNER_FOCUS > 0 && m_bot->IsSpellReady(INNER_FOCUS) && !m_bot->HasAura(INNER_FOCUS, EFFECT_INDEX_0) && CastSpell(INNER_FOCUS, m_bot))
+    if (m_ai.IsInCombat() && (hp < 50 || m_ai.GetManaPercent() < 40))
+        if (INNER_FOCUS > 0 && m_bot.IsSpellReady(INNER_FOCUS) && !m_bot.HasAura(INNER_FOCUS, EFFECT_INDEX_0) && CastSpell(INNER_FOCUS, &m_bot))
             return RETURN_CONTINUE;
 
-    if (hp < 25 && POWER_WORD_SHIELD > 0 && m_ai->IsInCombat() && m_ai->In_Reach(target, POWER_WORD_SHIELD) && !m_bot->HasAura(POWER_WORD_SHIELD, EFFECT_INDEX_0) && !target->HasAura(WEAKNED_SOUL, EFFECT_INDEX_0) && m_ai->CastSpell(POWER_WORD_SHIELD, *target) == SPELL_CAST_OK)
+    if (hp < 25 && POWER_WORD_SHIELD > 0 && m_ai.IsInCombat() && m_ai.In_Reach(target, POWER_WORD_SHIELD) && !m_bot.HasAura(POWER_WORD_SHIELD, EFFECT_INDEX_0) && !target->HasAura(WEAKNED_SOUL, EFFECT_INDEX_0) && m_ai.CastSpell(POWER_WORD_SHIELD, *target) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
-    if (hp < 35 && FLASH_HEAL > 0 && m_ai->In_Reach(target, FLASH_HEAL) && m_ai->CastSpell(FLASH_HEAL, *target) == SPELL_CAST_OK)
+    if (hp < 35 && FLASH_HEAL > 0 && m_ai.In_Reach(target, FLASH_HEAL) && m_ai.CastSpell(FLASH_HEAL, *target) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
-    if (hp < 50 && GREATER_HEAL > 0 && m_ai->In_Reach(target, GREATER_HEAL) && m_ai->CastSpell(GREATER_HEAL, *target) == SPELL_CAST_OK)
+    if (hp < 50 && GREATER_HEAL > 0 && m_ai.In_Reach(target, GREATER_HEAL) && m_ai.CastSpell(GREATER_HEAL, *target) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
-    if (hp < 70 && HEAL > 0 && m_ai->In_Reach(target, HEAL) && m_ai->CastSpell(HEAL, *target) == SPELL_CAST_OK)
+    if (hp < 70 && HEAL > 0 && m_ai.In_Reach(target, HEAL) && m_ai.CastSpell(HEAL, *target) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
-    if (hp < 90 && RENEW > 0 && m_ai->In_Reach(target, RENEW) && !target->HasAura(RENEW) && m_ai->CastSpell(RENEW, *target) == SPELL_CAST_OK)
+    if (hp < 90 && RENEW > 0 && m_ai.In_Reach(target, RENEW) && !target->HasAura(RENEW) && m_ai.CastSpell(RENEW, *target) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
     // Group heal. Not really useful until a group check is available?
-    //if (hp < 40 && PRAYER_OF_HEALING > 0 && m_ai->CastSpell(PRAYER_OF_HEALING, *target) & RETURN_CONTINUE)
+    //if (hp < 40 && PRAYER_OF_HEALING > 0 && m_ai.CastSpell(PRAYER_OF_HEALING, *target) & RETURN_CONTINUE)
     //    return RETURN_CONTINUE;
 
     return RETURN_NO_ACTION_OK;
@@ -432,14 +426,14 @@ CombatManeuverReturns PlayerbotPriestAI::ResurrectPlayer(Player* target)
     if (r != RETURN_NO_ACTION_OK)
         return r;
 
-    if (m_ai->IsInCombat())     // Just in case as this was supposedly checked before calling this function
+    if (m_ai.IsInCombat())     // Just in case as this was supposedly checked before calling this function
         return RETURN_NO_ACTION_ERROR;
 
-    if (RESURRECTION > 0 && m_ai->In_Reach(target, RESURRECTION) && m_ai->CastSpell(RESURRECTION, *target) == SPELL_CAST_OK)
+    if (RESURRECTION > 0 && m_ai.In_Reach(target, RESURRECTION) && m_ai.CastSpell(RESURRECTION, *target) == SPELL_CAST_OK)
     {
         std::string msg = "Resurrecting ";
         msg += target->GetName();
-        m_bot->Say(msg, LANG_UNIVERSAL);
+        m_bot.Say(msg, LANG_UNIVERSAL);
         return RETURN_CONTINUE;
     }
     return RETURN_NO_ACTION_ERROR; // not error per se - possibly just OOM
@@ -475,19 +469,16 @@ CombatManeuverReturns PlayerbotPriestAI::DispelPlayer(Player* /*target*/)
 
 void PlayerbotPriestAI::DoNonCombatActions()
 {
-    if (!m_ai)   return;
-    if (!m_bot)  return;
+    if (!m_bot.IsAlive() || m_bot.IsInDuel()) return;
 
-    if (!m_bot->IsAlive() || m_bot->IsInDuel()) return;
-
-    uint32 spec = m_bot->GetSpec();
+    uint32 spec = m_bot.GetSpec();
 
     // selfbuff goes first
-    if (m_ai->SelfBuff(INNER_FIRE) == SPELL_CAST_OK)
+    if (m_ai.SelfBuff(INNER_FIRE) == SPELL_CAST_OK)
         return;
 
     // Dispel magic/disease
-    if (m_ai->HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
+    if (m_ai.HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
         return;
 
     // Revive
@@ -496,12 +487,12 @@ void PlayerbotPriestAI::DoNonCombatActions()
 
     // After revive
     if (spec == PRIEST_SPEC_SHADOW && SHADOWFORM > 0)
-        m_ai->SelfBuff(SHADOWFORM);
+        m_ai.SelfBuff(SHADOWFORM);
     if (VAMPIRIC_EMBRACE > 0)
-        m_ai->SelfBuff(VAMPIRIC_EMBRACE);
+        m_ai.SelfBuff(VAMPIRIC_EMBRACE);
 
     // Heal
-    if (m_ai->IsHealer())
+    if (m_ai.IsHealer())
     {
         if (HealPlayer(GetHealTarget()) & RETURN_CONTINUE)
             return;// RETURN_CONTINUE;
@@ -510,13 +501,13 @@ void PlayerbotPriestAI::DoNonCombatActions()
     {
         // Is this desirable? Debatable.
         // TODO: In a group/raid with a healer you'd want this bot to focus on DPS (it's not specced/geared for healing either)
-        if (HealPlayer(m_bot) & RETURN_CONTINUE)
+        if (HealPlayer(&m_bot) & RETURN_CONTINUE)
             return;// RETURN_CONTINUE;
     }
 
     // Buffing
     // the check for group targets is performed by NeedGroupBuff (if group is found for bots by the function)
-    if (NeedGroupBuff(PRAYER_OF_FORTITUDE, POWER_WORD_FORTITUDE) && m_ai->HasSpellReagents(PRAYER_OF_FORTITUDE))
+    if (NeedGroupBuff(PRAYER_OF_FORTITUDE, POWER_WORD_FORTITUDE) && m_ai.HasSpellReagents(PRAYER_OF_FORTITUDE))
     {
         if (Buff(&PlayerbotPriestAI::BuffHelper, PRAYER_OF_FORTITUDE) & RETURN_CONTINUE)
             return;
@@ -524,7 +515,7 @@ void PlayerbotPriestAI::DoNonCombatActions()
     else if (Buff(&PlayerbotPriestAI::BuffHelper, POWER_WORD_FORTITUDE) & RETURN_CONTINUE)
         return;
 
-    if (NeedGroupBuff(PRAYER_OF_SPIRIT, DIVINE_SPIRIT) && m_ai->HasSpellReagents(PRAYER_OF_FORTITUDE))
+    if (NeedGroupBuff(PRAYER_OF_SPIRIT, DIVINE_SPIRIT) && m_ai.HasSpellReagents(PRAYER_OF_FORTITUDE))
     {
         if (Buff(&PlayerbotPriestAI::BuffHelper, PRAYER_OF_SPIRIT) & RETURN_CONTINUE)
             return;
@@ -532,23 +523,23 @@ void PlayerbotPriestAI::DoNonCombatActions()
     else if (Buff(&PlayerbotPriestAI::BuffHelper, DIVINE_SPIRIT, (JOB_ALL | JOB_MANAONLY)) & RETURN_CONTINUE)
         return;
 
-    if (NeedGroupBuff(PRAYER_OF_SHADOW_PROTECTION, SHADOW_PROTECTION) && m_ai->HasSpellReagents(PRAYER_OF_FORTITUDE))
+    if (NeedGroupBuff(PRAYER_OF_SHADOW_PROTECTION, SHADOW_PROTECTION) && m_ai.HasSpellReagents(PRAYER_OF_FORTITUDE))
     {
-        if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_SHADOW && Buff(&PlayerbotPriestAI::BuffHelper, PRAYER_OF_SHADOW_PROTECTION) & RETURN_CONTINUE)
+        if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_SHADOW && Buff(&PlayerbotPriestAI::BuffHelper, PRAYER_OF_SHADOW_PROTECTION) & RETURN_CONTINUE)
             return;
     }
-    else if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_SHADOW && Buff(&PlayerbotPriestAI::BuffHelper, SHADOW_PROTECTION) & RETURN_CONTINUE)
+    else if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_SHADOW && Buff(&PlayerbotPriestAI::BuffHelper, SHADOW_PROTECTION) & RETURN_CONTINUE)
         return;
 
     if (EatDrinkBandage())
         return;
 
     // Nothing else to do, Night Elves will cast Shadowmeld to reduce their aggro versus patrols or nearby mobs
-    if (SHADOWMELD > 0 && !m_bot->isMovingOrTurning()
-        && !m_bot->IsMounted()
-        && !m_bot->HasAura(SHADOWMELD, EFFECT_INDEX_0))
+    if (SHADOWMELD > 0 && !m_bot.isMovingOrTurning()
+        && !m_bot.IsMounted()
+        && !m_bot.HasAura(SHADOWMELD, EFFECT_INDEX_0))
     {
-        m_ai->CastSpell(SHADOWMELD, *m_bot);
+        m_ai.CastSpell(SHADOWMELD, m_bot);
     }
 } // end DoNonCombatActions
 
@@ -568,13 +559,11 @@ bool PlayerbotPriestAI::BuffHelper(PlayerbotAI* ai, uint32 spellId, Unit* target
 
 bool PlayerbotPriestAI::CastHoTOnTank()
 {
-    if (!m_ai) return false;
-
-    if (!m_ai->IsHealer()) return false;
+    if (!m_ai.IsHealer()) return false;
 
     // Priest HoTs: Renew, Penance (with talents, channeled)
-    if (RENEW > 0 && m_ai->In_Reach(m_ai->GetGroupTank(), RENEW))
-        return (RETURN_CONTINUE & CastSpell(RENEW, m_ai->GetGroupTank()));
+    if (RENEW > 0 && m_ai.In_Reach(m_ai.GetGroupTank(), RENEW))
+        return (RETURN_CONTINUE & CastSpell(RENEW, m_ai.GetGroupTank()));
 
     return false;
 }
@@ -582,13 +571,11 @@ bool PlayerbotPriestAI::CastHoTOnTank()
 // Return to UpdateAI the spellId usable to neutralize a target with creaturetype
 uint32 PlayerbotPriestAI::Neutralize(uint8 creatureType)
 {
-    if (!m_bot)         return 0;
-    if (!m_ai)          return 0;
     if (!creatureType)  return 0;
 
     if (creatureType != CREATURE_TYPE_UNDEAD)
     {
-        m_ai->TellMaster("I can't shackle that target.");
+        m_ai.TellMaster("I can't shackle that target.");
         return 0;
     }
 

--- a/src/game/PlayerBot/AI/PlayerbotPriestAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotPriestAI.cpp
@@ -195,11 +195,8 @@ CombatManeuverReturns PlayerbotPriestAI::DoNextCombatManeuverPVE(Unit* pTarget)
                 return RETURN_CONTINUE;
         }
         // Else try to buff master
-        else if (GetMaster())
-        {
-            if (m_ai.In_Reach(GetMaster(), FEAR_WARD) && !GetMaster()->HasAura(FEAR_WARD, EFFECT_INDEX_0) && CastSpell(FEAR_WARD, GetMaster()))
-                return RETURN_CONTINUE;
-        }
+        if (m_ai.In_Reach(&m_master, FEAR_WARD) && !m_master.HasAura(FEAR_WARD, EFFECT_INDEX_0) && CastSpell(FEAR_WARD, &m_master))
+            return RETURN_CONTINUE;
     }
 
     //Used to determine if this bot is highest on threat
@@ -312,7 +309,7 @@ CombatManeuverReturns PlayerbotPriestAI::DoNextCombatManeuverPVE(Unit* pTarget)
             break;
 
         case PRIEST_SPEC_DISCIPLINE:
-            if (POWER_INFUSION > 0 && m_ai.In_Reach(GetMaster(), POWER_INFUSION) && CastSpell(POWER_INFUSION, GetMaster())) // TODO: just master?
+            if (POWER_INFUSION > 0 && m_ai.In_Reach(&m_master, POWER_INFUSION) && CastSpell(POWER_INFUSION, &m_master)) // TODO: just master?
                 return RETURN_CONTINUE;
             if (INNER_FOCUS > 0 && m_ai.In_Reach(&m_bot, INNER_FOCUS) && !m_bot.HasAura(INNER_FOCUS, EFFECT_INDEX_0) && CastSpell(INNER_FOCUS, &m_bot))
                 return RETURN_CONTINUE;

--- a/src/game/PlayerBot/AI/PlayerbotPriestAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotPriestAI.h
@@ -84,28 +84,28 @@ class MANGOS_DLL_SPEC PlayerbotPriestAI : PlayerbotClassAI
         virtual ~PlayerbotPriestAI();
 
         // all combat actions go here
-        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget);
-        uint32 Neutralize(uint8 creatureType);
+        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget) override;
+        uint32 Neutralize(uint8 creatureType) override;
 
         // all non combat actions go here, ex buffs, heals, rezzes
-        void DoNonCombatActions();
+        void DoNonCombatActions() override;
 
         // Utility Functions
         bool CastHoTOnTank();
 
     private:
-        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget);
+        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget) override;
 
         CombatManeuverReturns CastSpell(uint32 nextAction, Unit* pTarget = nullptr) { return CastSpellWand(nextAction, pTarget, SHOOT); }
 
         // Heals the target based off its hps
-        CombatManeuverReturns HealPlayer(Player* target);
+        CombatManeuverReturns HealPlayer(Player* target) override;
         // Resurrects the target
-        CombatManeuverReturns ResurrectPlayer(Player* target);
+        CombatManeuverReturns ResurrectPlayer(Player* target) override;
         // Dispel disease or negative magic effects from an internally selected target
         CombatManeuverReturns DispelPlayer(Player* target = nullptr);
 

--- a/src/game/PlayerBot/AI/PlayerbotPriestAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotPriestAI.h
@@ -80,7 +80,7 @@ enum PriestSpells
 class MANGOS_DLL_SPEC PlayerbotPriestAI : PlayerbotClassAI
 {
     public:
-        PlayerbotPriestAI(Player* const master, Player* const bot, PlayerbotAI* const ai);
+        PlayerbotPriestAI(Player& master, Player& bot, PlayerbotAI& ai);
         virtual ~PlayerbotPriestAI();
 
         // all combat actions go here

--- a/src/game/PlayerBot/AI/PlayerbotRogueAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotRogueAI.cpp
@@ -20,7 +20,7 @@
 #include "../Base/PlayerbotMgr.h"
 
 class PlayerbotAI;
-PlayerbotRogueAI::PlayerbotRogueAI(Player* const master, Player* const bot, PlayerbotAI* const ai) : PlayerbotClassAI(master, bot, ai)
+PlayerbotRogueAI::PlayerbotRogueAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
 {
     ADRENALINE_RUSH          = m_ai->initSpell(ADRENALINE_RUSH_1);
     SINISTER_STRIKE          = m_ai->initSpell(SINISTER_STRIKE_1);

--- a/src/game/PlayerBot/AI/PlayerbotRogueAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotRogueAI.cpp
@@ -20,46 +20,46 @@
 #include "../Base/PlayerbotMgr.h"
 
 class PlayerbotAI;
-PlayerbotRogueAI::PlayerbotRogueAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
+PlayerbotRogueAI::PlayerbotRogueAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(master, bot, ai)
 {
-    ADRENALINE_RUSH          = m_ai->initSpell(ADRENALINE_RUSH_1);
-    SINISTER_STRIKE          = m_ai->initSpell(SINISTER_STRIKE_1);
-    BACKSTAB                 = m_ai->initSpell(BACKSTAB_1);
-    KICK                     = m_ai->initSpell(KICK_1);
-    FEINT                    = m_ai->initSpell(FEINT_1);
-    GOUGE                    = m_ai->initSpell(GOUGE_1);
-    SPRINT                   = m_ai->initSpell(SPRINT_1);
+    ADRENALINE_RUSH          = m_ai.initSpell(ADRENALINE_RUSH_1);
+    SINISTER_STRIKE          = m_ai.initSpell(SINISTER_STRIKE_1);
+    BACKSTAB                 = m_ai.initSpell(BACKSTAB_1);
+    KICK                     = m_ai.initSpell(KICK_1);
+    FEINT                    = m_ai.initSpell(FEINT_1);
+    GOUGE                    = m_ai.initSpell(GOUGE_1);
+    SPRINT                   = m_ai.initSpell(SPRINT_1);
 
-    STEALTH                  = m_ai->initSpell(STEALTH_1);
-    VANISH                   = m_ai->initSpell(VANISH_1);
-    EVASION                  = m_ai->initSpell(EVASION_1);
-    HEMORRHAGE               = m_ai->initSpell(HEMORRHAGE_1);
-    GHOSTLY_STRIKE           = m_ai->initSpell(GHOSTLY_STRIKE_1);
-    BLIND                    = m_ai->initSpell(BLIND_1);
-    DISTRACT                 = m_ai->initSpell(DISTRACT_1);
-    PREPARATION              = m_ai->initSpell(PREPARATION_1);
-    PREMEDITATION            = m_ai->initSpell(PREMEDITATION_1);
-    PICK_POCKET              = m_ai->initSpell(PICK_POCKET_1);
+    STEALTH                  = m_ai.initSpell(STEALTH_1);
+    VANISH                   = m_ai.initSpell(VANISH_1);
+    EVASION                  = m_ai.initSpell(EVASION_1);
+    HEMORRHAGE               = m_ai.initSpell(HEMORRHAGE_1);
+    GHOSTLY_STRIKE           = m_ai.initSpell(GHOSTLY_STRIKE_1);
+    BLIND                    = m_ai.initSpell(BLIND_1);
+    DISTRACT                 = m_ai.initSpell(DISTRACT_1);
+    PREPARATION              = m_ai.initSpell(PREPARATION_1);
+    PREMEDITATION            = m_ai.initSpell(PREMEDITATION_1);
+    PICK_POCKET              = m_ai.initSpell(PICK_POCKET_1);
 
-    EVISCERATE               = m_ai->initSpell(EVISCERATE_1);
-    KIDNEY_SHOT              = m_ai->initSpell(KIDNEY_SHOT_1);
-    SLICE_DICE               = m_ai->initSpell(SLICE_AND_DICE_1);
-    GARROTE                  = m_ai->initSpell(GARROTE_1);
-    EXPOSE_ARMOR             = m_ai->initSpell(EXPOSE_ARMOR_1);
-    RUPTURE                  = m_ai->initSpell(RUPTURE_1);
-    CHEAP_SHOT               = m_ai->initSpell(CHEAP_SHOT_1);
-    AMBUSH                   = m_ai->initSpell(AMBUSH_1);
-    COLD_BLOOD               = m_ai->initSpell(COLD_BLOOD_1);
+    EVISCERATE               = m_ai.initSpell(EVISCERATE_1);
+    KIDNEY_SHOT              = m_ai.initSpell(KIDNEY_SHOT_1);
+    SLICE_DICE               = m_ai.initSpell(SLICE_AND_DICE_1);
+    GARROTE                  = m_ai.initSpell(GARROTE_1);
+    EXPOSE_ARMOR             = m_ai.initSpell(EXPOSE_ARMOR_1);
+    RUPTURE                  = m_ai.initSpell(RUPTURE_1);
+    CHEAP_SHOT               = m_ai.initSpell(CHEAP_SHOT_1);
+    AMBUSH                   = m_ai.initSpell(AMBUSH_1);
+    COLD_BLOOD               = m_ai.initSpell(COLD_BLOOD_1);
 
     RECENTLY_BANDAGED        = 11196; // first aid check
     // racial
-    STONEFORM                = m_ai->initSpell(STONEFORM_ALL); // dwarf
-    ESCAPE_ARTIST            = m_ai->initSpell(ESCAPE_ARTIST_ALL); // gnome
-    PERCEPTION               = m_ai->initSpell(PERCEPTION_ALL); // human
-    SHADOWMELD               = m_ai->initSpell(SHADOWMELD_ALL);
-    BLOOD_FURY               = m_ai->initSpell(BLOOD_FURY_ALL); // orc
-    BERSERKING               = m_ai->initSpell(BERSERKING_ALL); // troll
-    WILL_OF_THE_FORSAKEN     = m_ai->initSpell(WILL_OF_THE_FORSAKEN_ALL); // undead
+    STONEFORM                = m_ai.initSpell(STONEFORM_ALL); // dwarf
+    ESCAPE_ARTIST            = m_ai.initSpell(ESCAPE_ARTIST_ALL); // gnome
+    PERCEPTION               = m_ai.initSpell(PERCEPTION_ALL); // human
+    SHADOWMELD               = m_ai.initSpell(SHADOWMELD_ALL);
+    BLOOD_FURY               = m_ai.initSpell(BLOOD_FURY_ALL); // orc
+    BERSERKING               = m_ai.initSpell(BERSERKING_ALL); // troll
+    WILL_OF_THE_FORSAKEN     = m_ai.initSpell(WILL_OF_THE_FORSAKEN_ALL); // undead
 }
 
 PlayerbotRogueAI::~PlayerbotRogueAI() {}
@@ -68,30 +68,27 @@ CombatManeuverReturns PlayerbotRogueAI::DoFirstCombatManeuver(Unit* pTarget)
 {
     // There are NPCs in BGs and Open World PvP, so don't filter this on PvP scenarios (of course if PvP targets anyone but tank, all bets are off anyway)
     // Wait until the tank says so, until any non-tank gains aggro or X seconds - whichever is shortest
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->GroupTankHoldsAggro())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.GroupTankHoldsAggro())
         {
             return RETURN_NO_ACTION_OK; // wait it out
         }
         else
         {
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
         }
     }
 
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->IsGroupReady())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.IsGroupReady())
             return RETURN_NO_ACTION_OK; // wait it out
         else
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
     }
 
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -111,13 +108,13 @@ CombatManeuverReturns PlayerbotRogueAI::DoFirstCombatManeuver(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotRogueAI::DoFirstCombatManeuverPVE(Unit* pTarget)
 {
-    if (STEALTH > 0 && !m_bot->HasAura(STEALTH, EFFECT_INDEX_0) && m_ai->CastSpell(STEALTH, *m_bot) == SPELL_CAST_OK)
+    if (STEALTH > 0 && !m_bot.HasAura(STEALTH, EFFECT_INDEX_0) && m_ai.CastSpell(STEALTH, m_bot) == SPELL_CAST_OK)
     {
         return RETURN_FINISHED_FIRST_MOVES; // DoNextCombatManeuver handles active stealth
     }
-    else if (m_bot->HasAura(STEALTH, EFFECT_INDEX_0))
+    else if (m_bot.HasAura(STEALTH, EFFECT_INDEX_0))
     {
-        m_bot->GetMotionMaster()->MoveFollow(pTarget, 4.5f, m_bot->GetOrientation()); // TODO: this isn't the place for movement code, is it?
+        m_bot.GetMotionMaster()->MoveFollow(pTarget, 4.5f, m_bot.GetOrientation()); // TODO: this isn't the place for movement code, is it?
         return RETURN_FINISHED_FIRST_MOVES; // DoNextCombatManeuver handles active stealth
     }
 
@@ -128,13 +125,13 @@ CombatManeuverReturns PlayerbotRogueAI::DoFirstCombatManeuverPVE(Unit* pTarget)
 // TODO: blatant copy of PVE for now, please PVP-port it
 CombatManeuverReturns PlayerbotRogueAI::DoFirstCombatManeuverPVP(Unit* pTarget)
 {
-    if (STEALTH > 0 && !m_bot->HasAura(STEALTH, EFFECT_INDEX_0) && m_ai->CastSpell(STEALTH, *m_bot) == SPELL_CAST_OK)
+    if (STEALTH > 0 && !m_bot.HasAura(STEALTH, EFFECT_INDEX_0) && m_ai.CastSpell(STEALTH, m_bot) == SPELL_CAST_OK)
     {
         return RETURN_FINISHED_FIRST_MOVES; // DoNextCombatManeuver handles active stealth
     }
-    else if (m_bot->HasAura(STEALTH, EFFECT_INDEX_0))
+    else if (m_bot.HasAura(STEALTH, EFFECT_INDEX_0))
     {
-        m_bot->GetMotionMaster()->MoveFollow(pTarget, 4.5f, m_bot->GetOrientation()); // TODO: this isn't the place for movement code, is it?
+        m_bot.GetMotionMaster()->MoveFollow(pTarget, 4.5f, m_bot.GetOrientation()); // TODO: this isn't the place for movement code, is it?
         return RETURN_FINISHED_FIRST_MOVES; // DoNextCombatManeuver handles active stealth
     }
 
@@ -145,9 +142,9 @@ CombatManeuverReturns PlayerbotRogueAI::DoFirstCombatManeuverPVP(Unit* pTarget)
 CombatManeuverReturns PlayerbotRogueAI::DoNextCombatManeuver(Unit* pTarget)
 {
     // Face enemy, make sure bot is attacking
-    m_ai->FaceTarget(pTarget);
+    m_ai.FaceTarget(pTarget);
 
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -168,87 +165,85 @@ CombatManeuverReturns PlayerbotRogueAI::DoNextCombatManeuver(Unit* pTarget)
 CombatManeuverReturns PlayerbotRogueAI::DoNextCombatManeuverPVE(Unit* pTarget)
 {
     if (!pTarget) return RETURN_NO_ACTION_ERROR;
-    if (!m_ai)    return RETURN_NO_ACTION_ERROR;
-    if (!m_bot)   return RETURN_NO_ACTION_ERROR;
 
     Unit* pVictim = pTarget->GetVictim();
-    bool meleeReach = m_bot->CanReachWithMeleeAttack(pTarget);
+    bool meleeReach = m_bot.CanReachWithMeleeAttack(pTarget);
 
     // TODO: make this work better...
     /*if (pVictim)
        {
-        if( pVictim!=m_bot && !m_bot->hasUnitState(UNIT_STAT_FOLLOW) && !pTarget->isInBackInMap(m_bot,10) ) {
-            m_ai->TellMaster( "getting behind target" );
-            m_bot->GetMotionMaster()->Clear( true );
-            m_bot->GetMotionMaster()->MoveFollow( pTarget, 1, 2*M_PI );
+        if( pVictim!=m_bot && !m_bot.hasUnitState(UNIT_STAT_FOLLOW) && !pTarget->isInBackInMap(m_bot,10) ) {
+            m_ai.TellMaster( "getting behind target" );
+            m_bot.GetMotionMaster()->Clear( true );
+            m_bot.GetMotionMaster()->MoveFollow( pTarget, 1, 2*M_PI );
         }
-        else if( pVictim==m_bot && m_bot->hasUnitState(UNIT_STAT_FOLLOW) )
+        else if( pVictim==m_bot && m_bot.hasUnitState(UNIT_STAT_FOLLOW) )
         {
-            m_ai->TellMaster( "chasing attacking target" );
-            m_bot->GetMotionMaster()->Clear( true );
-            m_bot->GetMotionMaster()->MoveChase( pTarget );
+            m_ai.TellMaster( "chasing attacking target" );
+            m_bot.GetMotionMaster()->Clear( true );
+            m_bot.GetMotionMaster()->MoveChase( pTarget );
         }
        }*/
 
     // If bot is stealthed: pre-combat actions
-    if (m_bot->HasAura(STEALTH, EFFECT_INDEX_0))
+    if (m_bot.HasAura(STEALTH, EFFECT_INDEX_0))
     {
-        if (PICK_POCKET > 0 && m_ai->In_Reach(pTarget, PICK_POCKET) && (pTarget->GetCreatureTypeMask() & CREATURE_TYPEMASK_HUMANOID_OR_UNDEAD) != 0 && m_ai->PickPocket(pTarget))
+        if (PICK_POCKET > 0 && m_ai.In_Reach(pTarget, PICK_POCKET) && (pTarget->GetCreatureTypeMask() & CREATURE_TYPEMASK_HUMANOID_OR_UNDEAD) != 0 && m_ai.PickPocket(pTarget))
             return RETURN_CONTINUE;
-        if (PREMEDITATION > 0 && m_ai->CastSpell(PREMEDITATION, *pTarget) == SPELL_CAST_OK)
+        if (PREMEDITATION > 0 && m_ai.CastSpell(PREMEDITATION, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (AMBUSH > 0 && pTarget->isInBackInMap(m_bot, 5.0f) && m_ai->CastSpell(AMBUSH, *pTarget) == SPELL_CAST_OK)
+        if (AMBUSH > 0 && pTarget->isInBackInMap(&m_bot, 5.0f) && m_ai.CastSpell(AMBUSH, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (CHEAP_SHOT > 0 && !pTarget->HasAura(CHEAP_SHOT, EFFECT_INDEX_0) && m_ai->CastSpell(CHEAP_SHOT, *pTarget) == SPELL_CAST_OK)
+        if (CHEAP_SHOT > 0 && !pTarget->HasAura(CHEAP_SHOT, EFFECT_INDEX_0) && m_ai.CastSpell(CHEAP_SHOT, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (GARROTE > 0 && pTarget->isInBackInMap(m_bot, 5.0f) && m_ai->CastSpell(GARROTE, *pTarget) == SPELL_CAST_OK)
+        if (GARROTE > 0 && pTarget->isInBackInMap(&m_bot, 5.0f) && m_ai.CastSpell(GARROTE, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
 
         // No appropriate action found, remove stealth
-        m_bot->RemoveSpellsCausingAura(SPELL_AURA_MOD_STEALTH);
+        m_bot.RemoveSpellsCausingAura(SPELL_AURA_MOD_STEALTH);
         return RETURN_CONTINUE;
     }
 
     //Used to determine if this bot has highest threat
-    Unit* newTarget = m_ai->FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), m_bot);
-    if (newTarget && !(m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TANK) && !m_ai->IsNeutralized(newTarget)) // TODO: && party has a tank
+    Unit* newTarget = m_ai.FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), &m_bot);
+    if (newTarget && !(m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TANK) && !m_ai.IsNeutralized(newTarget)) // TODO: && party has a tank
     {
         // Aggroed by an elite
-        if (m_ai->IsElite(newTarget))
+        if (m_ai.IsElite(newTarget))
         {
-            if (VANISH > 0 && m_ai->GetHealthPercent() <= 20 && m_bot->IsSpellReady(VANISH) && !m_bot->HasAura(FEINT, EFFECT_INDEX_0) && m_ai->CastSpell(VANISH) == SPELL_CAST_OK)
+            if (VANISH > 0 && m_ai.GetHealthPercent() <= 20 && m_bot.IsSpellReady(VANISH) && !m_bot.HasAura(FEINT, EFFECT_INDEX_0) && m_ai.CastSpell(VANISH) == SPELL_CAST_OK)
             {
-                m_ai->SetIgnoreUpdateTime(11);
+                m_ai.SetIgnoreUpdateTime(11);
                 return RETURN_CONTINUE;
             }
-            if (BLIND > 0 && m_ai->GetHealthPercent() <= 30 && m_ai->HasSpellReagents(BLIND) && !newTarget->HasAura(BLIND, EFFECT_INDEX_0) && m_ai->CastSpell(BLIND, *newTarget) == SPELL_CAST_OK)
+            if (BLIND > 0 && m_ai.GetHealthPercent() <= 30 && m_ai.HasSpellReagents(BLIND) && !newTarget->HasAura(BLIND, EFFECT_INDEX_0) && m_ai.CastSpell(BLIND, *newTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (EVASION > 0 && m_ai->GetHealthPercent() <= 35 && m_bot->IsSpellReady(EVASION) && !m_bot->HasAura(EVASION, EFFECT_INDEX_0) && m_ai->CastSpell(EVASION) == SPELL_CAST_OK)
+            if (EVASION > 0 && m_ai.GetHealthPercent() <= 35 && m_bot.IsSpellReady(EVASION) && !m_bot.HasAura(EVASION, EFFECT_INDEX_0) && m_ai.CastSpell(EVASION) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (FEINT > 0 && m_bot->IsSpellReady(FEINT) && m_ai->CastSpell(FEINT, *newTarget) == SPELL_CAST_OK)
+            if (FEINT > 0 && m_bot.IsSpellReady(FEINT) && m_ai.CastSpell(FEINT, *newTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (PREPARATION > 0 && m_bot->IsSpellReady(PREPARATION) && (!m_bot->IsSpellReady(EVASION) || !m_bot->IsSpellReady(VANISH)) && m_ai->CastSpell(PREPARATION) == SPELL_CAST_OK)
+            if (PREPARATION > 0 && m_bot.IsSpellReady(PREPARATION) && (!m_bot.IsSpellReady(EVASION) || !m_bot.IsSpellReady(VANISH)) && m_ai.CastSpell(PREPARATION) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
         }
 
         // Default: Gouge the target
-        if (GOUGE > 0 && pTarget->isInFrontInMap(m_bot, 5.0f) && !pTarget->HasAura(GOUGE, EFFECT_INDEX_0) && m_ai->CastSpell(GOUGE, *newTarget) == SPELL_CAST_OK)
+        if (GOUGE > 0 && pTarget->isInFrontInMap(&m_bot, 5.0f) && !pTarget->HasAura(GOUGE, EFFECT_INDEX_0) && m_ai.CastSpell(GOUGE, *newTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
     }
 
     // Buff bot with cold blood if available
     // This buff is done after the stealth and aggro management code because we don't want to give starting extra damage (= extra threat) to a bot
     // as it is obviously not soloing his/her target
-    if (COLD_BLOOD > 0 && !m_bot->HasAura(COLD_BLOOD, EFFECT_INDEX_0) && m_bot->IsSpellReady(COLD_BLOOD) && m_ai->CastSpell(COLD_BLOOD, *m_bot) == SPELL_CAST_OK)
+    if (COLD_BLOOD > 0 && !m_bot.HasAura(COLD_BLOOD, EFFECT_INDEX_0) && m_bot.IsSpellReady(COLD_BLOOD) && m_ai.CastSpell(COLD_BLOOD, m_bot) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
     // Rogue like behaviour ^^
     /*if (VANISH > 0 && GetMaster()->IsDead()) { //Causes the server to crash :( removed for now.
-        m_bot->AttackStop();
-        m_bot->RemoveAllAttackers();
-        m_ai->CastSpell(VANISH);
-        //m_bot->RemoveAllSpellCooldown();
-        m_ai->TellMaster("AttackStop, CombatStop, Vanish");
+        m_bot.AttackStop();
+        m_bot.RemoveAllAttackers();
+        m_ai.CastSpell(VANISH);
+        //m_bot.RemoveAllSpellCooldown();
+        m_ai.TellMaster("AttackStop, CombatStop, Vanish");
     }*/
 
     // we fight in melee, target is not in range, skip the next part!
@@ -256,61 +251,61 @@ CombatManeuverReturns PlayerbotRogueAI::DoNextCombatManeuverPVE(Unit* pTarget)
         return RETURN_CONTINUE;
 
     // If target is elite and wounded: use adrenaline rush to finish it quicker
-    if (ADRENALINE_RUSH > 0 && m_ai->IsElite(pTarget) && pTarget->GetHealthPercent() < 50 && !m_bot->HasAura(ADRENALINE_RUSH, EFFECT_INDEX_0) && m_bot->IsSpellReady(ADRENALINE_RUSH) && m_ai->CastSpell(ADRENALINE_RUSH, *m_bot) == SPELL_CAST_OK)
+    if (ADRENALINE_RUSH > 0 && m_ai.IsElite(pTarget) && pTarget->GetHealthPercent() < 50 && !m_bot.HasAura(ADRENALINE_RUSH, EFFECT_INDEX_0) && m_bot.IsSpellReady(ADRENALINE_RUSH) && m_ai.CastSpell(ADRENALINE_RUSH, m_bot) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
     // Bot's target is casting a spell: try to interrupt it
     if (pTarget->IsNonMeleeSpellCasted(true))
     {
-        if ((KIDNEY_SHOT > 0 && m_bot->IsSpellReady(KIDNEY_SHOT) && m_bot->GetComboPoints() >= 1 && m_ai->CastSpell(KIDNEY_SHOT, *pTarget) == SPELL_CAST_OK) ||
-            (KICK > 0 && m_bot->IsSpellReady(KICK) && m_ai->CastSpell(KICK, *pTarget) == SPELL_CAST_OK))
+        if ((KIDNEY_SHOT > 0 && m_bot.IsSpellReady(KIDNEY_SHOT) && m_bot.GetComboPoints() >= 1 && m_ai.CastSpell(KIDNEY_SHOT, *pTarget) == SPELL_CAST_OK) ||
+            (KICK > 0 && m_bot.IsSpellReady(KICK) && m_ai.CastSpell(KICK, *pTarget) == SPELL_CAST_OK))
             return RETURN_CONTINUE;
     }
 
     // Finishing moves
     // Bot will try to activate finishing move at 4 combos points (5 combos points case will be bonus)
     // TODO : define combo points treshold depending on target rank and HP
-    if (m_bot->GetComboPoints() >= 4)
+    if (m_bot.GetComboPoints() >= 4)
     {
         // wait for energy
-        if (m_ai->GetEnergyAmount() < 25 && (KIDNEY_SHOT || SLICE_DICE || EXPOSE_ARMOR || RUPTURE))
+        if (m_ai.GetEnergyAmount() < 25 && (KIDNEY_SHOT || SLICE_DICE || EXPOSE_ARMOR || RUPTURE))
             return RETURN_NO_ACTION_OK;
 
         // If target is elite Slice & Dice is a must have
-        if (SLICE_DICE > 0 && m_ai->IsElite(pTarget) && !m_bot->HasAura(SLICE_DICE, EFFECT_INDEX_1) && m_ai->CastSpell(SLICE_DICE, *pTarget) == SPELL_CAST_OK) // 25 energy (checked above)
+        if (SLICE_DICE > 0 && m_ai.IsElite(pTarget) && !m_bot.HasAura(SLICE_DICE, EFFECT_INDEX_1) && m_ai.CastSpell(SLICE_DICE, *pTarget) == SPELL_CAST_OK) // 25 energy (checked above)
             return RETURN_CONTINUE;
 
         // If target is a warrior or paladin type (high armor): expose its armor unless already tanked by a warrior (Sunder Armor > Expose Armor)
-        if (m_ai->IsElite(pTarget) && ((Creature*)pTarget)->GetCreatureInfo()->UnitClass != 8)
+        if (m_ai.IsElite(pTarget) && ((Creature*)pTarget)->GetCreatureInfo()->UnitClass != 8)
         {
-            if  (!m_ai->GetGroupTank() || (m_ai->GetGroupTank() && m_ai->GetGroupTank()->GetVictim() != pTarget))
+            if  (!m_ai.GetGroupTank() || (m_ai.GetGroupTank() && m_ai.GetGroupTank()->GetVictim() != pTarget))
             {
-                if (EXPOSE_ARMOR > 0 && !pTarget->HasAura(EXPOSE_ARMOR, EFFECT_INDEX_0) && m_ai->CastSpell(EXPOSE_ARMOR, *pTarget) == SPELL_CAST_OK) // 25 energy (checked above)
+                if (EXPOSE_ARMOR > 0 && !pTarget->HasAura(EXPOSE_ARMOR, EFFECT_INDEX_0) && m_ai.CastSpell(EXPOSE_ARMOR, *pTarget) == SPELL_CAST_OK) // 25 energy (checked above)
                     return RETURN_CONTINUE;
             }
         }
 
-        if (RUPTURE > 0 && !pTarget->HasAura(RUPTURE, EFFECT_INDEX_0) && m_ai->CastSpell(RUPTURE, *pTarget) == SPELL_CAST_OK) // 25 energy (checked above)
+        if (RUPTURE > 0 && !pTarget->HasAura(RUPTURE, EFFECT_INDEX_0) && m_ai.CastSpell(RUPTURE, *pTarget) == SPELL_CAST_OK) // 25 energy (checked above)
             return RETURN_CONTINUE;
 
         // default combo action or if other combo action is unavailable/failed
         // wait for energy
-        if (m_ai->GetEnergyAmount() < 35 && EVISCERATE > 0)
+        if (m_ai.GetEnergyAmount() < 35 && EVISCERATE > 0)
             return RETURN_NO_ACTION_OK;
-        if (EVISCERATE > 0 && m_ai->CastSpell(EVISCERATE, *pTarget) == SPELL_CAST_OK)
+        if (EVISCERATE > 0 && m_ai.CastSpell(EVISCERATE, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
 
         // failed for some (non-energy related) reason, fall through to normal attacks to maximize DPS
     }
 
     // Combo generating or damage increasing attacks
-    if (HEMORRHAGE > 0 && !pTarget->HasAura(HEMORRHAGE, EFFECT_INDEX_2) && m_ai->CastSpell(HEMORRHAGE, *pTarget) == SPELL_CAST_OK)
+    if (HEMORRHAGE > 0 && !pTarget->HasAura(HEMORRHAGE, EFFECT_INDEX_2) && m_ai.CastSpell(HEMORRHAGE, *pTarget) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
-    if (BACKSTAB > 0 && pTarget->isInBackInMap(m_bot, 5.0f) && m_ai->CastSpell(BACKSTAB, *pTarget) == SPELL_CAST_OK)
+    if (BACKSTAB > 0 && pTarget->isInBackInMap(&m_bot, 5.0f) && m_ai.CastSpell(BACKSTAB, *pTarget) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
-    if (GHOSTLY_STRIKE > 0 && m_bot->IsSpellReady(GHOSTLY_STRIKE) && m_ai->CastSpell(GHOSTLY_STRIKE, *pTarget) == SPELL_CAST_OK)
+    if (GHOSTLY_STRIKE > 0 && m_bot.IsSpellReady(GHOSTLY_STRIKE) && m_ai.CastSpell(GHOSTLY_STRIKE, *pTarget) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
-    if (SINISTER_STRIKE > 0 && m_ai->CastSpell(SINISTER_STRIKE, *pTarget) == SPELL_CAST_OK)
+    if (SINISTER_STRIKE > 0 && m_ai.CastSpell(SINISTER_STRIKE, *pTarget) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
     return RETURN_NO_ACTION_OK;
@@ -319,18 +314,16 @@ CombatManeuverReturns PlayerbotRogueAI::DoNextCombatManeuverPVE(Unit* pTarget)
 CombatManeuverReturns PlayerbotRogueAI::DoNextCombatManeuverPVP(Unit* pTarget)
 {
     if (!pTarget) return RETURN_NO_ACTION_ERROR;
-    if (!m_ai)    return RETURN_NO_ACTION_ERROR;
-    if (!m_bot)   return RETURN_NO_ACTION_ERROR;
 
     Unit* pVictim = pTarget->GetVictim();
-    bool meleeReach = m_bot->CanReachWithMeleeAttack(pTarget);
+    bool meleeReach = m_bot.CanReachWithMeleeAttack(pTarget);
 
     // decide what to do:
-    if (m_bot->HasAura(STEALTH, EFFECT_INDEX_0))
+    if (m_bot.HasAura(STEALTH, EFFECT_INDEX_0))
         SpellSequence = RogueStealth;
     else if (pTarget->IsNonMeleeSpellCasted(true))
         SpellSequence = RogueSpellPreventing;
-    else if (pVictim == m_bot && m_ai->GetHealthPercent() < 40)
+    else if (pVictim == &m_bot && m_ai.GetHealthPercent() < 40)
         SpellSequence = RogueThreat;
     else
         SpellSequence = RogueCombat;
@@ -343,71 +336,71 @@ CombatManeuverReturns PlayerbotRogueAI::DoNextCombatManeuverPVP(Unit* pTarget)
     switch (SpellSequence)
     {
         case RogueStealth:
-            if (PREMEDITATION > 0 && m_ai->CastSpell(PREMEDITATION, *pTarget) == SPELL_CAST_OK)
+            if (PREMEDITATION > 0 && m_ai.CastSpell(PREMEDITATION, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (AMBUSH > 0 && m_ai->CastSpell(AMBUSH, *pTarget) == SPELL_CAST_OK)
+            if (AMBUSH > 0 && m_ai.CastSpell(AMBUSH, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (CHEAP_SHOT > 0 && !pTarget->HasAura(CHEAP_SHOT, EFFECT_INDEX_0) && m_ai->CastSpell(CHEAP_SHOT, *pTarget) == SPELL_CAST_OK)
+            if (CHEAP_SHOT > 0 && !pTarget->HasAura(CHEAP_SHOT, EFFECT_INDEX_0) && m_ai.CastSpell(CHEAP_SHOT, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (GARROTE > 0 && m_ai->CastSpell(GARROTE, *pTarget) == SPELL_CAST_OK)
+            if (GARROTE > 0 && m_ai.CastSpell(GARROTE, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
 
             // No appropriate action found, remove stealth
-            m_bot->RemoveSpellsCausingAura(SPELL_AURA_MOD_STEALTH);
+            m_bot.RemoveSpellsCausingAura(SPELL_AURA_MOD_STEALTH);
             return RETURN_CONTINUE;
 
         case RogueThreat:
-            if (GOUGE > 0 && !pTarget->HasAura(GOUGE, EFFECT_INDEX_0) && m_ai->CastSpell(GOUGE, *pTarget) == SPELL_CAST_OK)
+            if (GOUGE > 0 && !pTarget->HasAura(GOUGE, EFFECT_INDEX_0) && m_ai.CastSpell(GOUGE, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (EVASION > 0 && m_ai->GetHealthPercent() <= 35 && !m_bot->HasAura(EVASION, EFFECT_INDEX_0) && m_ai->CastSpell(EVASION) == SPELL_CAST_OK)
+            if (EVASION > 0 && m_ai.GetHealthPercent() <= 35 && !m_bot.HasAura(EVASION, EFFECT_INDEX_0) && m_ai.CastSpell(EVASION) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (BLIND > 0 && m_ai->GetHealthPercent() <= 30 && !pTarget->HasAura(BLIND, EFFECT_INDEX_0) && m_ai->CastSpell(BLIND, *pTarget) == SPELL_CAST_OK)
+            if (BLIND > 0 && m_ai.GetHealthPercent() <= 30 && !pTarget->HasAura(BLIND, EFFECT_INDEX_0) && m_ai.CastSpell(BLIND, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (FEINT > 0 && m_ai->GetHealthPercent() <= 25 && m_ai->CastSpell(FEINT) == SPELL_CAST_OK)
+            if (FEINT > 0 && m_ai.GetHealthPercent() <= 25 && m_ai.CastSpell(FEINT) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (VANISH > 0 && m_ai->GetHealthPercent() <= 20 && !m_bot->HasAura(FEINT, EFFECT_INDEX_0) && m_ai->CastSpell(VANISH) == SPELL_CAST_OK)
+            if (VANISH > 0 && m_ai.GetHealthPercent() <= 20 && !m_bot.HasAura(FEINT, EFFECT_INDEX_0) && m_ai.CastSpell(VANISH) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (PREPARATION > 0 && m_ai->CastSpell(PREPARATION) == SPELL_CAST_OK)
+            if (PREPARATION > 0 && m_ai.CastSpell(PREPARATION) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
             break;
 
         case RogueSpellPreventing:
-            if ((KIDNEY_SHOT > 0 && m_bot->GetComboPoints() >= 2 && m_ai->CastSpell(KIDNEY_SHOT, *pTarget) == SPELL_CAST_OK) ||
-                (KICK > 0 && m_ai->CastSpell(KICK, *pTarget) == SPELL_CAST_OK))
+            if ((KIDNEY_SHOT > 0 && m_bot.GetComboPoints() >= 2 && m_ai.CastSpell(KIDNEY_SHOT, *pTarget) == SPELL_CAST_OK) ||
+                (KICK > 0 && m_ai.CastSpell(KICK, *pTarget) == SPELL_CAST_OK))
                 return RETURN_CONTINUE;
         // break; // No action? Go combat!
 
         case RogueCombat:
         default:
-            if (m_bot->GetComboPoints() >= 5)
+            if (m_bot.GetComboPoints() >= 5)
             {
                 // wait for energy
-                if (m_ai->GetEnergyAmount() < 25 && (KIDNEY_SHOT || SLICE_DICE || EXPOSE_ARMOR))
+                if (m_ai.GetEnergyAmount() < 25 && (KIDNEY_SHOT || SLICE_DICE || EXPOSE_ARMOR))
                     return RETURN_NO_ACTION_OK;
 
                 switch (pTarget->getClass())
                 {
                     case CLASS_SHAMAN:
-                        if (KIDNEY_SHOT > 0 && m_ai->CastSpell(KIDNEY_SHOT, *pTarget) == SPELL_CAST_OK) // 25 energy (checked above)
+                        if (KIDNEY_SHOT > 0 && m_ai.CastSpell(KIDNEY_SHOT, *pTarget) == SPELL_CAST_OK) // 25 energy (checked above)
                             return RETURN_CONTINUE;
                         break;
 
                     case CLASS_WARLOCK:
                     case CLASS_HUNTER:
-                        if (SLICE_DICE > 0 && m_ai->CastSpell(SLICE_DICE, *pTarget) == SPELL_CAST_OK) // 25 energy (checked above)
+                        if (SLICE_DICE > 0 && m_ai.CastSpell(SLICE_DICE, *pTarget) == SPELL_CAST_OK) // 25 energy (checked above)
                             return RETURN_CONTINUE;
                         break;
 
                     case CLASS_WARRIOR:
                     case CLASS_PALADIN:
-                        if (EXPOSE_ARMOR > 0 && !pTarget->HasAura(EXPOSE_ARMOR, EFFECT_INDEX_0) && m_ai->CastSpell(EXPOSE_ARMOR, *pTarget) == SPELL_CAST_OK) // 25 energy (checked above)
+                        if (EXPOSE_ARMOR > 0 && !pTarget->HasAura(EXPOSE_ARMOR, EFFECT_INDEX_0) && m_ai.CastSpell(EXPOSE_ARMOR, *pTarget) == SPELL_CAST_OK) // 25 energy (checked above)
                             return RETURN_CONTINUE;
                         break;
 
 
                     case CLASS_MAGE:
                     case CLASS_PRIEST:
-                        if (RUPTURE > 0 && m_ai->CastSpell(RUPTURE, *pTarget) == SPELL_CAST_OK) // 25 energy (checked above)
+                        if (RUPTURE > 0 && m_ai.CastSpell(RUPTURE, *pTarget) == SPELL_CAST_OK) // 25 energy (checked above)
                             return RETURN_CONTINUE;
                         break;
 
@@ -419,27 +412,27 @@ CombatManeuverReturns PlayerbotRogueAI::DoNextCombatManeuverPVP(Unit* pTarget)
 
                 // default combo action for rogue/druid or if other combo action is unavailable/failed
                 // wait for energy
-                if (m_ai->GetEnergyAmount() < 35 && EVISCERATE)
+                if (m_ai.GetEnergyAmount() < 35 && EVISCERATE)
                     return RETURN_NO_ACTION_OK;
-                if (EVISCERATE > 0 && m_ai->CastSpell(EVISCERATE, *pTarget) == SPELL_CAST_OK)
+                if (EVISCERATE > 0 && m_ai.CastSpell(EVISCERATE, *pTarget) == SPELL_CAST_OK)
                     return RETURN_CONTINUE;
 
                 // failed for some (non-energy related) reason, fall through to normal attacks to maximize DPS
             }
 
-            if (CHEAP_SHOT > 0 && !pTarget->HasAura(CHEAP_SHOT, EFFECT_INDEX_0) && m_ai->CastSpell(CHEAP_SHOT, *pTarget) == SPELL_CAST_OK)
+            if (CHEAP_SHOT > 0 && !pTarget->HasAura(CHEAP_SHOT, EFFECT_INDEX_0) && m_ai.CastSpell(CHEAP_SHOT, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (AMBUSH > 0 && m_ai->CastSpell(AMBUSH, *pTarget) == SPELL_CAST_OK)
+            if (AMBUSH > 0 && m_ai.CastSpell(AMBUSH, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (GARROTE > 0 && m_ai->CastSpell(GARROTE, *pTarget) == SPELL_CAST_OK)
+            if (GARROTE > 0 && m_ai.CastSpell(GARROTE, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (BACKSTAB > 0 && pTarget->isInBackInMap(m_bot, 1) && m_ai->CastSpell(BACKSTAB, *pTarget) == SPELL_CAST_OK)
+            if (BACKSTAB > 0 && pTarget->isInBackInMap(&m_bot, 1) && m_ai.CastSpell(BACKSTAB, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (SINISTER_STRIKE > 0 && m_ai->CastSpell(SINISTER_STRIKE, *pTarget) == SPELL_CAST_OK)
+            if (SINISTER_STRIKE > 0 && m_ai.CastSpell(SINISTER_STRIKE, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (GHOSTLY_STRIKE > 0 && m_ai->CastSpell(GHOSTLY_STRIKE, *pTarget) == SPELL_CAST_OK)
+            if (GHOSTLY_STRIKE > 0 && m_ai.CastSpell(GHOSTLY_STRIKE, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (HEMORRHAGE > 0 && m_ai->CastSpell(HEMORRHAGE, *pTarget) == SPELL_CAST_OK)
+            if (HEMORRHAGE > 0 && m_ai.CastSpell(HEMORRHAGE, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
 
             break;
@@ -461,7 +454,7 @@ Item* PlayerbotRogueAI::FindPoison() const
     Item* poison;
     for (unsigned int priorizedPoisonId : uPriorizedPoisonIds)
     {
-        poison = m_ai->FindConsumable(priorizedPoisonId);
+        poison = m_ai.FindConsumable(priorizedPoisonId);
         if (poison)
             return poison;
     }
@@ -470,12 +463,9 @@ Item* PlayerbotRogueAI::FindPoison() const
 
 void PlayerbotRogueAI::DoNonCombatActions()
 {
-    if (!m_ai)  return;
-    if (!m_bot) return;
-
     // remove stealth
-    if (m_bot->HasAura(STEALTH))
-        m_bot->RemoveSpellsCausingAura(SPELL_AURA_MOD_STEALTH);
+    if (m_bot.HasAura(STEALTH))
+        m_bot.RemoveSpellsCausingAura(SPELL_AURA_MOD_STEALTH);
 
     // hp check
     if (EatDrinkBandage(false))
@@ -484,51 +474,51 @@ void PlayerbotRogueAI::DoNonCombatActions()
     // Search and apply poisons to weapons, if no poison found, try to apply a sharpening/weight stone
     // Mainhand ...
     Item* poison, * stone, * weapon;
-    weapon = m_bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+    weapon = m_bot.GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
     if (weapon && weapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0)
     {
         poison = FindPoison();
         if (poison)
         {
-            m_ai->UseItem(poison, EQUIPMENT_SLOT_MAINHAND);
-            m_ai->SetIgnoreUpdateTime(5);
+            m_ai.UseItem(poison, EQUIPMENT_SLOT_MAINHAND);
+            m_ai.SetIgnoreUpdateTime(5);
         }
         else
         {
-            stone = m_ai->FindStoneFor(weapon);
+            stone = m_ai.FindStoneFor(weapon);
             if (stone)
             {
-                m_ai->UseItem(stone, EQUIPMENT_SLOT_MAINHAND);
-                m_ai->SetIgnoreUpdateTime(5);
+                m_ai.UseItem(stone, EQUIPMENT_SLOT_MAINHAND);
+                m_ai.SetIgnoreUpdateTime(5);
             }
         }
     }
     //... and offhand
-    weapon = m_bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
+    weapon = m_bot.GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
     if (weapon && weapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0)
     {
         poison = FindPoison();
         if (poison)
         {
-            m_ai->UseItem(poison, EQUIPMENT_SLOT_OFFHAND);
-            m_ai->SetIgnoreUpdateTime(5);
+            m_ai.UseItem(poison, EQUIPMENT_SLOT_OFFHAND);
+            m_ai.SetIgnoreUpdateTime(5);
         }
         else
         {
-            stone = m_ai->FindStoneFor(weapon);
+            stone = m_ai.FindStoneFor(weapon);
             if (stone)
             {
-                m_ai->UseItem(stone, EQUIPMENT_SLOT_OFFHAND);
-                m_ai->SetIgnoreUpdateTime(5);
+                m_ai.UseItem(stone, EQUIPMENT_SLOT_OFFHAND);
+                m_ai.SetIgnoreUpdateTime(5);
             }
         }
     }
 
     // Nothing else to do, Night Elves will cast Shadowmeld to reduce their aggro versus patrols or nearby mobs
-    if (SHADOWMELD > 0 && !m_bot->isMovingOrTurning()
-        && !m_bot->IsMounted()
-        && !m_bot->HasAura(SHADOWMELD, EFFECT_INDEX_0))
+    if (SHADOWMELD > 0 && !m_bot.isMovingOrTurning()
+        && !m_bot.IsMounted()
+        && !m_bot.HasAura(SHADOWMELD, EFFECT_INDEX_0))
     {
-        m_ai->CastSpell(SHADOWMELD, *m_bot);
+        m_ai.CastSpell(SHADOWMELD, m_bot);
     }
 } // end DoNonCombatActions

--- a/src/game/PlayerBot/AI/PlayerbotRogueAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotRogueAI.h
@@ -77,7 +77,7 @@ enum RogueSpells
 class MANGOS_DLL_SPEC PlayerbotRogueAI : PlayerbotClassAI
 {
     public:
-        PlayerbotRogueAI(Player* const master, Player* const bot, PlayerbotAI* const ai);
+        PlayerbotRogueAI(Player& master, Player& bot, PlayerbotAI& ai);
         virtual ~PlayerbotRogueAI();
 
         // all combat actions go here

--- a/src/game/PlayerBot/AI/PlayerbotRogueAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotRogueAI.h
@@ -81,17 +81,17 @@ class MANGOS_DLL_SPEC PlayerbotRogueAI : PlayerbotClassAI
         virtual ~PlayerbotRogueAI();
 
         // all combat actions go here
-        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget);
+        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget) override;
 
         // all non combat actions go here, ex buffs, heals, rezzes
-        void DoNonCombatActions();
+        void DoNonCombatActions() override;
 
     private:
-        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget);
+        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget) override;
         Item* FindPoison() const;
 
         // COMBAT

--- a/src/game/PlayerBot/AI/PlayerbotShamanAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotShamanAI.cpp
@@ -20,7 +20,7 @@
 #include "../../Entities/Totem.h"
 
 class PlayerbotAI;
-PlayerbotShamanAI::PlayerbotShamanAI(Player* const master, Player* const bot, PlayerbotAI* const ai) : PlayerbotClassAI(master, bot, ai)
+PlayerbotShamanAI::PlayerbotShamanAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
 {
     // restoration
     CHAIN_HEAL               = m_ai->initSpell(CHAIN_HEAL_1);

--- a/src/game/PlayerBot/AI/PlayerbotShamanAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotShamanAI.cpp
@@ -399,15 +399,15 @@ void PlayerbotShamanAI::CheckShields()
 
     if (spec == SHAMAN_SPEC_ENHANCEMENT && LIGHTNING_SHIELD > 0 && !m_bot.HasAura(LIGHTNING_SHIELD, EFFECT_INDEX_0))
         m_ai.CastSpell(LIGHTNING_SHIELD, m_bot);
-    if (EARTH_SHIELD > 0 && !GetMaster()->HasAura(EARTH_SHIELD, EFFECT_INDEX_0))
-        m_ai.CastSpell(EARTH_SHIELD, *(GetMaster()));
+    if (EARTH_SHIELD > 0 && !m_master.HasAura(EARTH_SHIELD, EFFECT_INDEX_0))
+        m_ai.CastSpell(EARTH_SHIELD, m_master);
 }
 
 void PlayerbotShamanAI::UseCooldowns()
 {
     uint32 spec = m_bot.GetSpec();
 
-    if (BLOODLUST > 0 && (!GetMaster()->HasAura(BLOODLUST, EFFECT_INDEX_0)) && m_ai.CastSpell(BLOODLUST) == SPELL_CAST_OK)
+    if (BLOODLUST > 0 && (!m_master.HasAura(BLOODLUST, EFFECT_INDEX_0)) && m_ai.CastSpell(BLOODLUST) == SPELL_CAST_OK)
         return;
 
     switch (spec)

--- a/src/game/PlayerBot/AI/PlayerbotShamanAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotShamanAI.cpp
@@ -20,80 +20,80 @@
 #include "../../Entities/Totem.h"
 
 class PlayerbotAI;
-PlayerbotShamanAI::PlayerbotShamanAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
+PlayerbotShamanAI::PlayerbotShamanAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(master, bot, ai)
 {
     // restoration
-    CHAIN_HEAL               = m_ai->initSpell(CHAIN_HEAL_1);
-    HEALING_WAVE             = m_ai->initSpell(HEALING_WAVE_1);
-    LESSER_HEALING_WAVE      = m_ai->initSpell(LESSER_HEALING_WAVE_1);
-    ANCESTRAL_SPIRIT         = m_ai->initSpell(ANCESTRAL_SPIRIT_1);
-    EARTH_SHIELD             = m_ai->initSpell(EARTH_SHIELD_1);
-    TREMOR_TOTEM             = m_ai->initSpell(TREMOR_TOTEM_1); // totems
-    HEALING_STREAM_TOTEM     = m_ai->initSpell(HEALING_STREAM_TOTEM_1);
-    MANA_SPRING_TOTEM        = m_ai->initSpell(MANA_SPRING_TOTEM_1);
-    MANA_TIDE_TOTEM          = m_ai->initSpell(MANA_TIDE_TOTEM_1);
-    CURE_DISEASE_SHAMAN      = m_ai->initSpell(CURE_DISEASE_SHAMAN_1);
-    CURE_POISON_SHAMAN       = m_ai->initSpell(CURE_POISON_SHAMAN_1);
-    NATURES_SWIFTNESS_SHAMAN = m_ai->initSpell(NATURES_SWIFTNESS_SHAMAN_1);
+    CHAIN_HEAL               = m_ai.initSpell(CHAIN_HEAL_1);
+    HEALING_WAVE             = m_ai.initSpell(HEALING_WAVE_1);
+    LESSER_HEALING_WAVE      = m_ai.initSpell(LESSER_HEALING_WAVE_1);
+    ANCESTRAL_SPIRIT         = m_ai.initSpell(ANCESTRAL_SPIRIT_1);
+    EARTH_SHIELD             = m_ai.initSpell(EARTH_SHIELD_1);
+    TREMOR_TOTEM             = m_ai.initSpell(TREMOR_TOTEM_1); // totems
+    HEALING_STREAM_TOTEM     = m_ai.initSpell(HEALING_STREAM_TOTEM_1);
+    MANA_SPRING_TOTEM        = m_ai.initSpell(MANA_SPRING_TOTEM_1);
+    MANA_TIDE_TOTEM          = m_ai.initSpell(MANA_TIDE_TOTEM_1);
+    CURE_DISEASE_SHAMAN      = m_ai.initSpell(CURE_DISEASE_SHAMAN_1);
+    CURE_POISON_SHAMAN       = m_ai.initSpell(CURE_POISON_SHAMAN_1);
+    NATURES_SWIFTNESS_SHAMAN = m_ai.initSpell(NATURES_SWIFTNESS_SHAMAN_1);
     // enhancement
     FOCUSED                  = 0; // Focused what?
-    STORMSTRIKE              = m_ai->initSpell(STORMSTRIKE_1);
-    BLOODLUST                = m_ai->initSpell(BLOODLUST_1);
-    LIGHTNING_SHIELD         = m_ai->initSpell(LIGHTNING_SHIELD_1);
-    ROCKBITER_WEAPON         = m_ai->initSpell(ROCKBITER_WEAPON_1);
-    FLAMETONGUE_WEAPON       = m_ai->initSpell(FLAMETONGUE_WEAPON_1);
-    FROSTBRAND_WEAPON        = m_ai->initSpell(FROSTBRAND_WEAPON_1);
-    WINDFURY_WEAPON          = m_ai->initSpell(WINDFURY_WEAPON_1);
-    STONESKIN_TOTEM          = m_ai->initSpell(STONESKIN_TOTEM_1); // totems
-    STRENGTH_OF_EARTH_TOTEM  = m_ai->initSpell(STRENGTH_OF_EARTH_TOTEM_1);
-    FROST_RESISTANCE_TOTEM   = m_ai->initSpell(FROST_RESISTANCE_TOTEM_1);
-    FLAMETONGUE_TOTEM        = m_ai->initSpell(FLAMETONGUE_TOTEM_1);
-    FIRE_RESISTANCE_TOTEM    = m_ai->initSpell(FIRE_RESISTANCE_TOTEM_1);
-    GROUNDING_TOTEM          = m_ai->initSpell(GROUNDING_TOTEM_1);
-    NATURE_RESISTANCE_TOTEM  = m_ai->initSpell(NATURE_RESISTANCE_TOTEM_1);
-    WIND_FURY_TOTEM          = m_ai->initSpell(WINDFURY_TOTEM_1);
-    STONESKIN_TOTEM          = m_ai->initSpell(STONESKIN_TOTEM_1);
-    WRATH_OF_AIR_TOTEM       = m_ai->initSpell(WRATH_OF_AIR_TOTEM_1);
-    EARTH_ELEMENTAL_TOTEM    = m_ai->initSpell(EARTH_ELEMENTAL_TOTEM_1);
+    STORMSTRIKE              = m_ai.initSpell(STORMSTRIKE_1);
+    BLOODLUST                = m_ai.initSpell(BLOODLUST_1);
+    LIGHTNING_SHIELD         = m_ai.initSpell(LIGHTNING_SHIELD_1);
+    ROCKBITER_WEAPON         = m_ai.initSpell(ROCKBITER_WEAPON_1);
+    FLAMETONGUE_WEAPON       = m_ai.initSpell(FLAMETONGUE_WEAPON_1);
+    FROSTBRAND_WEAPON        = m_ai.initSpell(FROSTBRAND_WEAPON_1);
+    WINDFURY_WEAPON          = m_ai.initSpell(WINDFURY_WEAPON_1);
+    STONESKIN_TOTEM          = m_ai.initSpell(STONESKIN_TOTEM_1); // totems
+    STRENGTH_OF_EARTH_TOTEM  = m_ai.initSpell(STRENGTH_OF_EARTH_TOTEM_1);
+    FROST_RESISTANCE_TOTEM   = m_ai.initSpell(FROST_RESISTANCE_TOTEM_1);
+    FLAMETONGUE_TOTEM        = m_ai.initSpell(FLAMETONGUE_TOTEM_1);
+    FIRE_RESISTANCE_TOTEM    = m_ai.initSpell(FIRE_RESISTANCE_TOTEM_1);
+    GROUNDING_TOTEM          = m_ai.initSpell(GROUNDING_TOTEM_1);
+    NATURE_RESISTANCE_TOTEM  = m_ai.initSpell(NATURE_RESISTANCE_TOTEM_1);
+    WIND_FURY_TOTEM          = m_ai.initSpell(WINDFURY_TOTEM_1);
+    STONESKIN_TOTEM          = m_ai.initSpell(STONESKIN_TOTEM_1);
+    WRATH_OF_AIR_TOTEM       = m_ai.initSpell(WRATH_OF_AIR_TOTEM_1);
+    EARTH_ELEMENTAL_TOTEM    = m_ai.initSpell(EARTH_ELEMENTAL_TOTEM_1);
     // elemental
-    LIGHTNING_BOLT           = m_ai->initSpell(LIGHTNING_BOLT_1);
-    EARTH_SHOCK              = m_ai->initSpell(EARTH_SHOCK_1);
-    FLAME_SHOCK              = m_ai->initSpell(FLAME_SHOCK_1);
-    PURGE                    = m_ai->initSpell(PURGE_1);
-    FROST_SHOCK              = m_ai->initSpell(FROST_SHOCK_1);
-    CHAIN_LIGHTNING          = m_ai->initSpell(CHAIN_LIGHTNING_1);
-    STONECLAW_TOTEM          = m_ai->initSpell(STONECLAW_TOTEM_1); // totems
-    SEARING_TOTEM            = m_ai->initSpell(SEARING_TOTEM_1);
+    LIGHTNING_BOLT           = m_ai.initSpell(LIGHTNING_BOLT_1);
+    EARTH_SHOCK              = m_ai.initSpell(EARTH_SHOCK_1);
+    FLAME_SHOCK              = m_ai.initSpell(FLAME_SHOCK_1);
+    PURGE                    = m_ai.initSpell(PURGE_1);
+    FROST_SHOCK              = m_ai.initSpell(FROST_SHOCK_1);
+    CHAIN_LIGHTNING          = m_ai.initSpell(CHAIN_LIGHTNING_1);
+    STONECLAW_TOTEM          = m_ai.initSpell(STONECLAW_TOTEM_1); // totems
+    SEARING_TOTEM            = m_ai.initSpell(SEARING_TOTEM_1);
     FIRE_NOVA_TOTEM          = 0; // NPC only spell, check FIRE_NOVA_1
-    MAGMA_TOTEM              = m_ai->initSpell(MAGMA_TOTEM_1);
-    EARTHBIND_TOTEM          = m_ai->initSpell(EARTHBIND_TOTEM_1);
-    FIRE_ELEMENTAL_TOTEM     = m_ai->initSpell(FIRE_ELEMENTAL_TOTEM_1);
-    ELEMENTAL_MASTERY        = m_ai->initSpell(ELEMENTAL_MASTERY_1);
+    MAGMA_TOTEM              = m_ai.initSpell(MAGMA_TOTEM_1);
+    EARTHBIND_TOTEM          = m_ai.initSpell(EARTHBIND_TOTEM_1);
+    FIRE_ELEMENTAL_TOTEM     = m_ai.initSpell(FIRE_ELEMENTAL_TOTEM_1);
+    ELEMENTAL_MASTERY        = m_ai.initSpell(ELEMENTAL_MASTERY_1);
 
     RECENTLY_BANDAGED        = 11196; // first aid check
 
     // racial
-    BLOOD_FURY               = m_ai->initSpell(BLOOD_FURY_ALL); // orc
-    WAR_STOMP                = m_ai->initSpell(WAR_STOMP_ALL); // tauren
-    BERSERKING               = m_ai->initSpell(BERSERKING_ALL); // troll
+    BLOOD_FURY               = m_ai.initSpell(BLOOD_FURY_ALL); // orc
+    WAR_STOMP                = m_ai.initSpell(WAR_STOMP_ALL); // tauren
+    BERSERKING               = m_ai.initSpell(BERSERKING_ALL); // troll
 
     // totem buffs
-    STRENGTH_OF_EARTH_EFFECT    = m_ai->initSpell(STRENGTH_OF_EARTH_EFFECT_1);
-    FLAMETONGUE_EFFECT          = m_ai->initSpell(FLAMETONGUE_EFFECT_1);
-    MAGMA_TOTEM_EFFECT          = m_ai->initSpell(MAGMA_TOTEM_EFFECT_1);
-    STONECLAW_EFFECT            = m_ai->initSpell(STONECLAW_EFFECT_1);
-    FIRE_RESISTANCE_EFFECT      = m_ai->initSpell(FIRE_RESISTANCE_EFFECT_1);
-    FROST_RESISTANCE_EFFECT     = m_ai->initSpell(FROST_RESISTANCE_EFFECT_1);
-    GROUDNING_EFFECT            = m_ai->initSpell(GROUDNING_EFFECT_1);
-    NATURE_RESISTANCE_EFFECT    = m_ai->initSpell(NATURE_RESISTANCE_EFFECT_1);
-    STONESKIN_EFFECT            = m_ai->initSpell(STONESKIN_EFFECT_1);
-    WINDFURY_EFFECT             = m_ai->initSpell(WINDFURY_EFFECT_1);
-    WRATH_OF_AIR_EFFECT         = m_ai->initSpell(WRATH_OF_AIR_EFFECT_1);
-    CLEANSING_TOTEM_EFFECT      = m_ai->initSpell(CLEANSING_TOTEM_EFFECT_1);
-    MANA_SPRING_EFFECT          = m_ai->initSpell(MANA_SPRING_EFFECT_1);
-    TREMOR_TOTEM_EFFECT         = m_ai->initSpell(TREMOR_TOTEM_EFFECT_1);
-    STONECLAW_EFFECT            = m_ai->initSpell(STONECLAW_EFFECT_1);
-    EARTHBIND_EFFECT            = m_ai->initSpell(EARTHBIND_EFFECT_1);
+    STRENGTH_OF_EARTH_EFFECT    = m_ai.initSpell(STRENGTH_OF_EARTH_EFFECT_1);
+    FLAMETONGUE_EFFECT          = m_ai.initSpell(FLAMETONGUE_EFFECT_1);
+    MAGMA_TOTEM_EFFECT          = m_ai.initSpell(MAGMA_TOTEM_EFFECT_1);
+    STONECLAW_EFFECT            = m_ai.initSpell(STONECLAW_EFFECT_1);
+    FIRE_RESISTANCE_EFFECT      = m_ai.initSpell(FIRE_RESISTANCE_EFFECT_1);
+    FROST_RESISTANCE_EFFECT     = m_ai.initSpell(FROST_RESISTANCE_EFFECT_1);
+    GROUDNING_EFFECT            = m_ai.initSpell(GROUDNING_EFFECT_1);
+    NATURE_RESISTANCE_EFFECT    = m_ai.initSpell(NATURE_RESISTANCE_EFFECT_1);
+    STONESKIN_EFFECT            = m_ai.initSpell(STONESKIN_EFFECT_1);
+    WINDFURY_EFFECT             = m_ai.initSpell(WINDFURY_EFFECT_1);
+    WRATH_OF_AIR_EFFECT         = m_ai.initSpell(WRATH_OF_AIR_EFFECT_1);
+    CLEANSING_TOTEM_EFFECT      = m_ai.initSpell(CLEANSING_TOTEM_EFFECT_1);
+    MANA_SPRING_EFFECT          = m_ai.initSpell(MANA_SPRING_EFFECT_1);
+    TREMOR_TOTEM_EFFECT         = m_ai.initSpell(TREMOR_TOTEM_EFFECT_1);
+    STONECLAW_EFFECT            = m_ai.initSpell(STONECLAW_EFFECT_1);
+    EARTHBIND_EFFECT            = m_ai.initSpell(EARTHBIND_EFFECT_1);
 }
 
 PlayerbotShamanAI::~PlayerbotShamanAI() {}
@@ -102,30 +102,30 @@ CombatManeuverReturns PlayerbotShamanAI::DoFirstCombatManeuver(Unit* pTarget)
 {
     // There are NPCs in BGs and Open World PvP, so don't filter this on PvP scenarios (of course if PvP targets anyone but tank, all bets are off anyway)
     // Wait until the tank says so, until any non-tank gains aggro or X seconds - whichever is shortest
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->GroupTankHoldsAggro())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.GroupTankHoldsAggro())
         {
-            if (PlayerbotAI::ORDERS_HEAL & m_ai->GetCombatOrder())
+            if (PlayerbotAI::ORDERS_HEAL & m_ai.GetCombatOrder())
                 return HealPlayer(GetHealTarget());
             else
                 return RETURN_NO_ACTION_OK; // wait it out
         }
         else
         {
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
         }
     }
 
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->IsGroupReady())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.IsGroupReady())
             return RETURN_NO_ACTION_OK; // wait it out
         else
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
     }
 
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -153,9 +153,9 @@ CombatManeuverReturns PlayerbotShamanAI::DoFirstCombatManeuverPVP(Unit* /*pTarge
 CombatManeuverReturns PlayerbotShamanAI::DoNextCombatManeuver(Unit* pTarget)
 {
     // Face enemy, make sure bot is attacking
-    m_ai->FaceTarget(pTarget);
+    m_ai.FaceTarget(pTarget);
 
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -172,19 +172,16 @@ CombatManeuverReturns PlayerbotShamanAI::DoNextCombatManeuver(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotShamanAI::DoNextCombatManeuverPVE(Unit* pTarget)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
-    uint32 spec = m_bot->GetSpec();
+    uint32 spec = m_bot.GetSpec();
 
     // Make sure healer stays put, don't even melee (aggro) if in range.
-    if (m_ai->IsHealer() && m_ai->GetCombatStyle() != PlayerbotAI::COMBAT_RANGED)
-        m_ai->SetCombatStyle(PlayerbotAI::COMBAT_RANGED);
-    else if (!m_ai->IsHealer() && m_ai->GetCombatStyle() != PlayerbotAI::COMBAT_MELEE)
-        m_ai->SetCombatStyle(PlayerbotAI::COMBAT_MELEE);
+    if (m_ai.IsHealer() && m_ai.GetCombatStyle() != PlayerbotAI::COMBAT_RANGED)
+        m_ai.SetCombatStyle(PlayerbotAI::COMBAT_RANGED);
+    else if (!m_ai.IsHealer() && m_ai.GetCombatStyle() != PlayerbotAI::COMBAT_MELEE)
+        m_ai.SetCombatStyle(PlayerbotAI::COMBAT_MELEE);
 
     // Dispel disease/poison
-    if (m_ai->HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
+    if (m_ai.HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
         return RETURN_CONTINUE;
 
     // Heal (try to pick a target by on common rules, than heal using each PlayerbotClassAI HealPlayer() method)
@@ -198,14 +195,14 @@ CombatManeuverReturns PlayerbotShamanAI::DoNextCombatManeuverPVE(Unit* pTarget)
     switch (spec)
     {
         case SHAMAN_SPEC_ENHANCEMENT:
-            if (STORMSTRIKE > 0 && (m_bot->IsSpellReady(STORMSTRIKE)) && m_ai->CastSpell(STORMSTRIKE, *pTarget) == SPELL_CAST_OK)
+            if (STORMSTRIKE > 0 && (m_bot.IsSpellReady(STORMSTRIKE)) && m_ai.CastSpell(STORMSTRIKE, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (FLAME_SHOCK > 0 && (!pTarget->HasAura(FLAME_SHOCK)) && m_ai->CastSpell(FLAME_SHOCK, *pTarget) == SPELL_CAST_OK)
+            if (FLAME_SHOCK > 0 && (!pTarget->HasAura(FLAME_SHOCK)) && m_ai.CastSpell(FLAME_SHOCK, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (EARTH_SHOCK > 0 && (m_bot->IsSpellReady(EARTH_SHOCK)) && m_ai->CastSpell(EARTH_SHOCK, *pTarget) == SPELL_CAST_OK)
+            if (EARTH_SHOCK > 0 && (m_bot.IsSpellReady(EARTH_SHOCK)) && m_ai.CastSpell(EARTH_SHOCK, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
 
-            /*if (FOCUSED > 0 && m_ai->CastSpell(FOCUSED, *pTarget) == SPELL_CAST_OK)
+            /*if (FOCUSED > 0 && m_ai.CastSpell(FOCUSED, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;*/
             break;
 
@@ -213,13 +210,13 @@ CombatManeuverReturns PlayerbotShamanAI::DoNextCombatManeuverPVE(Unit* pTarget)
         // fall through to elemental
 
         case SHAMAN_SPEC_ELEMENTAL:
-            if (FLAME_SHOCK > 0 && (!pTarget->HasAura(FLAME_SHOCK)) && m_ai->CastSpell(FLAME_SHOCK, *pTarget) == SPELL_CAST_OK)
+            if (FLAME_SHOCK > 0 && (!pTarget->HasAura(FLAME_SHOCK)) && m_ai.CastSpell(FLAME_SHOCK, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (LIGHTNING_BOLT > 0 && m_ai->CastSpell(LIGHTNING_BOLT, *pTarget) == SPELL_CAST_OK)
+            if (LIGHTNING_BOLT > 0 && m_ai.CastSpell(LIGHTNING_BOLT, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            /*if (FROST_SHOCK > 0 && !pTarget->HasAura(FROST_SHOCK, EFFECT_INDEX_0) && m_ai->CastSpell(FROST_SHOCK, *pTarget) == SPELL_CAST_OK)
+            /*if (FROST_SHOCK > 0 && !pTarget->HasAura(FROST_SHOCK, EFFECT_INDEX_0) && m_ai.CastSpell(FROST_SHOCK, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;*/
-            /*if (CHAIN_LIGHTNING > 0 && m_ai->CastSpell(CHAIN_LIGHTNING, *pTarget) == SPELL_CAST_OK)
+            /*if (CHAIN_LIGHTNING > 0 && m_ai.CastSpell(CHAIN_LIGHTNING, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;*/
     }
 
@@ -232,10 +229,10 @@ CombatManeuverReturns PlayerbotShamanAI::DoNextCombatManeuverPVP(Unit* pTarget)
     CheckShields();
     UseCooldowns();
 
-    Player* healTarget = (m_ai->GetScenarioType() == PlayerbotAI::SCENARIO_PVP_DUEL) ? GetHealTarget() : m_bot;
+    Player* healTarget = (m_ai.GetScenarioType() == PlayerbotAI::SCENARIO_PVP_DUEL) ? GetHealTarget() : &m_bot;
     if (HealPlayer(healTarget) & (RETURN_NO_ACTION_OK | RETURN_CONTINUE))
         return RETURN_CONTINUE;
-    if (m_ai->CastSpell(LIGHTNING_BOLT) == SPELL_CAST_OK)
+    if (m_ai.CastSpell(LIGHTNING_BOLT) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
     return DoNextCombatManeuverPVE(pTarget); // TODO: bad idea perhaps, but better than the alternative
@@ -253,10 +250,10 @@ CombatManeuverReturns PlayerbotShamanAI::HealPlayer(Player* target)
     // TODO: This code should be common to all healers and will probably
     // move to a more suitable place like PlayerbotAI::DoCombatMovement()
     if ((GetTargetJob(target) == JOB_TANK || GetTargetJob(target) == JOB_MAIN_TANK)
-            && m_bot->GetPlayerbotAI()->GetMovementOrder() != PlayerbotAI::MOVEMENT_STAY
-            && !m_ai->In_Reach(target, HEALING_WAVE))
+            && m_bot.GetPlayerbotAI()->GetMovementOrder() != PlayerbotAI::MOVEMENT_STAY
+            && !m_ai.In_Reach(target, HEALING_WAVE))
     {
-        m_bot->GetMotionMaster()->MoveFollow(target, 39.0f, m_bot->GetOrientation());
+        m_bot.GetMotionMaster()->MoveFollow(target, 39.0f, m_bot.GetOrientation());
         return RETURN_CONTINUE;
     }
 
@@ -265,11 +262,11 @@ CombatManeuverReturns PlayerbotShamanAI::HealPlayer(Player* target)
         return RETURN_NO_ACTION_OK;
 
     // Technically the best rotation is CHAIN + LHW + LHW subbing in HW for trouble (bad mana efficiency)
-    if (target->GetHealthPercent() < 30 && HEALING_WAVE > 0 && m_ai->CastSpell(HEALING_WAVE, *target) == SPELL_CAST_OK)
+    if (target->GetHealthPercent() < 30 && HEALING_WAVE > 0 && m_ai.CastSpell(HEALING_WAVE, *target) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
-    if (target->GetHealthPercent() < 50 && LESSER_HEALING_WAVE > 0 && m_ai->CastSpell(LESSER_HEALING_WAVE, *target) == SPELL_CAST_OK)
+    if (target->GetHealthPercent() < 50 && LESSER_HEALING_WAVE > 0 && m_ai.CastSpell(LESSER_HEALING_WAVE, *target) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
-    if (target->GetHealthPercent() < 80 && CHAIN_HEAL > 0 && m_ai->CastSpell(CHAIN_HEAL, *target) == SPELL_CAST_OK)
+    if (target->GetHealthPercent() < 80 && CHAIN_HEAL > 0 && m_ai.CastSpell(CHAIN_HEAL, *target) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
     return RETURN_NO_ACTION_UNKNOWN;
@@ -281,14 +278,14 @@ CombatManeuverReturns PlayerbotShamanAI::ResurrectPlayer(Player* target)
     if (r != RETURN_NO_ACTION_OK)
         return r;
 
-    if (m_ai->IsInCombat())     // Just in case as this was supposedly checked before calling this function
+    if (m_ai.IsInCombat())     // Just in case as this was supposedly checked before calling this function
         return RETURN_NO_ACTION_ERROR;
 
-    if (ANCESTRAL_SPIRIT > 0 && m_ai->In_Reach(target, ANCESTRAL_SPIRIT) && m_ai->CastSpell(ANCESTRAL_SPIRIT, *target) == SPELL_CAST_OK)
+    if (ANCESTRAL_SPIRIT > 0 && m_ai.In_Reach(target, ANCESTRAL_SPIRIT) && m_ai.CastSpell(ANCESTRAL_SPIRIT, *target) == SPELL_CAST_OK)
     {
         std::string msg = "Resurrecting ";
         msg += target->GetName();
-        m_bot->Say(msg, LANG_UNIVERSAL);
+        m_bot.Say(msg, LANG_UNIVERSAL);
         return RETURN_CONTINUE;
     }
     return RETURN_NO_ACTION_ERROR; // not error per se - possibly just OOM
@@ -303,7 +300,7 @@ CombatManeuverReturns PlayerbotShamanAI::DispelPlayer(Player* /*target*/)
         if (r != RETURN_NO_ACTION_OK)
             return r;
 
-        if (CURE_POISON_SHAMAN > 0 && m_ai->CastSpell(CURE_POISON_SHAMAN, *poisonedTarget) == SPELL_CAST_OK)
+        if (CURE_POISON_SHAMAN > 0 && m_ai.CastSpell(CURE_POISON_SHAMAN, *poisonedTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
     }
 
@@ -314,7 +311,7 @@ CombatManeuverReturns PlayerbotShamanAI::DispelPlayer(Player* /*target*/)
         if (r != RETURN_NO_ACTION_OK)
             return r;
 
-        if (CURE_DISEASE_SHAMAN > 0 && m_ai->CastSpell(CURE_DISEASE_SHAMAN, *diseasedTarget) == SPELL_CAST_OK)
+        if (CURE_DISEASE_SHAMAN > 0 && m_ai.CastSpell(CURE_DISEASE_SHAMAN, *diseasedTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
     }
     return RETURN_NO_ACTION_OK;
@@ -322,104 +319,95 @@ CombatManeuverReturns PlayerbotShamanAI::DispelPlayer(Player* /*target*/)
 
 void PlayerbotShamanAI::DropTotems()
 {
-    if (!m_ai)  return;
-    if (!m_bot) return;
+    uint32 spec = m_bot.GetSpec();
 
-    uint32 spec = m_bot->GetSpec();
-
-    Totem* earth = m_bot->GetTotem(TOTEM_SLOT_EARTH);
-    Totem* fire = m_bot->GetTotem(TOTEM_SLOT_FIRE);
-    Totem* water = m_bot->GetTotem(TOTEM_SLOT_WATER);
-    Totem* air = m_bot->GetTotem(TOTEM_SLOT_AIR);
+    Totem* earth = m_bot.GetTotem(TOTEM_SLOT_EARTH);
+    Totem* fire = m_bot.GetTotem(TOTEM_SLOT_FIRE);
+    Totem* water = m_bot.GetTotem(TOTEM_SLOT_WATER);
+    Totem* air = m_bot.GetTotem(TOTEM_SLOT_AIR);
 
     // Earth Totems
-    if ((earth == nullptr) || (m_bot->GetDistance(earth) > 30))
+    if ((earth == nullptr) || (m_bot.GetDistance(earth) > 30))
     {
-        if (STRENGTH_OF_EARTH_TOTEM > 0 && m_ai->CastSpell(STRENGTH_OF_EARTH_TOTEM) == SPELL_CAST_OK)
+        if (STRENGTH_OF_EARTH_TOTEM > 0 && m_ai.CastSpell(STRENGTH_OF_EARTH_TOTEM) == SPELL_CAST_OK)
             return;
     }
 
     // Fire Totems
-    if ((fire == nullptr) || (m_bot->GetDistance(fire) > 30))
+    if ((fire == nullptr) || (m_bot.GetDistance(fire) > 30))
     {
-        if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_FROST && FROST_RESISTANCE_TOTEM > 0 && m_ai->CastSpell(FROST_RESISTANCE_TOTEM) == SPELL_CAST_OK)
+        if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_FROST && FROST_RESISTANCE_TOTEM > 0 && m_ai.CastSpell(FROST_RESISTANCE_TOTEM) == SPELL_CAST_OK)
             return;
         // If the spec didn't take totem of wrath, use flametongue
-        else if ((spec != SHAMAN_SPEC_ELEMENTAL) && FLAMETONGUE_TOTEM > 0 && m_ai->CastSpell(FLAMETONGUE_TOTEM) == SPELL_CAST_OK)
+        else if ((spec != SHAMAN_SPEC_ELEMENTAL) && FLAMETONGUE_TOTEM > 0 && m_ai.CastSpell(FLAMETONGUE_TOTEM) == SPELL_CAST_OK)
             return;
     }
 
     // Air totems
-    if ((air == nullptr) || (m_bot->GetDistance(air) > 30))
+    if ((air == nullptr) || (m_bot.GetDistance(air) > 30))
     {
-        if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_NATURE && NATURE_RESISTANCE_TOTEM > 0 && m_ai->CastSpell(NATURE_RESISTANCE_TOTEM) == SPELL_CAST_OK)
+        if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_NATURE && NATURE_RESISTANCE_TOTEM > 0 && m_ai.CastSpell(NATURE_RESISTANCE_TOTEM) == SPELL_CAST_OK)
             return;
         else if (spec == SHAMAN_SPEC_ENHANCEMENT)
         {
-            if (WIND_FURY_TOTEM > 0 /*&& !m_bot->HasAura(IMPROVED_ICY_TALONS)*/ && m_ai->CastSpell(WIND_FURY_TOTEM) == SPELL_CAST_OK)
+            if (WIND_FURY_TOTEM > 0 /*&& !m_bot.HasAura(IMPROVED_ICY_TALONS)*/ && m_ai.CastSpell(WIND_FURY_TOTEM) == SPELL_CAST_OK)
                 return;
         }
         else
         {
-            if (WRATH_OF_AIR_TOTEM > 0 && m_ai->CastSpell(WRATH_OF_AIR_TOTEM) == SPELL_CAST_OK)
+            if (WRATH_OF_AIR_TOTEM > 0 && m_ai.CastSpell(WRATH_OF_AIR_TOTEM) == SPELL_CAST_OK)
                 return;
         }
     }
 
     // Water Totems
-    if ((water == nullptr) || (m_bot->GetDistance(water) > 30))
+    if ((water == nullptr) || (m_bot.GetDistance(water) > 30))
     {
-        if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_FIRE && FIRE_RESISTANCE_TOTEM > 0 && m_ai->CastSpell(FIRE_RESISTANCE_TOTEM) == SPELL_CAST_OK)
+        if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_RESIST_FIRE && FIRE_RESISTANCE_TOTEM > 0 && m_ai.CastSpell(FIRE_RESISTANCE_TOTEM) == SPELL_CAST_OK)
             return;
-        else if (MANA_SPRING_TOTEM > 0 && m_ai->CastSpell(MANA_SPRING_TOTEM) == SPELL_CAST_OK)
+        else if (MANA_SPRING_TOTEM > 0 && m_ai.CastSpell(MANA_SPRING_TOTEM) == SPELL_CAST_OK)
             return;
     }
 
-    /*if (EARTH_ELEMENTAL_TOTEM > 0 && m_ai->CastSpell(EARTH_ELEMENTAL_TOTEM) == SPELL_CAST_OK)
+    /*if (EARTH_ELEMENTAL_TOTEM > 0 && m_ai.CastSpell(EARTH_ELEMENTAL_TOTEM) == SPELL_CAST_OK)
         return RETURN_CONTINUE;*/
-    /*if (EARTHBIND_TOTEM > 0 && !pTarget->HasAura(EARTHBIND_TOTEM, EFFECT_INDEX_0) && !m_bot->HasAura(STRENGTH_OF_EARTH_TOTEM, EFFECT_INDEX_0) && m_ai->CastSpell(EARTHBIND_TOTEM) == SPELL_CAST_OK)
+    /*if (EARTHBIND_TOTEM > 0 && !pTarget->HasAura(EARTHBIND_TOTEM, EFFECT_INDEX_0) && !m_bot.HasAura(STRENGTH_OF_EARTH_TOTEM, EFFECT_INDEX_0) && m_ai.CastSpell(EARTHBIND_TOTEM) == SPELL_CAST_OK)
         return RETURN_CONTINUE;*/
-    /*if (FIRE_ELEMENTAL_TOTEM > 0 && m_ai->CastSpell(FIRE_ELEMENTAL_TOTEM) == SPELL_CAST_OK)
+    /*if (FIRE_ELEMENTAL_TOTEM > 0 && m_ai.CastSpell(FIRE_ELEMENTAL_TOTEM) == SPELL_CAST_OK)
         return RETURN_CONTINUE;*/
-    /*if (FIRE_NOVA_TOTEM > 0 && m_ai->CastSpell(FIRE_NOVA_TOTEM) == SPELL_CAST_OK)
+    /*if (FIRE_NOVA_TOTEM > 0 && m_ai.CastSpell(FIRE_NOVA_TOTEM) == SPELL_CAST_OK)
         return RETURN_CONTINUE;*/
-    /*if (GROUNDING_TOTEM > 0 && !m_bot->HasAura(GROUNDING_TOTEM, EFFECT_INDEX_0) && !m_bot->HasAura(WRATH_OF_AIR_TOTEM, EFFECT_INDEX_0) && !m_bot->HasAura(WIND_FURY_TOTEM, EFFECT_INDEX_0) && m_ai->CastSpell(GROUNDING_TOTEM) == SPELL_CAST_OK)
+    /*if (GROUNDING_TOTEM > 0 && !m_bot.HasAura(GROUNDING_TOTEM, EFFECT_INDEX_0) && !m_bot.HasAura(WRATH_OF_AIR_TOTEM, EFFECT_INDEX_0) && !m_bot.HasAura(WIND_FURY_TOTEM, EFFECT_INDEX_0) && m_ai.CastSpell(GROUNDING_TOTEM) == SPELL_CAST_OK)
         return RETURN_CONTINUE;*/
-    /*if (HEALING_STREAM_TOTEM > 0 && m_ai->GetHealthPercent() < 50 && !m_bot->HasAura(HEALING_STREAM_TOTEM, EFFECT_INDEX_0) && !m_bot->HasAura(MANA_SPRING_TOTEM, EFFECT_INDEX_0) && m_ai->CastSpell(HEALING_STREAM_TOTEM) == SPELL_CAST_OK)
+    /*if (HEALING_STREAM_TOTEM > 0 && m_ai.GetHealthPercent() < 50 && !m_bot.HasAura(HEALING_STREAM_TOTEM, EFFECT_INDEX_0) && !m_bot.HasAura(MANA_SPRING_TOTEM, EFFECT_INDEX_0) && m_ai.CastSpell(HEALING_STREAM_TOTEM) == SPELL_CAST_OK)
         return RETURN_CONTINUE;*/
-    /*if (MAGMA_TOTEM > 0 && (!m_bot->HasAura(TOTEM_OF_WRATH, EFFECT_INDEX_0)) && m_ai->CastSpell(MAGMA_TOTEM) == SPELL_CAST_OK)
+    /*if (MAGMA_TOTEM > 0 && (!m_bot.HasAura(TOTEM_OF_WRATH, EFFECT_INDEX_0)) && m_ai.CastSpell(MAGMA_TOTEM) == SPELL_CAST_OK)
         return RETURN_CONTINUE;*/
-    /*if (SEARING_TOTEM > 0 && !pTarget->HasAura(SEARING_TOTEM, EFFECT_INDEX_0) && !m_bot->HasAura(TOTEM_OF_WRATH, EFFECT_INDEX_0) && m_ai->CastSpell(SEARING_TOTEM) == SPELL_CAST_OK)
+    /*if (SEARING_TOTEM > 0 && !pTarget->HasAura(SEARING_TOTEM, EFFECT_INDEX_0) && !m_bot.HasAura(TOTEM_OF_WRATH, EFFECT_INDEX_0) && m_ai.CastSpell(SEARING_TOTEM) == SPELL_CAST_OK)
         return RETURN_CONTINUE;*/
-    /*if (STONECLAW_TOTEM > 0 && m_ai->GetHealthPercent() < 51 && !pTarget->HasAura(STONECLAW_TOTEM, EFFECT_INDEX_0) && !pTarget->HasAura(EARTHBIND_TOTEM, EFFECT_INDEX_0) && !m_bot->HasAura(STRENGTH_OF_EARTH_TOTEM, EFFECT_INDEX_0) && m_ai->CastSpell(STONECLAW_TOTEM) == SPELL_CAST_OK)
+    /*if (STONECLAW_TOTEM > 0 && m_ai.GetHealthPercent() < 51 && !pTarget->HasAura(STONECLAW_TOTEM, EFFECT_INDEX_0) && !pTarget->HasAura(EARTHBIND_TOTEM, EFFECT_INDEX_0) && !m_bot.HasAura(STRENGTH_OF_EARTH_TOTEM, EFFECT_INDEX_0) && m_ai.CastSpell(STONECLAW_TOTEM) == SPELL_CAST_OK)
         return RETURN_CONTINUE;*/
-    /*if (STONESKIN_TOTEM > 0 && !m_bot->HasAura(STONESKIN_TOTEM, EFFECT_INDEX_0) && !m_bot->HasAura(STRENGTH_OF_EARTH_TOTEM, EFFECT_INDEX_0) && m_ai->CastSpell(STONESKIN_TOTEM) == SPELL_CAST_OK)
+    /*if (STONESKIN_TOTEM > 0 && !m_bot.HasAura(STONESKIN_TOTEM, EFFECT_INDEX_0) && !m_bot.HasAura(STRENGTH_OF_EARTH_TOTEM, EFFECT_INDEX_0) && m_ai.CastSpell(STONESKIN_TOTEM) == SPELL_CAST_OK)
         return RETURN_CONTINUE;*/
-    /*if (TREMOR_TOTEM > 0 && !m_bot->HasAura(STRENGTH_OF_EARTH_TOTEM, EFFECT_INDEX_0) && m_ai->CastSpell(TREMOR_TOTEM) == SPELL_CAST_OK)
+    /*if (TREMOR_TOTEM > 0 && !m_bot.HasAura(STRENGTH_OF_EARTH_TOTEM, EFFECT_INDEX_0) && m_ai.CastSpell(TREMOR_TOTEM) == SPELL_CAST_OK)
         return RETURN_CONTINUE;*/
 }
 
 void PlayerbotShamanAI::CheckShields()
 {
-    if (!m_ai)  return;
-    if (!m_bot) return;
+    uint32 spec = m_bot.GetSpec();
 
-    uint32 spec = m_bot->GetSpec();
-
-    if (spec == SHAMAN_SPEC_ENHANCEMENT && LIGHTNING_SHIELD > 0 && !m_bot->HasAura(LIGHTNING_SHIELD, EFFECT_INDEX_0))
-        m_ai->CastSpell(LIGHTNING_SHIELD, *m_bot);
+    if (spec == SHAMAN_SPEC_ENHANCEMENT && LIGHTNING_SHIELD > 0 && !m_bot.HasAura(LIGHTNING_SHIELD, EFFECT_INDEX_0))
+        m_ai.CastSpell(LIGHTNING_SHIELD, m_bot);
     if (EARTH_SHIELD > 0 && !GetMaster()->HasAura(EARTH_SHIELD, EFFECT_INDEX_0))
-        m_ai->CastSpell(EARTH_SHIELD, *(GetMaster()));
+        m_ai.CastSpell(EARTH_SHIELD, *(GetMaster()));
 }
 
 void PlayerbotShamanAI::UseCooldowns()
 {
-    if (!m_ai)  return;
-    if (!m_bot) return;
+    uint32 spec = m_bot.GetSpec();
 
-    uint32 spec = m_bot->GetSpec();
-
-    if (BLOODLUST > 0 && (!GetMaster()->HasAura(BLOODLUST, EFFECT_INDEX_0)) && m_ai->CastSpell(BLOODLUST) == SPELL_CAST_OK)
+    if (BLOODLUST > 0 && (!GetMaster()->HasAura(BLOODLUST, EFFECT_INDEX_0)) && m_ai.CastSpell(BLOODLUST) == SPELL_CAST_OK)
         return;
 
     switch (spec)
@@ -428,14 +416,14 @@ void PlayerbotShamanAI::UseCooldowns()
             break;
 
         case SHAMAN_SPEC_ELEMENTAL:
-            if (ELEMENTAL_MASTERY > 0 && m_ai->CastSpell(ELEMENTAL_MASTERY, *m_bot) == SPELL_CAST_OK)
+            if (ELEMENTAL_MASTERY > 0 && m_ai.CastSpell(ELEMENTAL_MASTERY, m_bot) == SPELL_CAST_OK)
                 return;
             break;
 
         case SHAMAN_SPEC_RESTORATION:
-            if (MANA_TIDE_TOTEM > 0 && m_ai->GetManaPercent() < 50 && m_ai->CastSpell(MANA_TIDE_TOTEM) == SPELL_CAST_OK)
+            if (MANA_TIDE_TOTEM > 0 && m_ai.GetManaPercent() < 50 && m_ai.CastSpell(MANA_TIDE_TOTEM) == SPELL_CAST_OK)
                 return;
-            else if (NATURES_SWIFTNESS_SHAMAN > 0 && m_ai->CastSpell(NATURES_SWIFTNESS_SHAMAN) == SPELL_CAST_OK)
+            else if (NATURES_SWIFTNESS_SHAMAN > 0 && m_ai.CastSpell(NATURES_SWIFTNESS_SHAMAN) == SPELL_CAST_OK)
                 return;
 
         default:
@@ -445,13 +433,10 @@ void PlayerbotShamanAI::UseCooldowns()
 
 void PlayerbotShamanAI::DoNonCombatActions()
 {
-    if (!m_ai)   return;
-    if (!m_bot)  return;
-
-    if (!m_bot->IsAlive() || m_bot->IsInDuel()) return;
+    if (!m_bot.IsAlive() || m_bot.IsInDuel()) return;
 
     // Dispel disease/poison
-    if (m_ai->HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
+    if (m_ai.HasDispelOrder() && DispelPlayer() & RETURN_CONTINUE)
         return;
 
     // Revive
@@ -459,7 +444,7 @@ void PlayerbotShamanAI::DoNonCombatActions()
         return;
 
     // Heal
-    if (m_ai->IsHealer())
+    if (m_ai.IsHealer())
     {
         if (HealPlayer(GetHealTarget()) & RETURN_CONTINUE)
             return;// RETURN_CONTINUE;
@@ -468,38 +453,38 @@ void PlayerbotShamanAI::DoNonCombatActions()
     {
         // Is this desirable? Debatable.
         // TODO: In a group/raid with a healer you'd want this bot to focus on DPS (it's not specced/geared for healing either)
-        if (HealPlayer(m_bot) & RETURN_CONTINUE)
+        if (HealPlayer(&m_bot) & RETURN_CONTINUE)
             return;// RETURN_CONTINUE;
     }
 
-    uint32 spec = m_bot->GetSpec();
+    uint32 spec = m_bot.GetSpec();
 
     CheckShields();
     /*
            // buff myself weapon
            if (ROCKBITER_WEAPON > 0)
-                (!m_bot->HasAura(ROCKBITER_WEAPON, EFFECT_INDEX_0) && !m_bot->HasAura(WINDFURY_WEAPON, EFFECT_INDEX_0) && !m_bot->HasAura(FLAMETONGUE_WEAPON, EFFECT_INDEX_0) && !m_bot->HasAura(FROSTBRAND_WEAPON, EFFECT_INDEX_0) && m_ai->CastSpell(ROCKBITER_WEAPON,*m_bot) == SPELL_CAST_OK);
+                (!m_bot.HasAura(ROCKBITER_WEAPON, EFFECT_INDEX_0) && !m_bot.HasAura(WINDFURY_WEAPON, EFFECT_INDEX_0) && !m_bot.HasAura(FLAMETONGUE_WEAPON, EFFECT_INDEX_0) && !m_bot.HasAura(FROSTBRAND_WEAPON, EFFECT_INDEX_0) && m_ai.CastSpell(ROCKBITER_WEAPON,m_bot) == SPELL_CAST_OK);
            else if (EARTHLIVING_WEAPON > 0)
-                (!m_bot->HasAura(EARTHLIVING_WEAPON, EFFECT_INDEX_0) && !m_bot->HasAura(FLAMETONGUE_WEAPON, EFFECT_INDEX_0) && !m_bot->HasAura(FROSTBRAND_WEAPON, EFFECT_INDEX_0) && !m_bot->HasAura(ROCKBITER_WEAPON, EFFECT_INDEX_0) && m_ai->CastSpell(WINDFURY_WEAPON,*m_bot) == SPELL_CAST_OK);
+                (!m_bot.HasAura(EARTHLIVING_WEAPON, EFFECT_INDEX_0) && !m_bot.HasAura(FLAMETONGUE_WEAPON, EFFECT_INDEX_0) && !m_bot.HasAura(FROSTBRAND_WEAPON, EFFECT_INDEX_0) && !m_bot.HasAura(ROCKBITER_WEAPON, EFFECT_INDEX_0) && m_ai.CastSpell(WINDFURY_WEAPON,m_bot) == SPELL_CAST_OK);
            else if (WINDFURY_WEAPON > 0)
-                (!m_bot->HasAura(WINDFURY_WEAPON, EFFECT_INDEX_0) && !m_bot->HasAura(FLAMETONGUE_WEAPON, EFFECT_INDEX_0) && !m_bot->HasAura(FROSTBRAND_WEAPON, EFFECT_INDEX_0) && !m_bot->HasAura(ROCKBITER_WEAPON, EFFECT_INDEX_0) && m_ai->CastSpell(WINDFURY_WEAPON,*m_bot) == SPELL_CAST_OK);
+                (!m_bot.HasAura(WINDFURY_WEAPON, EFFECT_INDEX_0) && !m_bot.HasAura(FLAMETONGUE_WEAPON, EFFECT_INDEX_0) && !m_bot.HasAura(FROSTBRAND_WEAPON, EFFECT_INDEX_0) && !m_bot.HasAura(ROCKBITER_WEAPON, EFFECT_INDEX_0) && m_ai.CastSpell(WINDFURY_WEAPON,m_bot) == SPELL_CAST_OK);
            else if (FLAMETONGUE_WEAPON > 0)
-                (!m_bot->HasAura(FLAMETONGUE_WEAPON, EFFECT_INDEX_0) && !m_bot->HasAura(WINDFURY_WEAPON, EFFECT_INDEX_0) && !m_bot->HasAura(FROSTBRAND_WEAPON, EFFECT_INDEX_0) && !m_bot->HasAura(ROCKBITER_WEAPON, EFFECT_INDEX_0) && m_ai->CastSpell(FLAMETONGUE_WEAPON,*m_bot) == SPELL_CAST_OK);
+                (!m_bot.HasAura(FLAMETONGUE_WEAPON, EFFECT_INDEX_0) && !m_bot.HasAura(WINDFURY_WEAPON, EFFECT_INDEX_0) && !m_bot.HasAura(FROSTBRAND_WEAPON, EFFECT_INDEX_0) && !m_bot.HasAura(ROCKBITER_WEAPON, EFFECT_INDEX_0) && m_ai.CastSpell(FLAMETONGUE_WEAPON,m_bot) == SPELL_CAST_OK);
            else if (FROSTBRAND_WEAPON > 0)
-                (!m_bot->HasAura(FROSTBRAND_WEAPON, EFFECT_INDEX_0) && !m_bot->HasAura(WINDFURY_WEAPON, EFFECT_INDEX_0) && !m_bot->HasAura(FLAMETONGUE_WEAPON, EFFECT_INDEX_0) && !m_bot->HasAura(ROCKBITER_WEAPON, EFFECT_INDEX_0) && m_ai->CastSpell(FROSTBRAND_WEAPON,*m_bot) == SPELL_CAST_OK);
+                (!m_bot.HasAura(FROSTBRAND_WEAPON, EFFECT_INDEX_0) && !m_bot.HasAura(WINDFURY_WEAPON, EFFECT_INDEX_0) && !m_bot.HasAura(FLAMETONGUE_WEAPON, EFFECT_INDEX_0) && !m_bot.HasAura(ROCKBITER_WEAPON, EFFECT_INDEX_0) && m_ai.CastSpell(FROSTBRAND_WEAPON,m_bot) == SPELL_CAST_OK);
      */
     // Mainhand
     Item* weapon;
-    weapon = m_bot->GetItemByPos(EQUIPMENT_SLOT_MAINHAND);
+    weapon = m_bot.GetItemByPos(EQUIPMENT_SLOT_MAINHAND);
     if (weapon && (weapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0) && spec == SHAMAN_SPEC_ELEMENTAL)
-        m_ai->CastSpell(FLAMETONGUE_WEAPON, *m_bot);
+        m_ai.CastSpell(FLAMETONGUE_WEAPON, m_bot);
     else if (weapon && (weapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0) && spec == SHAMAN_SPEC_ENHANCEMENT)
-        m_ai->CastSpell(WINDFURY_WEAPON, *m_bot);
+        m_ai.CastSpell(WINDFURY_WEAPON, m_bot);
 
     //Offhand
-    weapon = m_bot->GetItemByPos(EQUIPMENT_SLOT_OFFHAND);
+    weapon = m_bot.GetItemByPos(EQUIPMENT_SLOT_OFFHAND);
     if (weapon && (weapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0) && spec == SHAMAN_SPEC_ENHANCEMENT)
-        m_ai->CastSpell(FLAMETONGUE_WEAPON, *m_bot);
+        m_ai.CastSpell(FLAMETONGUE_WEAPON, m_bot);
 
     // hp/mana check
     if (EatDrinkBandage())
@@ -508,9 +493,7 @@ void PlayerbotShamanAI::DoNonCombatActions()
 
 bool PlayerbotShamanAI::CastHoTOnTank()
 {
-    if (!m_ai) return false;
-
-    if (!m_ai->IsHealer()) return false;
+    if (!m_ai.IsHealer()) return false;
 
     // Shaman: Healing Stream Totem
     // None of these are cast before Pulling

--- a/src/game/PlayerBot/AI/PlayerbotShamanAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotShamanAI.h
@@ -110,25 +110,25 @@ class MANGOS_DLL_SPEC PlayerbotShamanAI : PlayerbotClassAI
         virtual ~PlayerbotShamanAI();
 
         // all combat actions go here
-        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget);
+        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget) override;
 
         // all non combat actions go here, ex buffs, heals, rezzes
-        void DoNonCombatActions();
+        void DoNonCombatActions() override;
 
         // Utility Functions
         bool CastHoTOnTank();
 
     private:
-        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget);
+        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget) override;
 
         // Heals the target based off its hps
-        CombatManeuverReturns HealPlayer(Player* target);
+        CombatManeuverReturns HealPlayer(Player* target) override;
         // Resurrects the target
-        CombatManeuverReturns ResurrectPlayer(Player* target);
+        CombatManeuverReturns ResurrectPlayer(Player* target) override;
         // Dispel disease or negative magic effects from an internally selected target
         CombatManeuverReturns DispelPlayer(Player* target = nullptr);
 

--- a/src/game/PlayerBot/AI/PlayerbotShamanAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotShamanAI.h
@@ -106,7 +106,7 @@ enum
 class MANGOS_DLL_SPEC PlayerbotShamanAI : PlayerbotClassAI
 {
     public:
-        PlayerbotShamanAI(Player* const master, Player* const bot, PlayerbotAI* const ai);
+        PlayerbotShamanAI(Player& master, Player& bot, PlayerbotAI& ai);
         virtual ~PlayerbotShamanAI();
 
         // all combat actions go here

--- a/src/game/PlayerBot/AI/PlayerbotWarlockAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotWarlockAI.cpp
@@ -19,7 +19,7 @@
 #include "PlayerbotWarlockAI.h"
 
 class PlayerbotAI;
-PlayerbotWarlockAI::PlayerbotWarlockAI(Player* const master, Player* const bot, PlayerbotAI* const ai) : PlayerbotClassAI(master, bot, ai)
+PlayerbotWarlockAI::PlayerbotWarlockAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
 {
     // DESTRUCTION
     SHADOW_BOLT           = m_ai->initSpell(SHADOW_BOLT_1);

--- a/src/game/PlayerBot/AI/PlayerbotWarlockAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotWarlockAI.cpp
@@ -19,69 +19,69 @@
 #include "PlayerbotWarlockAI.h"
 
 class PlayerbotAI;
-PlayerbotWarlockAI::PlayerbotWarlockAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
+PlayerbotWarlockAI::PlayerbotWarlockAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(master, bot, ai)
 {
     // DESTRUCTION
-    SHADOW_BOLT           = m_ai->initSpell(SHADOW_BOLT_1);
-    IMMOLATE              = m_ai->initSpell(IMMOLATE_1);
-    SEARING_PAIN          = m_ai->initSpell(SEARING_PAIN_1);
-    CONFLAGRATE           = m_ai->initSpell(CONFLAGRATE_1);
-    HELLFIRE              = m_ai->initSpell(HELLFIRE_1);
-    RAIN_OF_FIRE          = m_ai->initSpell(RAIN_OF_FIRE_1);
-    SOUL_FIRE             = m_ai->initSpell(SOUL_FIRE_1); // soul shard spells
-    SHADOWBURN            = m_ai->initSpell(SHADOWBURN_1);
+    SHADOW_BOLT           = m_ai.initSpell(SHADOW_BOLT_1);
+    IMMOLATE              = m_ai.initSpell(IMMOLATE_1);
+    SEARING_PAIN          = m_ai.initSpell(SEARING_PAIN_1);
+    CONFLAGRATE           = m_ai.initSpell(CONFLAGRATE_1);
+    HELLFIRE              = m_ai.initSpell(HELLFIRE_1);
+    RAIN_OF_FIRE          = m_ai.initSpell(RAIN_OF_FIRE_1);
+    SOUL_FIRE             = m_ai.initSpell(SOUL_FIRE_1); // soul shard spells
+    SHADOWBURN            = m_ai.initSpell(SHADOWBURN_1);
     // CURSE
-    CURSE_OF_WEAKNESS     = m_ai->initSpell(CURSE_OF_WEAKNESS_1);
-    CURSE_OF_THE_ELEMENTS = m_ai->initSpell(CURSE_OF_THE_ELEMENTS_1);
-    CURSE_OF_AGONY        = m_ai->initSpell(CURSE_OF_AGONY_1);
-    CURSE_OF_EXHAUSTION   = m_ai->initSpell(CURSE_OF_EXHAUSTION_1);
-    CURSE_OF_RECKLESSNESS = m_ai->initSpell(CURSE_OF_RECKLESSNESS_1);
-    CURSE_OF_SHADOW       = m_ai->initSpell(CURSE_OF_SHADOW_1);
-    CURSE_OF_TONGUES      = m_ai->initSpell(CURSE_OF_TONGUES_1);
-    CURSE_OF_DOOM         = m_ai->initSpell(CURSE_OF_DOOM_1);
+    CURSE_OF_WEAKNESS     = m_ai.initSpell(CURSE_OF_WEAKNESS_1);
+    CURSE_OF_THE_ELEMENTS = m_ai.initSpell(CURSE_OF_THE_ELEMENTS_1);
+    CURSE_OF_AGONY        = m_ai.initSpell(CURSE_OF_AGONY_1);
+    CURSE_OF_EXHAUSTION   = m_ai.initSpell(CURSE_OF_EXHAUSTION_1);
+    CURSE_OF_RECKLESSNESS = m_ai.initSpell(CURSE_OF_RECKLESSNESS_1);
+    CURSE_OF_SHADOW       = m_ai.initSpell(CURSE_OF_SHADOW_1);
+    CURSE_OF_TONGUES      = m_ai.initSpell(CURSE_OF_TONGUES_1);
+    CURSE_OF_DOOM         = m_ai.initSpell(CURSE_OF_DOOM_1);
     // AFFLICTION
-    AMPLIFY_CURSE         = m_ai->initSpell(AMPLIFY_CURSE_1);
-    CORRUPTION            = m_ai->initSpell(CORRUPTION_1);
-    DRAIN_SOUL            = m_ai->initSpell(DRAIN_SOUL_1);
-    DRAIN_LIFE            = m_ai->initSpell(DRAIN_LIFE_1);
-    DRAIN_MANA            = m_ai->initSpell(DRAIN_MANA_1);
-    LIFE_TAP              = m_ai->initSpell(LIFE_TAP_1);
-    DARK_PACT             = m_ai->initSpell(DARK_PACT_1);
-    HOWL_OF_TERROR        = m_ai->initSpell(HOWL_OF_TERROR_1);
-    FEAR                  = m_ai->initSpell(FEAR_1);
-    SIPHON_LIFE           = m_ai->initSpell(SIPHON_LIFE_1);
+    AMPLIFY_CURSE         = m_ai.initSpell(AMPLIFY_CURSE_1);
+    CORRUPTION            = m_ai.initSpell(CORRUPTION_1);
+    DRAIN_SOUL            = m_ai.initSpell(DRAIN_SOUL_1);
+    DRAIN_LIFE            = m_ai.initSpell(DRAIN_LIFE_1);
+    DRAIN_MANA            = m_ai.initSpell(DRAIN_MANA_1);
+    LIFE_TAP              = m_ai.initSpell(LIFE_TAP_1);
+    DARK_PACT             = m_ai.initSpell(DARK_PACT_1);
+    HOWL_OF_TERROR        = m_ai.initSpell(HOWL_OF_TERROR_1);
+    FEAR                  = m_ai.initSpell(FEAR_1);
+    SIPHON_LIFE           = m_ai.initSpell(SIPHON_LIFE_1);
     // DEMONOLOGY
-    BANISH                = m_ai->initSpell(BANISH_1);
-    ENSLAVE_DEMON         = m_ai->initSpell(ENSLAVE_DEMON_1);
-    DEMON_SKIN            = m_ai->initSpell(DEMON_SKIN_1);
-    DEMON_ARMOR           = m_ai->initSpell(DEMON_ARMOR_1);
-    SHADOW_WARD           = m_ai->initSpell(SHADOW_WARD_1);
-    SOUL_LINK             = m_ai->initSpell(SOUL_LINK_1);
+    BANISH                = m_ai.initSpell(BANISH_1);
+    ENSLAVE_DEMON         = m_ai.initSpell(ENSLAVE_DEMON_1);
+    DEMON_SKIN            = m_ai.initSpell(DEMON_SKIN_1);
+    DEMON_ARMOR           = m_ai.initSpell(DEMON_ARMOR_1);
+    SHADOW_WARD           = m_ai.initSpell(SHADOW_WARD_1);
+    SOUL_LINK             = m_ai.initSpell(SOUL_LINK_1);
     SOUL_LINK_AURA        = 25228; // dummy aura applied, after spell SOUL_LINK
-    HEALTH_FUNNEL         = m_ai->initSpell(HEALTH_FUNNEL_1);
-    DETECT_INVISIBILITY   = m_ai->initSpell(DETECT_INVISIBILITY_1);
-    CREATE_FIRESTONE      = m_ai->initSpell(CREATE_FIRESTONE_1);
-    CREATE_HEALTHSTONE    = m_ai->initSpell(CREATE_HEALTHSTONE_1);
-    CREATE_SOULSTONE      = m_ai->initSpell(CREATE_SOULSTONE_1);
-    CREATE_SPELLSTONE     = m_ai->initSpell(CREATE_SPELLSTONE_1);
+    HEALTH_FUNNEL         = m_ai.initSpell(HEALTH_FUNNEL_1);
+    DETECT_INVISIBILITY   = m_ai.initSpell(DETECT_INVISIBILITY_1);
+    CREATE_FIRESTONE      = m_ai.initSpell(CREATE_FIRESTONE_1);
+    CREATE_HEALTHSTONE    = m_ai.initSpell(CREATE_HEALTHSTONE_1);
+    CREATE_SOULSTONE      = m_ai.initSpell(CREATE_SOULSTONE_1);
+    CREATE_SPELLSTONE     = m_ai.initSpell(CREATE_SPELLSTONE_1);
     // demon summon
-    SUMMON_IMP            = m_ai->initSpell(SUMMON_IMP_1);
-    SUMMON_VOIDWALKER     = m_ai->initSpell(SUMMON_VOIDWALKER_1);
-    SUMMON_SUCCUBUS       = m_ai->initSpell(SUMMON_SUCCUBUS_1);
-    SUMMON_FELHUNTER      = m_ai->initSpell(SUMMON_FELHUNTER_1);
+    SUMMON_IMP            = m_ai.initSpell(SUMMON_IMP_1);
+    SUMMON_VOIDWALKER     = m_ai.initSpell(SUMMON_VOIDWALKER_1);
+    SUMMON_SUCCUBUS       = m_ai.initSpell(SUMMON_SUCCUBUS_1);
+    SUMMON_FELHUNTER      = m_ai.initSpell(SUMMON_FELHUNTER_1);
     // demon skills should be initialized on demons
     BLOOD_PACT            = 0; // imp skill
     CONSUME_SHADOWS       = 0; // voidwalker skill
     // RANGED COMBAT
-    SHOOT                 = m_ai->initSpell(SHOOT_3);
+    SHOOT                 = m_ai.initSpell(SHOOT_3);
 
     RECENTLY_BANDAGED     = 11196; // first aid check
 
     // racial
-    ESCAPE_ARTIST         = m_ai->initSpell(ESCAPE_ARTIST_ALL); // gnome
-    PERCEPTION            = m_ai->initSpell(PERCEPTION_ALL); // human
-    BLOOD_FURY            = m_ai->initSpell(BLOOD_FURY_ALL); // orc
-    WILL_OF_THE_FORSAKEN  = m_ai->initSpell(WILL_OF_THE_FORSAKEN_ALL); // undead
+    ESCAPE_ARTIST         = m_ai.initSpell(ESCAPE_ARTIST_ALL); // gnome
+    PERCEPTION            = m_ai.initSpell(PERCEPTION_ALL); // human
+    BLOOD_FURY            = m_ai.initSpell(BLOOD_FURY_ALL); // orc
+    WILL_OF_THE_FORSAKEN  = m_ai.initSpell(WILL_OF_THE_FORSAKEN_ALL); // undead
 
     m_lastDemon           = 0;
     m_isTempImp           = false;
@@ -94,27 +94,27 @@ CombatManeuverReturns PlayerbotWarlockAI::DoFirstCombatManeuver(Unit* pTarget)
 {
     // There are NPCs in BGs and Open World PvP, so don't filter this on PvP scenarios (of course if PvP targets anyone but tank, all bets are off anyway)
     // Wait until the tank says so, until any non-tank gains aggro or X seconds - whichever is shortest
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->GroupTankHoldsAggro())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.GroupTankHoldsAggro())
         {
             return RETURN_NO_ACTION_OK; // wait it out
         }
         else
         {
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
         }
     }
 
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->IsGroupReady())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.IsGroupReady())
             return RETURN_NO_ACTION_OK; // wait it out
         else
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
     }
 
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -146,9 +146,9 @@ CombatManeuverReturns PlayerbotWarlockAI::DoFirstCombatManeuverPVP(Unit* /*pTarg
 CombatManeuverReturns PlayerbotWarlockAI::DoNextCombatManeuver(Unit* pTarget)
 {
     // Face enemy, make sure bot is attacking
-    m_ai->FaceTarget(pTarget);
+    m_ai.FaceTarget(pTarget);
 
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -168,48 +168,45 @@ CombatManeuverReturns PlayerbotWarlockAI::DoNextCombatManeuver(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotWarlockAI::DoNextCombatManeuverPVE(Unit* pTarget)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
     //Unit* pVictim = pTarget->GetVictim();
-    bool meleeReach = m_bot->CanReachWithMeleeAttack(pTarget);
-    Pet* pet = m_bot->GetPet();
-    uint32 spec = m_bot->GetSpec();
-    uint8 shardCount = m_bot->GetItemCount(SOUL_SHARD, false, nullptr);
+    bool meleeReach = m_bot.CanReachWithMeleeAttack(pTarget);
+    Pet* pet = m_bot.GetPet();
+    uint32 spec = m_bot.GetSpec();
+    uint8 shardCount = m_bot.GetItemCount(SOUL_SHARD, false, nullptr);
 
     // Voidwalker is near death - sacrifice it for a shield
-    if (pet && pet->GetEntry() == DEMON_VOIDWALKER && SACRIFICE && !m_bot->HasAura(SACRIFICE) && pet->GetHealthPercent() < 10)
-        m_ai->CastPetSpell(SACRIFICE);
+    if (pet && pet->GetEntry() == DEMON_VOIDWALKER && SACRIFICE && !m_bot.HasAura(SACRIFICE) && pet->GetHealthPercent() < 10)
+        m_ai.CastPetSpell(SACRIFICE);
 
     // Use healthstone
-    if (m_ai->GetHealthPercent() < 30)
+    if (m_ai.GetHealthPercent() < 30)
     {
-        Item* healthStone = m_ai->FindConsumable(HEALTHSTONE_DISPLAYID);
+        Item* healthStone = m_ai.FindConsumable(HEALTHSTONE_DISPLAYID);
         if (healthStone)
-            m_ai->UseItem(healthStone);
+            m_ai.UseItem(healthStone);
     }
 
     // Voidwalker sacrifice gives shield - but you lose the pet (and it's DPS/tank) - use only as last resort for your own health!
-    if (m_ai->GetHealthPercent() < 20 && pet && pet->GetEntry() == DEMON_VOIDWALKER && SACRIFICE && !m_bot->HasAura(SACRIFICE))
-        m_ai->CastPetSpell(SACRIFICE);
+    if (m_ai.GetHealthPercent() < 20 && pet && pet->GetEntry() == DEMON_VOIDWALKER && SACRIFICE && !m_bot.HasAura(SACRIFICE))
+        m_ai.CastPetSpell(SACRIFICE);
 
-    if (m_ai->GetCombatStyle() != PlayerbotAI::COMBAT_RANGED && !meleeReach)
-        m_ai->SetCombatStyle(PlayerbotAI::COMBAT_RANGED);
+    if (m_ai.GetCombatStyle() != PlayerbotAI::COMBAT_RANGED && !meleeReach)
+        m_ai.SetCombatStyle(PlayerbotAI::COMBAT_RANGED);
     // switch to melee if in melee range AND can't shoot OR have no ranged (wand) equipped
-    else if (m_ai->GetCombatStyle() != PlayerbotAI::COMBAT_MELEE
+    else if (m_ai.GetCombatStyle() != PlayerbotAI::COMBAT_MELEE
              && meleeReach
-             && (SHOOT == 0 || !m_bot->GetWeaponForAttack(RANGED_ATTACK, true, true)))
-        m_ai->SetCombatStyle(PlayerbotAI::COMBAT_MELEE);
+             && (SHOOT == 0 || !m_bot.GetWeaponForAttack(RANGED_ATTACK, true, true)))
+        m_ai.SetCombatStyle(PlayerbotAI::COMBAT_MELEE);
 
     //Used to determine if this bot is highest on threat
-    Unit* newTarget = m_ai->FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), m_bot);
+    Unit* newTarget = m_ai.FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), &m_bot);
     if (newTarget && !PlayerbotAI::IsNeutralized(newTarget)) // TODO: && party has a tank
     {
         // Have threat, can't quickly lower it. 3 options remain: Stop attacking, lowlevel damage (wand), keep on keeping on.
         if (newTarget->GetHealthPercent() > 25)
         {
             // If elite
-            if (m_ai->IsElite(newTarget))
+            if (m_ai.IsElite(newTarget))
             {
                 // let warlock pet handle it to win some time
                 // no need to check if newTarget can be a player because IsElite() returns false for players
@@ -220,12 +217,12 @@ CombatManeuverReturns PlayerbotWarlockAI::DoNextCombatManeuverPVE(Unit* pTarget)
                     {
                         // taunt the elite and tank it
                         case DEMON_VOIDWALKER:
-                            if (TORMENT && m_ai->CastPetSpell(TORMENT, newTarget) == SPELL_CAST_OK)
+                            if (TORMENT && m_ai.CastPetSpell(TORMENT, newTarget) == SPELL_CAST_OK)
                                 return RETURN_NO_ACTION_OK;
                         // maybe give it some love?
                         case DEMON_SUCCUBUS:
                             if (creature->GetCreatureInfo()->CreatureType == CREATURE_TYPE_HUMANOID)
-                                if (SEDUCTION && !newTarget->HasAura(SEDUCTION) && m_ai->CastPetSpell(SEDUCTION, newTarget) == SPELL_CAST_OK)
+                                if (SEDUCTION && !newTarget->HasAura(SEDUCTION) && m_ai.CastPetSpell(SEDUCTION, newTarget) == SPELL_CAST_OK)
                                     return RETURN_NO_ACTION_OK;
                     }
 
@@ -247,28 +244,28 @@ CombatManeuverReturns PlayerbotWarlockAI::DoNextCombatManeuverPVE(Unit* pTarget)
     }
 
     // Create soul shard (only on non-worldboss)
-    uint8 freeSpace = m_ai->GetFreeBagSpace();
-    uint8 HPThreshold = (m_ai->IsElite(pTarget) ? 10 : 25);
-    if (!m_ai->IsElite(pTarget, true) && pTarget->GetHealthPercent() < HPThreshold && (shardCount < MAX_SHARD_COUNT && freeSpace > 0))
+    uint8 freeSpace = m_ai.GetFreeBagSpace();
+    uint8 HPThreshold = (m_ai.IsElite(pTarget) ? 10 : 25);
+    if (!m_ai.IsElite(pTarget, true) && pTarget->GetHealthPercent() < HPThreshold && (shardCount < MAX_SHARD_COUNT && freeSpace > 0))
     {
-        if (SHADOWBURN && m_ai->In_Reach(pTarget, SHADOWBURN) && !pTarget->HasAura(SHADOWBURN) && m_bot->IsSpellReady(SHADOWBURN) && CastSpell(SHADOWBURN, pTarget))
+        if (SHADOWBURN && m_ai.In_Reach(pTarget, SHADOWBURN) && !pTarget->HasAura(SHADOWBURN) && m_bot.IsSpellReady(SHADOWBURN) && CastSpell(SHADOWBURN, pTarget))
             return RETURN_CONTINUE;
 
         // Do not cast Drain Soul if Shadowburn is active on target
-        if (DRAIN_SOUL && m_ai->In_Reach(pTarget, DRAIN_SOUL) && !pTarget->HasAura(DRAIN_SOUL) && !pTarget->HasAura(SHADOWBURN) && CastSpell(DRAIN_SOUL, pTarget))
+        if (DRAIN_SOUL && m_ai.In_Reach(pTarget, DRAIN_SOUL) && !pTarget->HasAura(DRAIN_SOUL) && !pTarget->HasAura(SHADOWBURN) && CastSpell(DRAIN_SOUL, pTarget))
         {
-            m_ai->SetIgnoreUpdateTime(15);
+            m_ai.SetIgnoreUpdateTime(15);
             return RETURN_CONTINUE;
         }
     }
 
-    if (pet && DARK_PACT && (100 * pet->GetPower(POWER_MANA) / pet->GetMaxPower(POWER_MANA)) > 10 && m_ai->GetManaPercent() <= 20)
-        if (m_ai->CastSpell(DARK_PACT, *m_bot) == SPELL_CAST_OK)
+    if (pet && DARK_PACT && (100 * pet->GetPower(POWER_MANA) / pet->GetMaxPower(POWER_MANA)) > 10 && m_ai.GetManaPercent() <= 20)
+        if (m_ai.CastSpell(DARK_PACT, m_bot) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
 
     // Mana check and replenishment
-    if (LIFE_TAP && m_ai->GetManaPercent() <= 20 && m_ai->GetHealthPercent() > 50)
-        if (m_ai->CastSpell(LIFE_TAP, *m_bot) == SPELL_CAST_OK)
+    if (LIFE_TAP && m_ai.GetManaPercent() <= 20 && m_ai.GetHealthPercent() > 50)
+        if (m_ai.CastSpell(LIFE_TAP, m_bot) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
 
     // HP, mana and aggro checks done
@@ -282,35 +279,35 @@ CombatManeuverReturns PlayerbotWarlockAI::DoNextCombatManeuverPVE(Unit* pTarget)
         switch (spec)
         {
             case WARLOCK_SPEC_AFFLICTION:
-                if (CORRUPTION && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai->In_Reach(pTarget, CORRUPTION) && !pTarget->HasAura(CORRUPTION) && CastSpell(CORRUPTION, pTarget))
+                if (CORRUPTION && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai.In_Reach(pTarget, CORRUPTION) && !pTarget->HasAura(CORRUPTION) && CastSpell(CORRUPTION, pTarget))
                     return RETURN_CONTINUE;
-                if (IMMOLATE && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai->In_Reach(pTarget, IMMOLATE) && !pTarget->HasAura(IMMOLATE) && CastSpell(IMMOLATE, pTarget))
+                if (IMMOLATE && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai.In_Reach(pTarget, IMMOLATE) && !pTarget->HasAura(IMMOLATE) && CastSpell(IMMOLATE, pTarget))
                     return RETURN_CONTINUE;
-                if (SIPHON_LIFE > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai->In_Reach(pTarget, SIPHON_LIFE) && !pTarget->HasAura(SIPHON_LIFE) && CastSpell(SIPHON_LIFE, pTarget))
+                if (SIPHON_LIFE > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai.In_Reach(pTarget, SIPHON_LIFE) && !pTarget->HasAura(SIPHON_LIFE) && CastSpell(SIPHON_LIFE, pTarget))
                     return RETURN_CONTINUE;
                 break;
 
             case WARLOCK_SPEC_DEMONOLOGY:
-                if (CORRUPTION && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai->In_Reach(pTarget, CORRUPTION) && !pTarget->HasAura(CORRUPTION) && CastSpell(CORRUPTION, pTarget))
+                if (CORRUPTION && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai.In_Reach(pTarget, CORRUPTION) && !pTarget->HasAura(CORRUPTION) && CastSpell(CORRUPTION, pTarget))
                     return RETURN_CONTINUE;
-                if (IMMOLATE && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai->In_Reach(pTarget, IMMOLATE) && !pTarget->HasAura(IMMOLATE) && CastSpell(IMMOLATE, pTarget))
+                if (IMMOLATE && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai.In_Reach(pTarget, IMMOLATE) && !pTarget->HasAura(IMMOLATE) && CastSpell(IMMOLATE, pTarget))
                     return RETURN_CONTINUE;
                 break;
 
             case WARLOCK_SPEC_DESTRUCTION:
-                if (SHADOWBURN && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && pTarget->GetHealthPercent() < (HPThreshold / 2.0) && m_ai->In_Reach(pTarget, SHADOWBURN) && !pTarget->HasAura(SHADOWBURN) && CastSpell(SHADOWBURN, pTarget))
+                if (SHADOWBURN && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && pTarget->GetHealthPercent() < (HPThreshold / 2.0) && m_ai.In_Reach(pTarget, SHADOWBURN) && !pTarget->HasAura(SHADOWBURN) && CastSpell(SHADOWBURN, pTarget))
                     return RETURN_CONTINUE;
-                if (CORRUPTION && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai->In_Reach(pTarget, CORRUPTION) && !pTarget->HasAura(CORRUPTION) && CastSpell(CORRUPTION, pTarget))
+                if (CORRUPTION && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai.In_Reach(pTarget, CORRUPTION) && !pTarget->HasAura(CORRUPTION) && CastSpell(CORRUPTION, pTarget))
                     return RETURN_CONTINUE;
-                if (IMMOLATE && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai->In_Reach(pTarget, IMMOLATE) && !pTarget->HasAura(IMMOLATE) && CastSpell(IMMOLATE, pTarget))
+                if (IMMOLATE && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai.In_Reach(pTarget, IMMOLATE) && !pTarget->HasAura(IMMOLATE) && CastSpell(IMMOLATE, pTarget))
                     return RETURN_CONTINUE;
-                if (CONFLAGRATE && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai->In_Reach(pTarget, CONFLAGRATE) && pTarget->HasAura(IMMOLATE) && m_bot->IsSpellReady(CONFLAGRATE) && CastSpell(CONFLAGRATE, pTarget))
+                if (CONFLAGRATE && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai.In_Reach(pTarget, CONFLAGRATE) && pTarget->HasAura(IMMOLATE) && m_bot.IsSpellReady(CONFLAGRATE) && CastSpell(CONFLAGRATE, pTarget))
                     return RETURN_CONTINUE;
                 break;
         }
 
         // Shadow bolt is common to all specs
-        if (SHADOW_BOLT && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai->In_Reach(pTarget, SHADOW_BOLT) && CastSpell(SHADOW_BOLT, pTarget))
+        if (SHADOW_BOLT && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai.In_Reach(pTarget, SHADOW_BOLT) && CastSpell(SHADOW_BOLT, pTarget))
             return RETURN_CONTINUE;
 
         // Default: shoot with wand
@@ -318,11 +315,11 @@ CombatManeuverReturns PlayerbotWarlockAI::DoNextCombatManeuverPVE(Unit* pTarget)
     }
 
     // No spec due to low level OR no spell found yet
-    if (CORRUPTION && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai->In_Reach(pTarget, CORRUPTION) && !pTarget->HasAura(CORRUPTION) && CastSpell(CORRUPTION, pTarget))
+    if (CORRUPTION && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai.In_Reach(pTarget, CORRUPTION) && !pTarget->HasAura(CORRUPTION) && CastSpell(CORRUPTION, pTarget))
         return RETURN_CONTINUE;
-    if (IMMOLATE && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai->In_Reach(pTarget, IMMOLATE) && !pTarget->HasAura(IMMOLATE) && CastSpell(IMMOLATE, pTarget))
+    if (IMMOLATE && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_FIRE) && m_ai.In_Reach(pTarget, IMMOLATE) && !pTarget->HasAura(IMMOLATE) && CastSpell(IMMOLATE, pTarget))
         return RETURN_CONTINUE;
-    if (SHADOW_BOLT && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai->In_Reach(pTarget, SHADOW_BOLT))
+    if (SHADOW_BOLT && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_SHADOW) && m_ai.In_Reach(pTarget, SHADOW_BOLT))
         return CastSpell(SHADOW_BOLT, pTarget);
 
     // Default: shoot with wand
@@ -331,9 +328,9 @@ CombatManeuverReturns PlayerbotWarlockAI::DoNextCombatManeuverPVE(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotWarlockAI::DoNextCombatManeuverPVP(Unit* pTarget)
 {
-    if (FEAR && m_ai->In_Reach(pTarget, FEAR) && m_ai->CastSpell(FEAR, *pTarget) == SPELL_CAST_OK)
+    if (FEAR && m_ai.In_Reach(pTarget, FEAR) && m_ai.CastSpell(FEAR, *pTarget) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
-    if (SHADOW_BOLT && m_ai->In_Reach(pTarget, SHADOW_BOLT) && m_ai->CastSpell(SHADOW_BOLT) == SPELL_CAST_OK)
+    if (SHADOW_BOLT && m_ai.In_Reach(pTarget, SHADOW_BOLT) && m_ai.CastSpell(SHADOW_BOLT) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
     return DoNextCombatManeuverPVE(pTarget); // TODO: bad idea perhaps, but better than the alternative
@@ -354,10 +351,10 @@ bool PlayerbotWarlockAI::CheckCurse(Unit* target)
         // Curse of Exhaustion first to avoid increasing damage output on tank
         if (creature->GetCreatureInfo()->CreatureType == CREATURE_TYPE_HUMANOID && target->GetHealthPercent() < 20 && !creature->IsWorldBoss())
         {
-            if (CURSE_OF_EXHAUSTION && m_ai->In_Reach(target, CURSE_OF_EXHAUSTION) && !target->HasAura(CURSE_OF_EXHAUSTION))
+            if (CURSE_OF_EXHAUSTION && m_ai.In_Reach(target, CURSE_OF_EXHAUSTION) && !target->HasAura(CURSE_OF_EXHAUSTION))
             {
-                if (AMPLIFY_CURSE && m_bot->IsSpellReady(AMPLIFY_CURSE))
-                    CastSpell(AMPLIFY_CURSE, m_bot);
+                if (AMPLIFY_CURSE && m_bot.IsSpellReady(AMPLIFY_CURSE))
+                    CastSpell(AMPLIFY_CURSE, &m_bot);
 
                 if (CastSpell(CURSE_OF_EXHAUSTION, target))
                 {
@@ -365,7 +362,7 @@ bool PlayerbotWarlockAI::CheckCurse(Unit* target)
                     return true;
                 }
             }
-            else if (CURSE_OF_RECKLESSNESS && m_ai->In_Reach(target, CURSE_OF_RECKLESSNESS) && !target->HasAura(CURSE_OF_RECKLESSNESS) && !target->HasAura(CURSE_OF_EXHAUSTION) && CastSpell(CURSE_OF_RECKLESSNESS, target))
+            else if (CURSE_OF_RECKLESSNESS && m_ai.In_Reach(target, CURSE_OF_RECKLESSNESS) && !target->HasAura(CURSE_OF_RECKLESSNESS) && !target->HasAura(CURSE_OF_EXHAUSTION) && CastSpell(CURSE_OF_RECKLESSNESS, target))
             {
                 m_CurrentCurse = CURSE_OF_RECKLESSNESS;
                 return true;
@@ -380,11 +377,11 @@ bool PlayerbotWarlockAI::CheckCurse(Unit* target)
     // No curse or effect worn off: choose again which curse to use
 
     // Target is a boss and bot is part of a group
-    if (m_ai->IsElite(target, true) && m_bot->GetGroup())
+    if (m_ai.IsElite(target, true) && m_bot.GetGroup())
     {
         uint8 mages = 0;
         uint8 warlocks = 1;
-        Group::MemberSlotList const& groupSlot = m_bot->GetGroup()->GetMemberSlots();
+        Group::MemberSlotList const& groupSlot = m_bot.GetGroup()->GetMemberSlots();
         for (auto itr = groupSlot.begin(); itr != groupSlot.end(); itr++)
         {
             Player* groupMember = sObjectMgr.GetPlayer(itr->guid);
@@ -413,12 +410,12 @@ bool PlayerbotWarlockAI::CheckCurse(Unit* target)
         curseToCast = CURSE_OF_TONGUES;
 
     // Try to curse the target with the selected curse
-    if (curseToCast && m_ai->In_Reach(target, curseToCast) && !target->HasAura(curseToCast))
+    if (curseToCast && m_ai.In_Reach(target, curseToCast) && !target->HasAura(curseToCast))
     {
         if (curseToCast == CURSE_OF_AGONY)
         {
-            if (AMPLIFY_CURSE && m_bot->IsSpellReady(AMPLIFY_CURSE))
-                CastSpell(AMPLIFY_CURSE, m_bot);
+            if (AMPLIFY_CURSE && m_bot.IsSpellReady(AMPLIFY_CURSE))
+                CastSpell(AMPLIFY_CURSE, &m_bot);
         }
 
         if (CastSpell(curseToCast, target))
@@ -428,10 +425,10 @@ bool PlayerbotWarlockAI::CheckCurse(Unit* target)
         }
     }
     // else: go for Curse of Agony: in the long run: go for direct damage
-    else if (CURSE_OF_AGONY && m_ai->In_Reach(target, CURSE_OF_AGONY) && !target->HasAura(CURSE_OF_AGONY))
+    else if (CURSE_OF_AGONY && m_ai.In_Reach(target, CURSE_OF_AGONY) && !target->HasAura(CURSE_OF_AGONY))
     {
-        if (AMPLIFY_CURSE && m_bot->IsSpellReady(AMPLIFY_CURSE))
-            CastSpell(AMPLIFY_CURSE, m_bot);
+        if (AMPLIFY_CURSE && m_bot.IsSpellReady(AMPLIFY_CURSE))
+            CastSpell(AMPLIFY_CURSE, &m_bot);
 
         if (CastSpell(CURSE_OF_AGONY, target))
         {
@@ -442,8 +439,8 @@ bool PlayerbotWarlockAI::CheckCurse(Unit* target)
     // else: go for Curse of Weakness
     else if (CURSE_OF_WEAKNESS && !target->HasAura(CURSE_OF_WEAKNESS) && !target->HasAura(CURSE_OF_AGONY))
     {
-        if (AMPLIFY_CURSE && m_bot->IsSpellReady(AMPLIFY_CURSE))
-            CastSpell(AMPLIFY_CURSE, m_bot);
+        if (AMPLIFY_CURSE && m_bot.IsSpellReady(AMPLIFY_CURSE))
+            CastSpell(AMPLIFY_CURSE, &m_bot);
 
         if (CastSpell(CURSE_OF_WEAKNESS, target))
         {
@@ -456,9 +453,9 @@ bool PlayerbotWarlockAI::CheckCurse(Unit* target)
 
 void PlayerbotWarlockAI::CheckDemon()
 {
-    uint32 spec = m_bot->GetSpec();
-    uint8 shardCount = m_bot->GetItemCount(SOUL_SHARD, false, nullptr);
-    Pet* pet = m_bot->GetPet();
+    uint32 spec = m_bot.GetSpec();
+    uint8 shardCount = m_bot.GetItemCount(SOUL_SHARD, false, nullptr);
+    Pet* pet = m_bot.GetPet();
     uint32 demonOfChoice;
 
     // If pet other than imp is active: return
@@ -497,19 +494,19 @@ void PlayerbotWarlockAI::CheckDemon()
                     summonSpellId = 0;
             }
 
-            if (summonSpellId && m_ai->CastSpell(summonSpellId) == SPELL_CAST_OK)
+            if (summonSpellId && m_ai.CastSpell(summonSpellId) == SPELL_CAST_OK)
             {
-                //m_ai->TellMaster("Summoning favorite demon...");
+                //m_ai.TellMaster("Summoning favorite demon...");
                 m_isTempImp = false;
                 return;
             }
         }
 
-        if (!pet && SUMMON_IMP && m_ai->CastSpell(SUMMON_IMP) == SPELL_CAST_OK)
+        if (!pet && SUMMON_IMP && m_ai.CastSpell(SUMMON_IMP) == SPELL_CAST_OK)
         {
             m_isTempImp = demonOfChoice != DEMON_IMP;
 
-            //m_ai->TellMaster("Summoning Imp...");
+            //m_ai.TellMaster("Summoning Imp...");
             return;
         }
     }
@@ -517,11 +514,8 @@ void PlayerbotWarlockAI::CheckDemon()
 
 void PlayerbotWarlockAI::DoNonCombatActions()
 {
-    if (!m_ai)  return;
-    if (!m_bot) return;
-
-    //uint32 spec = m_bot->GetSpec();
-    Pet* pet = m_bot->GetPet();
+    //uint32 spec = m_bot.GetSpec();
+    Pet* pet = m_bot.GetPet();
 
     // Initialize pet spells
     if (pet && pet->GetEntry() != m_lastDemon)
@@ -529,27 +523,27 @@ void PlayerbotWarlockAI::DoNonCombatActions()
         switch (pet->GetEntry())
         {
             case DEMON_IMP:
-                BLOOD_PACT       = m_ai->initPetSpell(BLOOD_PACT_ICON);
-                FIREBOLT         = m_ai->initPetSpell(FIREBOLT_ICON);
-                FIRE_SHIELD      = m_ai->initPetSpell(FIRE_SHIELD_ICON);
+                BLOOD_PACT       = m_ai.initPetSpell(BLOOD_PACT_ICON);
+                FIREBOLT         = m_ai.initPetSpell(FIREBOLT_ICON);
+                FIRE_SHIELD      = m_ai.initPetSpell(FIRE_SHIELD_ICON);
                 break;
 
             case DEMON_VOIDWALKER:
-                CONSUME_SHADOWS  = m_ai->initPetSpell(CONSUME_SHADOWS_ICON);
-                SACRIFICE        = m_ai->initPetSpell(SACRIFICE_ICON);
-                SUFFERING        = m_ai->initPetSpell(SUFFERING_ICON);
-                TORMENT          = m_ai->initPetSpell(TORMENT_ICON);
+                CONSUME_SHADOWS  = m_ai.initPetSpell(CONSUME_SHADOWS_ICON);
+                SACRIFICE        = m_ai.initPetSpell(SACRIFICE_ICON);
+                SUFFERING        = m_ai.initPetSpell(SUFFERING_ICON);
+                TORMENT          = m_ai.initPetSpell(TORMENT_ICON);
                 break;
 
             case DEMON_SUCCUBUS:
-                LASH_OF_PAIN     = m_ai->initPetSpell(LASH_OF_PAIN_ICON);
-                SEDUCTION        = m_ai->initPetSpell(SEDUCTION_ICON);
-                SOOTHING_KISS    = m_ai->initPetSpell(SOOTHING_KISS_ICON);
+                LASH_OF_PAIN     = m_ai.initPetSpell(LASH_OF_PAIN_ICON);
+                SEDUCTION        = m_ai.initPetSpell(SEDUCTION_ICON);
+                SOOTHING_KISS    = m_ai.initPetSpell(SOOTHING_KISS_ICON);
                 break;
 
             case DEMON_FELHUNTER:
-                DEVOUR_MAGIC     = m_ai->initPetSpell(DEVOUR_MAGIC_ICON);
-                SPELL_LOCK       = m_ai->initPetSpell(SPELL_LOCK_ICON);
+                DEVOUR_MAGIC     = m_ai.initPetSpell(DEVOUR_MAGIC_ICON);
+                SPELL_LOCK       = m_ai.initPetSpell(SPELL_LOCK_ICON);
                 break;
         }
 
@@ -557,39 +551,39 @@ void PlayerbotWarlockAI::DoNonCombatActions()
     }
 
     // Destroy extra soul shards
-    uint8 shardCount = m_bot->GetItemCount(SOUL_SHARD, false, nullptr);
-    uint8 freeSpace = m_ai->GetFreeBagSpace();
+    uint8 shardCount = m_bot.GetItemCount(SOUL_SHARD, false, nullptr);
+    uint8 freeSpace = m_ai.GetFreeBagSpace();
     if (shardCount > MAX_SHARD_COUNT || (freeSpace == 0 && shardCount > 1))
-        m_bot->DestroyItemCount(SOUL_SHARD, shardCount > MAX_SHARD_COUNT ? shardCount - MAX_SHARD_COUNT : 1, true, false);
+        m_bot.DestroyItemCount(SOUL_SHARD, shardCount > MAX_SHARD_COUNT ? shardCount - MAX_SHARD_COUNT : 1, true, false);
 
     // buff myself DEMON_SKIN, DEMON_ARMOR, FEL_ARMOR - Strongest one available is chosen
     if (DEMON_ARMOR)
     {
-        if (m_ai->SelfBuff(DEMON_ARMOR) == SPELL_CAST_OK)
+        if (m_ai.SelfBuff(DEMON_ARMOR) == SPELL_CAST_OK)
             return;
     }
     else if (DEMON_SKIN)
-        if (m_ai->SelfBuff(DEMON_SKIN) == SPELL_CAST_OK)
+        if (m_ai.SelfBuff(DEMON_SKIN) == SPELL_CAST_OK)
             return;
 
     // healthstone creation
     if (CREATE_HEALTHSTONE && shardCount > 0)
     {
-        Item* const healthStone = m_ai->FindConsumable(HEALTHSTONE_DISPLAYID);
-        if (!healthStone && m_ai->CastSpell(CREATE_HEALTHSTONE) == SPELL_CAST_OK)
+        Item* const healthStone = m_ai.FindConsumable(HEALTHSTONE_DISPLAYID);
+        if (!healthStone && m_ai.CastSpell(CREATE_HEALTHSTONE) == SPELL_CAST_OK)
             return;
     }
 
     // soulstone creation and use
     if (CREATE_SOULSTONE)
     {
-        Item* soulStone = m_ai->FindConsumable(SOULSTONE_DISPLAYID);
+        Item* soulStone = m_ai.FindConsumable(SOULSTONE_DISPLAYID);
         if (!soulStone)
         {
             // try create one only if there is place on bags
-            if (m_ai->CanStore())
+            if (m_ai.CanStore())
             {
-                if (shardCount > 0 && m_bot->IsSpellReady(CREATE_SOULSTONE) && m_ai->CastSpell(CREATE_SOULSTONE) == SPELL_CAST_OK)
+                if (shardCount > 0 && m_bot.IsSpellReady(CREATE_SOULSTONE) && m_ai.CastSpell(CREATE_SOULSTONE) == SPELL_CAST_OK)
                     return;
             }
         }
@@ -597,59 +591,59 @@ void PlayerbotWarlockAI::DoNonCombatActions()
         {
             uint32 soulStoneSpell = soulStone->GetProto()->Spells[0].SpellId;
             Player* master = GetMaster();
-            if (!master->HasAura(soulStoneSpell) && m_bot->IsSpellReady(soulStoneSpell))
+            if (!master->HasAura(soulStoneSpell) && m_bot.IsSpellReady(soulStoneSpell))
             {
                 // TODO: first choice: healer. Second choice: anyone else with revive spell. Third choice: self or master.
-                m_ai->UseItem(soulStone, master);
+                m_ai.UseItem(soulStone, master);
                 return;
             }
         }
     }
 
     // hp/mana check
-    if (pet && DARK_PACT && (100 * pet->GetPower(POWER_MANA) / pet->GetMaxPower(POWER_MANA)) > 40 && m_ai->GetManaPercent() <= 60)
-        if (m_ai->CastSpell(DARK_PACT, *m_bot) == SPELL_CAST_OK)
+    if (pet && DARK_PACT && (100 * pet->GetPower(POWER_MANA) / pet->GetMaxPower(POWER_MANA)) > 40 && m_ai.GetManaPercent() <= 60)
+        if (m_ai.CastSpell(DARK_PACT, m_bot) == SPELL_CAST_OK)
             return;
 
-    if (LIFE_TAP && m_ai->GetManaPercent() <= 80 && m_ai->GetHealthPercent() > 50)
-        if (m_ai->CastSpell(LIFE_TAP, *m_bot) == SPELL_CAST_OK)
+    if (LIFE_TAP && m_ai.GetManaPercent() <= 80 && m_ai.GetHealthPercent() > 50)
+        if (m_ai.CastSpell(LIFE_TAP, m_bot) == SPELL_CAST_OK)
             return;
 
     // Do not waste time/soul shards to create spellstone or firestone
     // if two-handed weapon (staff) or off-hand item are already equiped
     // Spellstone creation and use (Spellstone dominates firestone completely as I understand it)
-    Item* const weapon = m_bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
-    Item* const offweapon = m_bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
+    Item* const weapon = m_bot.GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+    Item* const offweapon = m_bot.GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
     if (weapon && !offweapon && weapon->GetProto()->SubClass != ITEM_SUBCLASS_WEAPON_STAFF && weapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0)
     {
-        Item* const stone = m_ai->FindConsumable(SPELLSTONE_DISPLAYID);
-        Item* const stone2 = m_ai->FindConsumable(FIRESTONE_DISPLAYID);
-        uint8 spellstone_count = m_bot->GetItemCount(SPELLSTONE, false, nullptr);
+        Item* const stone = m_ai.FindConsumable(SPELLSTONE_DISPLAYID);
+        Item* const stone2 = m_ai.FindConsumable(FIRESTONE_DISPLAYID);
+        uint8 spellstone_count = m_bot.GetItemCount(SPELLSTONE, false, nullptr);
         if (spellstone_count == 0)
-            spellstone_count = m_bot->GetItemCount(GREATER_SPELLSTONE, false, nullptr);
+            spellstone_count = m_bot.GetItemCount(GREATER_SPELLSTONE, false, nullptr);
         if (spellstone_count == 0)
-            spellstone_count = m_bot->GetItemCount(MAJOR_SPELLSTONE, false, nullptr);
-        uint8 firestone_count = m_bot->GetItemCount(LESSER_FIRESTONE, false, nullptr);
+            spellstone_count = m_bot.GetItemCount(MAJOR_SPELLSTONE, false, nullptr);
+        uint8 firestone_count = m_bot.GetItemCount(LESSER_FIRESTONE, false, nullptr);
         if (firestone_count == 0)
-            firestone_count = m_bot->GetItemCount(FIRESTONE, false, nullptr);
+            firestone_count = m_bot.GetItemCount(FIRESTONE, false, nullptr);
         if (firestone_count == 0)
-            firestone_count = m_bot->GetItemCount(GREATER_FIRESTONE, false, nullptr);
+            firestone_count = m_bot.GetItemCount(GREATER_FIRESTONE, false, nullptr);
         if (firestone_count == 0)
-            firestone_count = m_bot->GetItemCount(MAJOR_FIRESTONE, false, nullptr);
+            firestone_count = m_bot.GetItemCount(MAJOR_FIRESTONE, false, nullptr);
         if (spellstone_count == 0 && firestone_count == 0)
         {
-            if ((CREATE_SPELLSTONE && shardCount > 0 && m_ai->CastSpell(CREATE_SPELLSTONE) == SPELL_CAST_OK) ||
-                (CREATE_SPELLSTONE == 0 && CREATE_FIRESTONE > 0 && shardCount > 0 && m_ai->CastSpell(CREATE_FIRESTONE) == SPELL_CAST_OK))
+            if ((CREATE_SPELLSTONE && shardCount > 0 && m_ai.CastSpell(CREATE_SPELLSTONE) == SPELL_CAST_OK) ||
+                (CREATE_SPELLSTONE == 0 && CREATE_FIRESTONE > 0 && shardCount > 0 && m_ai.CastSpell(CREATE_FIRESTONE) == SPELL_CAST_OK))
                 return;
         }
         else if (stone)
         {
-            m_ai->UseItem(stone, EQUIPMENT_SLOT_OFFHAND);
+            m_ai.UseItem(stone, EQUIPMENT_SLOT_OFFHAND);
             return;
         }
         else
         {
-            m_ai->UseItem(stone2, EQUIPMENT_SLOT_OFFHAND);
+            m_ai.UseItem(stone2, EQUIPMENT_SLOT_OFFHAND);
             return;
         }
     }
@@ -659,30 +653,28 @@ void PlayerbotWarlockAI::DoNonCombatActions()
 
     //Heal Voidwalker
     if (pet && pet->GetEntry() == DEMON_VOIDWALKER && CONSUME_SHADOWS && pet->GetHealthPercent() < 75 && !pet->HasAura(CONSUME_SHADOWS))
-        m_ai->CastPetSpell(CONSUME_SHADOWS);
+        m_ai.CastPetSpell(CONSUME_SHADOWS);
 
     CheckDemon();
 
     // Soul link demon
-    if (pet && SOUL_LINK && !m_bot->HasAura(SOUL_LINK_AURA) && m_ai->CastSpell(SOUL_LINK, *m_bot) == SPELL_CAST_OK)
+    if (pet && SOUL_LINK && !m_bot.HasAura(SOUL_LINK_AURA) && m_ai.CastSpell(SOUL_LINK, m_bot) == SPELL_CAST_OK)
         return;
 
     // Check demon buffs
-    if (pet && pet->GetEntry() == DEMON_IMP && BLOOD_PACT && !m_bot->HasAura(BLOOD_PACT) && m_ai->CastPetSpell(BLOOD_PACT) == SPELL_CAST_OK)
+    if (pet && pet->GetEntry() == DEMON_IMP && BLOOD_PACT && !m_bot.HasAura(BLOOD_PACT) && m_ai.CastPetSpell(BLOOD_PACT) == SPELL_CAST_OK)
         return;
 } // end DoNonCombatActions
 
 // Return to UpdateAI the spellId usable to neutralize a target with creaturetype
 uint32 PlayerbotWarlockAI::Neutralize(uint8 creatureType)
 {
-    if (!m_bot)         return 0;
-    if (!m_ai)          return 0;
     if (!creatureType)  return 0;
 
     // TODO: add a way to handle spell cast by pet like Seduction
     if (creatureType != CREATURE_TYPE_DEMON && creatureType != CREATURE_TYPE_ELEMENTAL)
     {
-        m_ai->TellMaster("I can't banish that target.");
+        m_ai.TellMaster("I can't banish that target.");
         return 0;
     }
 

--- a/src/game/PlayerBot/AI/PlayerbotWarlockAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotWarlockAI.cpp
@@ -590,11 +590,10 @@ void PlayerbotWarlockAI::DoNonCombatActions()
         else
         {
             uint32 soulStoneSpell = soulStone->GetProto()->Spells[0].SpellId;
-            Player* master = GetMaster();
-            if (!master->HasAura(soulStoneSpell) && m_bot.IsSpellReady(soulStoneSpell))
+            if (!m_master.HasAura(soulStoneSpell) && m_bot.IsSpellReady(soulStoneSpell))
             {
                 // TODO: first choice: healer. Second choice: anyone else with revive spell. Third choice: self or master.
-                m_ai.UseItem(soulStone, master);
+                m_ai.UseItem(soulStone, &m_master);
                 return;
             }
         }

--- a/src/game/PlayerBot/AI/PlayerbotWarlockAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotWarlockAI.h
@@ -134,7 +134,7 @@ enum WarlockSpells
 class MANGOS_DLL_SPEC PlayerbotWarlockAI : PlayerbotClassAI
 {
     public:
-        PlayerbotWarlockAI(Player* const master, Player* const bot, PlayerbotAI* const ai);
+        PlayerbotWarlockAI(Player& master, Player& bot, PlayerbotAI& ai);
         virtual ~PlayerbotWarlockAI();
 
         // all combat actions go here

--- a/src/game/PlayerBot/AI/PlayerbotWarlockAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotWarlockAI.h
@@ -138,21 +138,21 @@ class MANGOS_DLL_SPEC PlayerbotWarlockAI : PlayerbotClassAI
         virtual ~PlayerbotWarlockAI();
 
         // all combat actions go here
-        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget);
-        uint32 Neutralize(uint8 creatureType);
+        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget) override;
+        uint32 Neutralize(uint8 creatureType) override;
 
         // all non combat actions go here, ex buffs, heals, rezzes
-        void DoNonCombatActions();
+        void DoNonCombatActions() override;
 
         // buff a specific player, usually a real PC who is not in group
         //void BuffPlayer(Player *target);
 
     private:
-        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget);
+        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget) override;
 
         CombatManeuverReturns CastSpell(uint32 nextAction, Unit* pTarget = nullptr) { return CastSpellWand(nextAction, pTarget, SHOOT); }
 

--- a/src/game/PlayerBot/AI/PlayerbotWarriorAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotWarriorAI.cpp
@@ -20,7 +20,7 @@
 #include "../Base/PlayerbotMgr.h"
 
 class PlayerbotAI;
-PlayerbotWarriorAI::PlayerbotWarriorAI(Player* const master, Player* const bot, PlayerbotAI* const ai) : PlayerbotClassAI(master, bot, ai)
+PlayerbotWarriorAI::PlayerbotWarriorAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
 {
     SHOOT_BOW               = m_ai->initSpell(SHOOT_BOW_1); // GENERAL
     SHOOT_GUN               = m_ai->initSpell(SHOOT_GUN_1); // GENERAL

--- a/src/game/PlayerBot/AI/PlayerbotWarriorAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotWarriorAI.cpp
@@ -20,63 +20,63 @@
 #include "../Base/PlayerbotMgr.h"
 
 class PlayerbotAI;
-PlayerbotWarriorAI::PlayerbotWarriorAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(&master, &bot, &ai)
+PlayerbotWarriorAI::PlayerbotWarriorAI(Player& master, Player& bot, PlayerbotAI& ai) : PlayerbotClassAI(master, bot, ai)
 {
-    SHOOT_BOW               = m_ai->initSpell(SHOOT_BOW_1); // GENERAL
-    SHOOT_GUN               = m_ai->initSpell(SHOOT_GUN_1); // GENERAL
-    SHOOT_XBOW              = m_ai->initSpell(SHOOT_XBOW_1); // GENERAL
+    SHOOT_BOW               = m_ai.initSpell(SHOOT_BOW_1); // GENERAL
+    SHOOT_GUN               = m_ai.initSpell(SHOOT_GUN_1); // GENERAL
+    SHOOT_XBOW              = m_ai.initSpell(SHOOT_XBOW_1); // GENERAL
 
-    BATTLE_STANCE           = m_ai->initSpell(BATTLE_STANCE_1); //ARMS
-    CHARGE                  = m_ai->initSpell(CHARGE_1); //ARMS
-    OVERPOWER               = m_ai->initSpell(OVERPOWER_1); // ARMS
-    HEROIC_STRIKE           = m_ai->initSpell(HEROIC_STRIKE_1); //ARMS
-    REND                    = m_ai->initSpell(REND_1); //ARMS
-    THUNDER_CLAP            = m_ai->initSpell(THUNDER_CLAP_1);  //ARMS
-    HAMSTRING               = m_ai->initSpell(HAMSTRING_1);  //ARMS
-    MOCKING_BLOW            = m_ai->initSpell(MOCKING_BLOW_1);  //ARMS
-    RETALIATION             = m_ai->initSpell(RETALIATION_1);  //ARMS
-    SWEEPING_STRIKES        = m_ai->initSpell(SWEEPING_STRIKES_1); //ARMS
-    MORTAL_STRIKE           = m_ai->initSpell(MORTAL_STRIKE_1);  //ARMS
-    BLOODRAGE               = m_ai->initSpell(BLOODRAGE_1); //PROTECTION
-    DEFENSIVE_STANCE        = m_ai->initSpell(DEFENSIVE_STANCE_1); //PROTECTION
-    SUNDER_ARMOR            = m_ai->initSpell(SUNDER_ARMOR_1); //PROTECTION
-    TAUNT                   = m_ai->initSpell(TAUNT_1); //PROTECTION
-    SHIELD_BASH             = m_ai->initSpell(SHIELD_BASH_1); //PROTECTION
-    REVENGE                 = m_ai->initSpell(REVENGE_1); //PROTECTION
-    SHIELD_BLOCK            = m_ai->initSpell(SHIELD_BLOCK_1); //PROTECTION
-    DISARM                  = m_ai->initSpell(DISARM_1); //PROTECTION
-    SHIELD_WALL             = m_ai->initSpell(SHIELD_WALL_1); //PROTECTION
-    SHIELD_SLAM             = m_ai->initSpell(SHIELD_SLAM_1); //PROTECTION
-    CONCUSSION_BLOW         = m_ai->initSpell(CONCUSSION_BLOW_1); //PROTECTION
-    LAST_STAND              = m_ai->initSpell(LAST_STAND_1); //PROTECTION
-    BATTLE_SHOUT            = m_ai->initSpell(BATTLE_SHOUT_1); //FURY
-    DEMORALIZING_SHOUT      = m_ai->initSpell(DEMORALIZING_SHOUT_1); //FURY
-    CLEAVE                  = m_ai->initSpell(CLEAVE_1); //FURY
-    INTIMIDATING_SHOUT      = m_ai->initSpell(INTIMIDATING_SHOUT_1); //FURY
-    EXECUTE                 = m_ai->initSpell(EXECUTE_1); //FURY
-    CHALLENGING_SHOUT       = m_ai->initSpell(CHALLENGING_SHOUT_1); //FURY
-    SLAM                    = m_ai->initSpell(SLAM_1); //FURY
-    BERSERKER_STANCE        = m_ai->initSpell(BERSERKER_STANCE_1); //FURY
-    INTERCEPT               = m_ai->initSpell(INTERCEPT_1); //FURY
-    DEATH_WISH              = m_ai->initSpell(DEATH_WISH_1); //FURY
-    BERSERKER_RAGE          = m_ai->initSpell(BERSERKER_RAGE_1); //FURY
-    WHIRLWIND               = m_ai->initSpell(WHIRLWIND_1); //FURY
-    PUMMEL                  = m_ai->initSpell(PUMMEL_1); //FURY
-    BLOODTHIRST             = m_ai->initSpell(BLOODTHIRST_1); //FURY
-    RECKLESSNESS            = m_ai->initSpell(RECKLESSNESS_1); //FURY
-    PIERCING_HOWL           = m_ai->initSpell(PIERCING_HOWL_1); //FURY
+    BATTLE_STANCE           = m_ai.initSpell(BATTLE_STANCE_1); //ARMS
+    CHARGE                  = m_ai.initSpell(CHARGE_1); //ARMS
+    OVERPOWER               = m_ai.initSpell(OVERPOWER_1); // ARMS
+    HEROIC_STRIKE           = m_ai.initSpell(HEROIC_STRIKE_1); //ARMS
+    REND                    = m_ai.initSpell(REND_1); //ARMS
+    THUNDER_CLAP            = m_ai.initSpell(THUNDER_CLAP_1);  //ARMS
+    HAMSTRING               = m_ai.initSpell(HAMSTRING_1);  //ARMS
+    MOCKING_BLOW            = m_ai.initSpell(MOCKING_BLOW_1);  //ARMS
+    RETALIATION             = m_ai.initSpell(RETALIATION_1);  //ARMS
+    SWEEPING_STRIKES        = m_ai.initSpell(SWEEPING_STRIKES_1); //ARMS
+    MORTAL_STRIKE           = m_ai.initSpell(MORTAL_STRIKE_1);  //ARMS
+    BLOODRAGE               = m_ai.initSpell(BLOODRAGE_1); //PROTECTION
+    DEFENSIVE_STANCE        = m_ai.initSpell(DEFENSIVE_STANCE_1); //PROTECTION
+    SUNDER_ARMOR            = m_ai.initSpell(SUNDER_ARMOR_1); //PROTECTION
+    TAUNT                   = m_ai.initSpell(TAUNT_1); //PROTECTION
+    SHIELD_BASH             = m_ai.initSpell(SHIELD_BASH_1); //PROTECTION
+    REVENGE                 = m_ai.initSpell(REVENGE_1); //PROTECTION
+    SHIELD_BLOCK            = m_ai.initSpell(SHIELD_BLOCK_1); //PROTECTION
+    DISARM                  = m_ai.initSpell(DISARM_1); //PROTECTION
+    SHIELD_WALL             = m_ai.initSpell(SHIELD_WALL_1); //PROTECTION
+    SHIELD_SLAM             = m_ai.initSpell(SHIELD_SLAM_1); //PROTECTION
+    CONCUSSION_BLOW         = m_ai.initSpell(CONCUSSION_BLOW_1); //PROTECTION
+    LAST_STAND              = m_ai.initSpell(LAST_STAND_1); //PROTECTION
+    BATTLE_SHOUT            = m_ai.initSpell(BATTLE_SHOUT_1); //FURY
+    DEMORALIZING_SHOUT      = m_ai.initSpell(DEMORALIZING_SHOUT_1); //FURY
+    CLEAVE                  = m_ai.initSpell(CLEAVE_1); //FURY
+    INTIMIDATING_SHOUT      = m_ai.initSpell(INTIMIDATING_SHOUT_1); //FURY
+    EXECUTE                 = m_ai.initSpell(EXECUTE_1); //FURY
+    CHALLENGING_SHOUT       = m_ai.initSpell(CHALLENGING_SHOUT_1); //FURY
+    SLAM                    = m_ai.initSpell(SLAM_1); //FURY
+    BERSERKER_STANCE        = m_ai.initSpell(BERSERKER_STANCE_1); //FURY
+    INTERCEPT               = m_ai.initSpell(INTERCEPT_1); //FURY
+    DEATH_WISH              = m_ai.initSpell(DEATH_WISH_1); //FURY
+    BERSERKER_RAGE          = m_ai.initSpell(BERSERKER_RAGE_1); //FURY
+    WHIRLWIND               = m_ai.initSpell(WHIRLWIND_1); //FURY
+    PUMMEL                  = m_ai.initSpell(PUMMEL_1); //FURY
+    BLOODTHIRST             = m_ai.initSpell(BLOODTHIRST_1); //FURY
+    RECKLESSNESS            = m_ai.initSpell(RECKLESSNESS_1); //FURY
+    PIERCING_HOWL           = m_ai.initSpell(PIERCING_HOWL_1); //FURY
 
     RECENTLY_BANDAGED       = 11196; // first aid check
 
     // racial
-    STONEFORM               = m_ai->initSpell(STONEFORM_ALL); // dwarf
-    ESCAPE_ARTIST           = m_ai->initSpell(ESCAPE_ARTIST_ALL); // gnome
-    PERCEPTION              = m_ai->initSpell(PERCEPTION_ALL); // human
-    SHADOWMELD              = m_ai->initSpell(SHADOWMELD_ALL); // night elf
-    BLOOD_FURY              = m_ai->initSpell(BLOOD_FURY_ALL); // orc
-    WAR_STOMP               = m_ai->initSpell(WAR_STOMP_ALL); // tauren
-    BERSERKING              = m_ai->initSpell(BERSERKING_ALL); // troll
-    WILL_OF_THE_FORSAKEN    = m_ai->initSpell(WILL_OF_THE_FORSAKEN_ALL); // undead
+    STONEFORM               = m_ai.initSpell(STONEFORM_ALL); // dwarf
+    ESCAPE_ARTIST           = m_ai.initSpell(ESCAPE_ARTIST_ALL); // gnome
+    PERCEPTION              = m_ai.initSpell(PERCEPTION_ALL); // human
+    SHADOWMELD              = m_ai.initSpell(SHADOWMELD_ALL); // night elf
+    BLOOD_FURY              = m_ai.initSpell(BLOOD_FURY_ALL); // orc
+    WAR_STOMP               = m_ai.initSpell(WAR_STOMP_ALL); // tauren
+    BERSERKING              = m_ai.initSpell(BERSERKING_ALL); // troll
+    WILL_OF_THE_FORSAKEN    = m_ai.initSpell(WILL_OF_THE_FORSAKEN_ALL); // undead
 
     //Procs
 }
@@ -86,20 +86,20 @@ CombatManeuverReturns PlayerbotWarriorAI::DoFirstCombatManeuver(Unit* pTarget)
 {
     // There are NPCs in BGs and Open World PvP, so don't filter this on PvP scenarios (of course if PvP targets anyone but tank, all bets are off anyway)
     // Wait until the tank says so, until any non-tank gains aggro or X seconds - whichever is shortest
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->GroupTankHoldsAggro())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.GroupTankHoldsAggro())
         {
-            if (PlayerbotAI::ORDERS_TANK & m_ai->GetCombatOrder())
+            if (PlayerbotAI::ORDERS_TANK & m_ai.GetCombatOrder())
             {
-                if (m_bot->GetDistance(pTarget, true, DIST_CALC_COMBAT_REACH_WITH_MELEE) <= ATTACK_DISTANCE)
+                if (m_bot.GetDistance(pTarget, true, DIST_CALC_COMBAT_REACH_WITH_MELEE) <= ATTACK_DISTANCE)
                 {
                     // Set everyone's UpdateAI() waiting to 2 seconds
-                    m_ai->SetGroupIgnoreUpdateTime(2);
+                    m_ai.SetGroupIgnoreUpdateTime(2);
                     // Clear their TEMP_WAIT_TANKAGGRO flag
-                    m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
+                    m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
                     // Start attacking, force target on current target
-                    m_ai->Attack(m_ai->GetCurrentTarget());
+                    m_ai.Attack(m_ai.GetCurrentTarget());
 
                     // While everyone else is waiting 2 second, we need to build up aggro, so don't return
                 }
@@ -114,19 +114,19 @@ CombatManeuverReturns PlayerbotWarriorAI::DoFirstCombatManeuver(Unit* pTarget)
         }
         else
         {
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_TANKAGGRO);
         }
     }
 
-    if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
+    if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TEMP_WAIT_OOC)
     {
-        if (m_WaitUntil > m_ai->CurrentTime() && m_ai->IsGroupReady())
+        if (m_WaitUntil > m_ai.CurrentTime() && m_ai.IsGroupReady())
             return RETURN_NO_ACTION_OK; // wait it out
         else
-            m_ai->ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
+            m_ai.ClearGroupCombatOrder(PlayerbotAI::ORDERS_TEMP_WAIT_OOC);
     }
 
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -143,59 +143,56 @@ CombatManeuverReturns PlayerbotWarriorAI::DoFirstCombatManeuver(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotWarriorAI::DoFirstCombatManeuverPVE(Unit* pTarget)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
-    float fTargetDist = m_bot->GetDistance(pTarget, true, DIST_CALC_COMBAT_REACH_WITH_MELEE);
+    float fTargetDist = m_bot.GetDistance(pTarget, true, DIST_CALC_COMBAT_REACH_WITH_MELEE);
 
     // Get bot spec. If bot has tank orders, force spec to protection
-    uint32 spec = ((m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TANK) ? WARRIOR_SPEC_PROTECTION : m_bot->GetSpec());
+    uint32 spec = ((m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TANK) ? WARRIOR_SPEC_PROTECTION : m_bot.GetSpec());
 
-    if (BERSERKER_STANCE && spec == WARRIOR_SPEC_FURY && (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_ASSIST))
+    if (BERSERKER_STANCE && spec == WARRIOR_SPEC_FURY && (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_ASSIST))
     {
-        if (!m_bot->HasAura(BERSERKER_STANCE, EFFECT_INDEX_0) && m_ai->CastSpell(BERSERKER_STANCE) == SPELL_CAST_OK)
+        if (!m_bot.HasAura(BERSERKER_STANCE, EFFECT_INDEX_0) && m_ai.CastSpell(BERSERKER_STANCE) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (BLOODRAGE > 0 && m_bot->HasAura(BERSERKER_STANCE, EFFECT_INDEX_0) && m_ai->GetRageAmount() <= 10)
-            return m_ai->CastSpell(BLOODRAGE) == SPELL_CAST_OK ? RETURN_FINISHED_FIRST_MOVES : RETURN_NO_ACTION_ERROR;
-        if (INTERCEPT > 0 && m_bot->HasAura(BERSERKER_STANCE, EFFECT_INDEX_0))
+        if (BLOODRAGE > 0 && m_bot.HasAura(BERSERKER_STANCE, EFFECT_INDEX_0) && m_ai.GetRageAmount() <= 10)
+            return m_ai.CastSpell(BLOODRAGE) == SPELL_CAST_OK ? RETURN_FINISHED_FIRST_MOVES : RETURN_NO_ACTION_ERROR;
+        if (INTERCEPT > 0 && m_bot.HasAura(BERSERKER_STANCE, EFFECT_INDEX_0))
         {
             if (fTargetDist < 8.0f)
                 return RETURN_NO_ACTION_OK;
             else if (fTargetDist > 25.0f)
                 return RETURN_CONTINUE; // wait to come into range
-            else if (INTERCEPT > 0 && m_ai->CastSpell(INTERCEPT, *pTarget) == SPELL_CAST_OK)
+            else if (INTERCEPT > 0 && m_ai.CastSpell(INTERCEPT, *pTarget) == SPELL_CAST_OK)
             {
                 float x, y, z;
-                pTarget->GetContactPoint(m_bot, x, y, z, 3.666666f);
-                m_bot->Relocate(x, y, z);
+                pTarget->GetContactPoint(&m_bot, x, y, z, 3.666666f);
+                m_bot.Relocate(x, y, z);
                 return RETURN_FINISHED_FIRST_MOVES;
             }
         }
     }
-    else if (BATTLE_STANCE && (spec == WARRIOR_SPEC_ARMS || (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_ASSIST)))
+    else if (BATTLE_STANCE && (spec == WARRIOR_SPEC_ARMS || (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_ASSIST)))
     {
-        if (!m_bot->HasAura(BATTLE_STANCE, EFFECT_INDEX_0) && m_ai->CastSpell(BATTLE_STANCE) == SPELL_CAST_OK)
+        if (!m_bot.HasAura(BATTLE_STANCE, EFFECT_INDEX_0) && m_ai.CastSpell(BATTLE_STANCE) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (CHARGE > 0 && m_bot->HasAura(BATTLE_STANCE, EFFECT_INDEX_0))
+        if (CHARGE > 0 && m_bot.HasAura(BATTLE_STANCE, EFFECT_INDEX_0))
         {
             if (fTargetDist < 8.0f)
                 return RETURN_NO_ACTION_OK;
             if (fTargetDist > 25.0f)
                 return RETURN_CONTINUE; // wait to come into range
-            else if (CHARGE > 0 && m_ai->CastSpell(CHARGE, *pTarget) == SPELL_CAST_OK)
+            else if (CHARGE > 0 && m_ai.CastSpell(CHARGE, *pTarget) == SPELL_CAST_OK)
             {
                 float x, y, z;
-                pTarget->GetContactPoint(m_bot, x, y, z, 3.666666f);
-                m_bot->Relocate(x, y, z);
+                pTarget->GetContactPoint(&m_bot, x, y, z, 3.666666f);
+                m_bot.Relocate(x, y, z);
                 return RETURN_FINISHED_FIRST_MOVES;
             }
         }
     }
     else if (DEFENSIVE_STANCE && spec == WARRIOR_SPEC_PROTECTION)
     {
-        if (!m_bot->HasAura(DEFENSIVE_STANCE, EFFECT_INDEX_0) && m_ai->CastSpell(DEFENSIVE_STANCE) == SPELL_CAST_OK)
+        if (!m_bot.HasAura(DEFENSIVE_STANCE, EFFECT_INDEX_0) && m_ai.CastSpell(DEFENSIVE_STANCE) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        else if (TAUNT > 0 && m_bot->HasAura(DEFENSIVE_STANCE, EFFECT_INDEX_0) && m_ai->CastSpell(TAUNT, *pTarget) == SPELL_CAST_OK)
+        else if (TAUNT > 0 && m_bot.HasAura(DEFENSIVE_STANCE, EFFECT_INDEX_0) && m_ai.CastSpell(TAUNT, *pTarget) == SPELL_CAST_OK)
             return RETURN_FINISHED_FIRST_MOVES;
     }
 
@@ -205,36 +202,33 @@ CombatManeuverReturns PlayerbotWarriorAI::DoFirstCombatManeuverPVE(Unit* pTarget
 // TODO: blatant copy of PVE for now, please PVP-port it
 CombatManeuverReturns PlayerbotWarriorAI::DoFirstCombatManeuverPVP(Unit* pTarget)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
+    float fTargetDist = m_bot.GetDistance(pTarget, true, DIST_CALC_COMBAT_REACH_WITH_MELEE);
 
-    float fTargetDist = m_bot->GetDistance(pTarget, true, DIST_CALC_COMBAT_REACH_WITH_MELEE);
-
-    if (DEFENSIVE_STANCE && (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TANK))
+    if (DEFENSIVE_STANCE && (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TANK))
     {
-        if (!m_bot->HasAura(DEFENSIVE_STANCE, EFFECT_INDEX_0) && m_ai->CastSpell(DEFENSIVE_STANCE) == SPELL_CAST_OK)
+        if (!m_bot.HasAura(DEFENSIVE_STANCE, EFFECT_INDEX_0) && m_ai.CastSpell(DEFENSIVE_STANCE) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        else if (TAUNT > 0 && m_bot->HasAura(DEFENSIVE_STANCE, EFFECT_INDEX_0) && m_ai->CastSpell(TAUNT, *pTarget) == SPELL_CAST_OK)
+        else if (TAUNT > 0 && m_bot.HasAura(DEFENSIVE_STANCE, EFFECT_INDEX_0) && m_ai.CastSpell(TAUNT, *pTarget) == SPELL_CAST_OK)
             return RETURN_FINISHED_FIRST_MOVES;
     }
 
     if (BERSERKER_STANCE)
     {
-        if (!m_bot->HasAura(BERSERKER_STANCE, EFFECT_INDEX_0) && m_ai->CastSpell(BERSERKER_STANCE) == SPELL_CAST_OK)
+        if (!m_bot.HasAura(BERSERKER_STANCE, EFFECT_INDEX_0) && m_ai.CastSpell(BERSERKER_STANCE) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (BLOODRAGE > 0 && m_bot->HasAura(BERSERKER_STANCE, EFFECT_INDEX_0) && m_ai->GetRageAmount() <= 10)
-            return m_ai->CastSpell(BLOODRAGE) == SPELL_CAST_OK ? RETURN_FINISHED_FIRST_MOVES : RETURN_NO_ACTION_ERROR;
-        if (INTERCEPT > 0 && m_bot->HasAura(BERSERKER_STANCE, EFFECT_INDEX_0))
+        if (BLOODRAGE > 0 && m_bot.HasAura(BERSERKER_STANCE, EFFECT_INDEX_0) && m_ai.GetRageAmount() <= 10)
+            return m_ai.CastSpell(BLOODRAGE) == SPELL_CAST_OK ? RETURN_FINISHED_FIRST_MOVES : RETURN_NO_ACTION_ERROR;
+        if (INTERCEPT > 0 && m_bot.HasAura(BERSERKER_STANCE, EFFECT_INDEX_0))
         {
             if (fTargetDist < 8.0f)
                 return RETURN_NO_ACTION_OK;
             else if (fTargetDist > 25.0f)
                 return RETURN_CONTINUE; // wait to come into range
-            else if (INTERCEPT > 0 && m_ai->CastSpell(INTERCEPT, *pTarget) == SPELL_CAST_OK)
+            else if (INTERCEPT > 0 && m_ai.CastSpell(INTERCEPT, *pTarget) == SPELL_CAST_OK)
             {
                 float x, y, z;
-                pTarget->GetContactPoint(m_bot, x, y, z, 3.666666f);
-                m_bot->Relocate(x, y, z);
+                pTarget->GetContactPoint(&m_bot, x, y, z, 3.666666f);
+                m_bot.Relocate(x, y, z);
                 return RETURN_FINISHED_FIRST_MOVES;
             }
         }
@@ -242,19 +236,19 @@ CombatManeuverReturns PlayerbotWarriorAI::DoFirstCombatManeuverPVP(Unit* pTarget
 
     if (BATTLE_STANCE)
     {
-        if (!m_bot->HasAura(BATTLE_STANCE, EFFECT_INDEX_0) && m_ai->CastSpell(BATTLE_STANCE) == SPELL_CAST_OK)
+        if (!m_bot.HasAura(BATTLE_STANCE, EFFECT_INDEX_0) && m_ai.CastSpell(BATTLE_STANCE) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (CHARGE > 0 && m_bot->HasAura(BATTLE_STANCE, EFFECT_INDEX_0))
+        if (CHARGE > 0 && m_bot.HasAura(BATTLE_STANCE, EFFECT_INDEX_0))
         {
             if (fTargetDist < 8.0f)
                 return RETURN_NO_ACTION_OK;
             if (fTargetDist > 25.0f)
                 return RETURN_CONTINUE; // wait to come into range
-            else if (CHARGE > 0 && m_ai->CastSpell(CHARGE, *pTarget) == SPELL_CAST_OK)
+            else if (CHARGE > 0 && m_ai.CastSpell(CHARGE, *pTarget) == SPELL_CAST_OK)
             {
                 float x, y, z;
-                pTarget->GetContactPoint(m_bot, x, y, z, 3.666666f);
-                m_bot->Relocate(x, y, z);
+                pTarget->GetContactPoint(&m_bot, x, y, z, 3.666666f);
+                m_bot.Relocate(x, y, z);
                 return RETURN_FINISHED_FIRST_MOVES;
             }
         }
@@ -266,9 +260,9 @@ CombatManeuverReturns PlayerbotWarriorAI::DoFirstCombatManeuverPVP(Unit* pTarget
 CombatManeuverReturns PlayerbotWarriorAI::DoNextCombatManeuver(Unit* pTarget)
 {
     // Face enemy, make sure bot is attacking
-    m_ai->FaceTarget(pTarget);
+    m_ai.FaceTarget(pTarget);
 
-    switch (m_ai->GetScenarioType())
+    switch (m_ai.GetScenarioType())
     {
         case PlayerbotAI::SCENARIO_PVP_DUEL:
         case PlayerbotAI::SCENARIO_PVP_BG:
@@ -285,87 +279,84 @@ CombatManeuverReturns PlayerbotWarriorAI::DoNextCombatManeuver(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotWarriorAI::DoNextCombatManeuverPVE(Unit* pTarget)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
-    //float fTargetDist = m_bot->GetCombatDistance(pTarget, true);
+    //float fTargetDist = m_bot.GetCombatDistance(pTarget, true);
 
     //Used to determine if this bot is highest on threat
-    Unit* newTarget = m_ai->FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), m_bot);
+    Unit* newTarget = m_ai.FindAttacker((PlayerbotAI::ATTACKERINFOTYPE)(PlayerbotAI::AIT_VICTIMSELF | PlayerbotAI::AIT_HIGHESTTHREAT), &m_bot);
     Unit* pVictim = pTarget->GetVictim();
 
     // do shouts, berserker rage, etc...
-    if (BERSERKER_RAGE > 0 && !m_bot->HasAura(BERSERKER_RAGE, EFFECT_INDEX_0))
-        m_ai->CastSpell(BERSERKER_RAGE);
-    else if (BLOODRAGE > 0 && m_ai->GetRageAmount() <= 10)
-        m_ai->CastSpell(BLOODRAGE);
+    if (BERSERKER_RAGE > 0 && !m_bot.HasAura(BERSERKER_RAGE, EFFECT_INDEX_0))
+        m_ai.CastSpell(BERSERKER_RAGE);
+    else if (BLOODRAGE > 0 && m_ai.GetRageAmount() <= 10)
+        m_ai.CastSpell(BLOODRAGE);
 
     // Prevent low health humanoid from fleeing with Hamstring
-    if ((m_bot->HasAura(BATTLE_STANCE, EFFECT_INDEX_0) || m_bot->HasAura(BERSERKER_STANCE, EFFECT_INDEX_0)) && pTarget->GetHealthPercent() < 20 && !m_ai->IsElite(pTarget, true))
+    if ((m_bot.HasAura(BATTLE_STANCE, EFFECT_INDEX_0) || m_bot.HasAura(BERSERKER_STANCE, EFFECT_INDEX_0)) && pTarget->GetHealthPercent() < 20 && !m_ai.IsElite(pTarget, true))
     {
-        if (HAMSTRING > 0 && !pTarget->HasAura(HAMSTRING, EFFECT_INDEX_0) && m_ai->CastSpell(HAMSTRING, *pTarget) == SPELL_CAST_OK)
+        if (HAMSTRING > 0 && !pTarget->HasAura(HAMSTRING, EFFECT_INDEX_0) && m_ai.CastSpell(HAMSTRING, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
     }
 
     CheckShouts();
 
     // Get bot spec. If bot has tank orders, force spec to protection
-    uint32 spec = ((m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TANK) ? WARRIOR_SPEC_PROTECTION : m_bot->GetSpec());
+    uint32 spec = ((m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TANK) ? WARRIOR_SPEC_PROTECTION : m_bot.GetSpec());
 
-    if (spec == WARRIOR_SPEC_FURY && (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_ASSIST))
+    if (spec == WARRIOR_SPEC_FURY && (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_ASSIST))
     {
         // Try to interrupt spell if target is casting one
         if (pTarget->IsNonMeleeSpellCasted(true))
         {
-            if (PUMMEL > 0 && m_bot->IsSpellReady(PUMMEL) && m_ai->CastSpell(PUMMEL, *pTarget) == SPELL_CAST_OK)
+            if (PUMMEL > 0 && m_bot.IsSpellReady(PUMMEL) && m_ai.CastSpell(PUMMEL, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
         }
 
-        if (DEATH_WISH > 0 && !m_bot->HasAura(DEATH_WISH, EFFECT_INDEX_0) && m_bot->IsSpellReady(DEATH_WISH) && m_ai->CastSpell(DEATH_WISH, *m_bot) == SPELL_CAST_OK)
+        if (DEATH_WISH > 0 && !m_bot.HasAura(DEATH_WISH, EFFECT_INDEX_0) && m_bot.IsSpellReady(DEATH_WISH) && m_ai.CastSpell(DEATH_WISH, m_bot) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (EXECUTE > 0 && pTarget->GetHealthPercent() < 20 && m_ai->CastSpell(EXECUTE, *pTarget) == SPELL_CAST_OK)
+        if (EXECUTE > 0 && pTarget->GetHealthPercent() < 20 && m_ai.CastSpell(EXECUTE, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (BLOODTHIRST > 0 && m_bot->IsSpellReady(BLOODTHIRST) && m_ai->CastSpell(BLOODTHIRST, *pTarget) == SPELL_CAST_OK)
+        if (BLOODTHIRST > 0 && m_bot.IsSpellReady(BLOODTHIRST) && m_ai.CastSpell(BLOODTHIRST, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (WHIRLWIND > 0 && m_bot->IsSpellReady(WHIRLWIND) && m_ai->CastSpell(WHIRLWIND, *pTarget) == SPELL_CAST_OK)
+        if (WHIRLWIND > 0 && m_bot.IsSpellReady(WHIRLWIND) && m_ai.CastSpell(WHIRLWIND, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (HEROIC_STRIKE > 0 && m_ai->CastSpell(HEROIC_STRIKE, *pTarget) == SPELL_CAST_OK)
+        if (HEROIC_STRIKE > 0 && m_ai.CastSpell(HEROIC_STRIKE, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
     }
-    else if (spec == WARRIOR_SPEC_ARMS || (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_ASSIST))
+    else if (spec == WARRIOR_SPEC_ARMS || (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_ASSIST))
     {
         // Try to interrupt spell if target is casting one
         if (pTarget->IsNonMeleeSpellCasted(true))
         {
-            if (SHIELD_BASH > 0 && m_ai->CastSpell(SHIELD_BASH, *pTarget) == SPELL_CAST_OK)
+            if (SHIELD_BASH > 0 && m_ai.CastSpell(SHIELD_BASH, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
         }
 
         // If bot's target is also attacking the bot, use retaliation for extra attacks
-        if (RETALIATION > 0 && pVictim == m_bot && m_ai->GetAttackerCount() >= 2 && m_bot->IsSpellReady(RETALIATION) && !m_bot->HasAura(RETALIATION, EFFECT_INDEX_0) && m_ai->CastSpell(RETALIATION, *m_bot) == SPELL_CAST_OK)
+        if (RETALIATION > 0 && pVictim == &m_bot && m_ai.GetAttackerCount() >= 2 && m_bot.IsSpellReady(RETALIATION) && !m_bot.HasAura(RETALIATION, EFFECT_INDEX_0) && m_ai.CastSpell(RETALIATION, m_bot) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
 
-        if (EXECUTE > 0 && pTarget->GetHealthPercent() < 20 && m_ai->CastSpell(EXECUTE, *pTarget) == SPELL_CAST_OK)
+        if (EXECUTE > 0 && pTarget->GetHealthPercent() < 20 && m_ai.CastSpell(EXECUTE, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (REND > 0 && !pTarget->HasAura(REND, EFFECT_INDEX_0) && m_ai->CastSpell(REND, *pTarget) == SPELL_CAST_OK)
+        if (REND > 0 && !pTarget->HasAura(REND, EFFECT_INDEX_0) && m_ai.CastSpell(REND, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (MORTAL_STRIKE > 0 && m_bot->IsSpellReady(MORTAL_STRIKE) && m_ai->CastSpell(MORTAL_STRIKE, *pTarget) == SPELL_CAST_OK)
+        if (MORTAL_STRIKE > 0 && m_bot.IsSpellReady(MORTAL_STRIKE) && m_ai.CastSpell(MORTAL_STRIKE, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (OVERPOWER > 0 && m_bot->IsSpellReady(OVERPOWER))
+        if (OVERPOWER > 0 && m_bot.IsSpellReady(OVERPOWER))
         {
-            uint8 base = pTarget->RollMeleeOutcomeAgainst(m_bot, BASE_ATTACK, SPELL_SCHOOL_MASK_NORMAL);
-            uint8 off = pTarget->RollMeleeOutcomeAgainst(m_bot, OFF_ATTACK, SPELL_SCHOOL_MASK_NORMAL);
+            uint8 base = pTarget->RollMeleeOutcomeAgainst(&m_bot, BASE_ATTACK, SPELL_SCHOOL_MASK_NORMAL);
+            uint8 off = pTarget->RollMeleeOutcomeAgainst(&m_bot, OFF_ATTACK, SPELL_SCHOOL_MASK_NORMAL);
             if (base == MELEE_HIT_DODGE || off == MELEE_HIT_DODGE)
             {
-                if (m_bot->IsSpellReady(OVERPOWER) && m_ai->CastSpell(OVERPOWER, *pTarget) == SPELL_CAST_OK)
+                if (m_bot.IsSpellReady(OVERPOWER) && m_ai.CastSpell(OVERPOWER, *pTarget) == SPELL_CAST_OK)
                     return RETURN_CONTINUE;
             }
         }
-        if (THUNDER_CLAP > 0 && !pTarget->HasAura(THUNDER_CLAP) && m_ai->CastSpell(THUNDER_CLAP, *pTarget) == SPELL_CAST_OK)
+        if (THUNDER_CLAP > 0 && !pTarget->HasAura(THUNDER_CLAP) && m_ai.CastSpell(THUNDER_CLAP, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (HEROIC_STRIKE > 0 && m_ai->CastSpell(HEROIC_STRIKE, *pTarget) == SPELL_CAST_OK)
+        if (HEROIC_STRIKE > 0 && m_ai.CastSpell(HEROIC_STRIKE, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (SLAM > 0 && m_ai->CastSpell(SLAM, *pTarget) == SPELL_CAST_OK)
+        if (SLAM > 0 && m_ai.CastSpell(SLAM, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
     }
     else if (spec == WARRIOR_SPEC_PROTECTION)
@@ -374,101 +365,101 @@ CombatManeuverReturns PlayerbotWarriorAI::DoNextCombatManeuverPVE(Unit* pTarget)
         if (!newTarget)
         {
             // Cast taunt on bot current target if the mob is targeting someone else
-            if (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_TANK && TAUNT > 0 && m_bot->IsSpellReady(TAUNT) && m_ai->CastSpell(TAUNT, *pTarget) == SPELL_CAST_OK)
+            if (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_TANK && TAUNT > 0 && m_bot.IsSpellReady(TAUNT) && m_ai.CastSpell(TAUNT, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
         }
 
         // If tank is on the verge of dying but "I DON'T WANT TO DIE !!! :'-(("
         // TODO: should behaviour (or treshold) be different between elite and normal mobs? We don't want bots to burn such precious cooldown needlessly
-        if (m_bot->GetHealthPercent() < 10)
+        if (m_bot.GetHealthPercent() < 10)
         {
             // Cast Last Stand first because it has lower cooldown
-            if (LAST_STAND > 0 && !m_bot->HasAura(LAST_STAND, EFFECT_INDEX_0) && m_ai->CastSpell(LAST_STAND, *m_bot) == SPELL_CAST_OK)
+            if (LAST_STAND > 0 && !m_bot.HasAura(LAST_STAND, EFFECT_INDEX_0) && m_ai.CastSpell(LAST_STAND, m_bot) == SPELL_CAST_OK)
             {
-                m_ai->TellMaster("I'm using LAST STAND");
+                m_ai.TellMaster("I'm using LAST STAND");
                 return RETURN_CONTINUE;
             }
             // Cast Shield Wall only if Last Stand is on cooldown and not active
-            if (SHIELD_WALL > 0 && (!m_bot->IsSpellReady(LAST_STAND) || LAST_STAND == 0) && !m_bot->HasAura(LAST_STAND, EFFECT_INDEX_0) && !m_bot->HasAura(SHIELD_WALL, EFFECT_INDEX_0) && m_ai->CastSpell(SHIELD_WALL, *m_bot) == SPELL_CAST_OK)
+            if (SHIELD_WALL > 0 && (!m_bot.IsSpellReady(LAST_STAND) || LAST_STAND == 0) && !m_bot.HasAura(LAST_STAND, EFFECT_INDEX_0) && !m_bot.HasAura(SHIELD_WALL, EFFECT_INDEX_0) && m_ai.CastSpell(SHIELD_WALL, m_bot) == SPELL_CAST_OK)
             {
-                m_ai->TellMaster("I'm using SHIELD WALL");
+                m_ai.TellMaster("I'm using SHIELD WALL");
                 return RETURN_CONTINUE;
             }
         }
 
         // Try to interrupt spell if target is casting one and target is not a worldboss (they are almost all immune to interrupt)
-        if (pTarget->IsNonMeleeSpellCasted(true) && !m_ai->IsElite(pTarget, true))
+        if (pTarget->IsNonMeleeSpellCasted(true) && !m_ai.IsElite(pTarget, true))
         {
-            if (SHIELD_BASH > 0 && m_ai->CastSpell(SHIELD_BASH, *pTarget) == SPELL_CAST_OK)
+            if (SHIELD_BASH > 0 && m_ai.CastSpell(SHIELD_BASH, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
         }
 
         //Do not waste rage applying Sunder Armor if it is already stacked 5 times
         if (SUNDER_ARMOR > 0)
         {
-            if (!pTarget->HasAura(SUNDER_ARMOR) && m_ai->CastSpell(SUNDER_ARMOR, *pTarget) == SPELL_CAST_OK)   // no stacks: cast it
+            if (!pTarget->HasAura(SUNDER_ARMOR) && m_ai.CastSpell(SUNDER_ARMOR, *pTarget) == SPELL_CAST_OK)   // no stacks: cast it
                 return RETURN_CONTINUE;
             else
             {
                 SpellAuraHolder* holder = pTarget->GetSpellAuraHolder(SUNDER_ARMOR);
-                if (holder && (holder->GetStackAmount() < 5) && m_ai->CastSpell(SUNDER_ARMOR, *pTarget) == SPELL_CAST_OK)
+                if (holder && (holder->GetStackAmount() < 5) && m_ai.CastSpell(SUNDER_ARMOR, *pTarget) == SPELL_CAST_OK)
                     return RETURN_CONTINUE;
             }
         }
 
-        if (REVENGE > 0 && m_bot->IsSpellReady(REVENGE))
+        if (REVENGE > 0 && m_bot.IsSpellReady(REVENGE))
         {
-            uint8 base = pTarget->RollMeleeOutcomeAgainst(m_bot, BASE_ATTACK, SPELL_SCHOOL_MASK_NORMAL);
-            uint8 off = pTarget->RollMeleeOutcomeAgainst(m_bot, OFF_ATTACK, SPELL_SCHOOL_MASK_NORMAL);
+            uint8 base = pTarget->RollMeleeOutcomeAgainst(&m_bot, BASE_ATTACK, SPELL_SCHOOL_MASK_NORMAL);
+            uint8 off = pTarget->RollMeleeOutcomeAgainst(&m_bot, OFF_ATTACK, SPELL_SCHOOL_MASK_NORMAL);
             if (base == MELEE_HIT_PARRY || base == MELEE_HIT_DODGE || base == MELEE_HIT_BLOCK || off == MELEE_HIT_PARRY || off == MELEE_HIT_DODGE || off == MELEE_HIT_BLOCK)
-                if (m_ai->CastSpell(REVENGE, *pTarget) == SPELL_CAST_OK)
+                if (m_ai.CastSpell(REVENGE, *pTarget) == SPELL_CAST_OK)
                     return RETURN_CONTINUE;
         }
-        if (REND > 0 && !pTarget->HasAura(REND, EFFECT_INDEX_0) && m_ai->CastSpell(REND, *pTarget) == SPELL_CAST_OK)
+        if (REND > 0 && !pTarget->HasAura(REND, EFFECT_INDEX_0) && m_ai.CastSpell(REND, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
 
-        if (DEMORALIZING_SHOUT > 0 && !pTarget->HasAura(DEMORALIZING_SHOUT, EFFECT_INDEX_0) && m_ai->CastSpell(DEMORALIZING_SHOUT, *pTarget) == SPELL_CAST_OK)
+        if (DEMORALIZING_SHOUT > 0 && !pTarget->HasAura(DEMORALIZING_SHOUT, EFFECT_INDEX_0) && m_ai.CastSpell(DEMORALIZING_SHOUT, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
         // check that target is dangerous (elite) before casting shield block: preserve bot cooldowns
-        if (SHIELD_BLOCK > 0 && m_ai->IsElite(pTarget) && !m_bot->HasAura(SHIELD_BLOCK, EFFECT_INDEX_0) && m_ai->CastSpell(SHIELD_BLOCK, *m_bot) == SPELL_CAST_OK)
+        if (SHIELD_BLOCK > 0 && m_ai.IsElite(pTarget) && !m_bot.HasAura(SHIELD_BLOCK, EFFECT_INDEX_0) && m_ai.CastSpell(SHIELD_BLOCK, m_bot) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
         // TODO: only cast disarm if target has equipment?
-        if (DISARM > 0 && !pTarget->HasAura(DISARM, EFFECT_INDEX_0) && m_ai->CastSpell(DISARM, *pTarget) == SPELL_CAST_OK)
+        if (DISARM > 0 && !pTarget->HasAura(DISARM, EFFECT_INDEX_0) && m_ai.CastSpell(DISARM, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (CONCUSSION_BLOW > 0 && m_bot->IsSpellReady(CONCUSSION_BLOW) && m_ai->CastSpell(CONCUSSION_BLOW, *pTarget) == SPELL_CAST_OK)
+        if (CONCUSSION_BLOW > 0 && m_bot.IsSpellReady(CONCUSSION_BLOW) && m_ai.CastSpell(CONCUSSION_BLOW, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (SHIELD_SLAM > 0 && m_bot->IsSpellReady(SHIELD_SLAM) && m_ai->CastSpell(SHIELD_SLAM, *pTarget) == SPELL_CAST_OK)
+        if (SHIELD_SLAM > 0 && m_bot.IsSpellReady(SHIELD_SLAM) && m_ai.CastSpell(SHIELD_SLAM, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
-        if (HEROIC_STRIKE > 0 && m_ai->CastSpell(HEROIC_STRIKE, *pTarget) == SPELL_CAST_OK)
+        if (HEROIC_STRIKE > 0 && m_ai.CastSpell(HEROIC_STRIKE, *pTarget) == SPELL_CAST_OK)
             return RETURN_CONTINUE;
     }
 
     /*    case WarriorBattle:
-            if (SWEEPING_STRIKES > 0 && m_ai->GetAttackerCount() >= 2 && !m_bot->HasAura(SWEEPING_STRIKES, EFFECT_INDEX_0) && m_ai->CastSpell(SWEEPING_STRIKES, *m_bot) == SPELL_CAST_OK)
+            if (SWEEPING_STRIKES > 0 && m_ai.GetAttackerCount() >= 2 && !m_bot.HasAura(SWEEPING_STRIKES, EFFECT_INDEX_0) && m_ai.CastSpell(SWEEPING_STRIKES, m_bot) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (INTIMIDATING_SHOUT > 0 && m_ai->GetAttackerCount() > 5 && m_ai->CastSpell(INTIMIDATING_SHOUT, *pTarget) == SPELL_CAST_OK)
+            if (INTIMIDATING_SHOUT > 0 && m_ai.GetAttackerCount() > 5 && m_ai.CastSpell(INTIMIDATING_SHOUT, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (CHALLENGING_SHOUT > 0 && pVictim != m_bot && m_ai->GetHealthPercent() > 25 && !pTarget->HasAura(MOCKING_BLOW, EFFECT_INDEX_0) && !pTarget->HasAura(CHALLENGING_SHOUT, EFFECT_INDEX_0) && m_ai->CastSpell(CHALLENGING_SHOUT, *pTarget) == SPELL_CAST_OK)
+            if (CHALLENGING_SHOUT > 0 && pVictim != m_bot && m_ai.GetHealthPercent() > 25 && !pTarget->HasAura(MOCKING_BLOW, EFFECT_INDEX_0) && !pTarget->HasAura(CHALLENGING_SHOUT, EFFECT_INDEX_0) && m_ai.CastSpell(CHALLENGING_SHOUT, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (CLEAVE > 0 && m_ai->CastSpell(CLEAVE, *pTarget) == SPELL_CAST_OK)
+            if (CLEAVE > 0 && m_ai.CastSpell(CLEAVE, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (PIERCING_HOWL > 0 && && m_ai->GetAttackerCount() >= 3 && !pTarget->HasAura(WAR_STOMP, EFFECT_INDEX_0) && !pTarget->HasAura(PIERCING_HOWL, EFFECT_INDEX_0) && !pTarget->HasAura(SHOCKWAVE, EFFECT_INDEX_0) && !pTarget->HasAura(CONCUSSION_BLOW, EFFECT_INDEX_0) && m_ai->CastSpell(PIERCING_HOWL, *pTarget) == SPELL_CAST_OK)
+            if (PIERCING_HOWL > 0 && && m_ai.GetAttackerCount() >= 3 && !pTarget->HasAura(WAR_STOMP, EFFECT_INDEX_0) && !pTarget->HasAura(PIERCING_HOWL, EFFECT_INDEX_0) && !pTarget->HasAura(SHOCKWAVE, EFFECT_INDEX_0) && !pTarget->HasAura(CONCUSSION_BLOW, EFFECT_INDEX_0) && m_ai.CastSpell(PIERCING_HOWL, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (MOCKING_BLOW > 0 && pVictim != m_bot && m_ai->GetHealthPercent() > 25 && !pTarget->HasAura(MOCKING_BLOW, EFFECT_INDEX_0) && !pTarget->HasAura(CHALLENGING_SHOUT, EFFECT_INDEX_0) && m_ai->CastSpell(MOCKING_BLOW, *pTarget) == SPELL_CAST_OK)
+            if (MOCKING_BLOW > 0 && pVictim != m_bot && m_ai.GetHealthPercent() > 25 && !pTarget->HasAura(MOCKING_BLOW, EFFECT_INDEX_0) && !pTarget->HasAura(CHALLENGING_SHOUT, EFFECT_INDEX_0) && m_ai.CastSpell(MOCKING_BLOW, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (m_bot->getRace() == RACE_TAUREN && !pTarget->HasAura(WAR_STOMP, EFFECT_INDEX_0) && !pTarget->HasAura(PIERCING_HOWL, EFFECT_INDEX_0) && !pTarget->HasAura(CONCUSSION_BLOW, EFFECT_INDEX_0) && m_ai->CastSpell(WAR_STOMP, *pTarget) == SPELL_CAST_OK)
+            if (m_bot.getRace() == RACE_TAUREN && !pTarget->HasAura(WAR_STOMP, EFFECT_INDEX_0) && !pTarget->HasAura(PIERCING_HOWL, EFFECT_INDEX_0) && !pTarget->HasAura(CONCUSSION_BLOW, EFFECT_INDEX_0) && m_ai.CastSpell(WAR_STOMP, *pTarget) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (m_bot->getRace() == RACE_HUMAN && m_bot->hasUnitState(UNIT_STAT_STUNNED) || m_bot->HasAuraType(SPELL_AURA_MOD_FEAR) || m_bot->HasAuraType(SPELL_AURA_MOD_DECREASE_SPEED) || m_bot->HasAuraType(SPELL_AURA_MOD_CHARM) && m_ai->CastSpell(EVERY_MAN_FOR_HIMSELF, *m_bot) == SPELL_CAST_OK)
+            if (m_bot.getRace() == RACE_HUMAN && m_bot.hasUnitState(UNIT_STAT_STUNNED) || m_bot.HasAuraType(SPELL_AURA_MOD_FEAR) || m_bot.HasAuraType(SPELL_AURA_MOD_DECREASE_SPEED) || m_bot.HasAuraType(SPELL_AURA_MOD_CHARM) && m_ai.CastSpell(EVERY_MAN_FOR_HIMSELF, m_bot) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (m_bot->getRace() == RACE_UNDEAD && m_bot->HasAuraType(SPELL_AURA_MOD_FEAR) || m_bot->HasAuraType(SPELL_AURA_MOD_CHARM) && m_ai->CastSpell(WILL_OF_THE_FORSAKEN, *m_bot) == SPELL_CAST_OK)
+            if (m_bot.getRace() == RACE_UNDEAD && m_bot.HasAuraType(SPELL_AURA_MOD_FEAR) || m_bot.HasAuraType(SPELL_AURA_MOD_CHARM) && m_ai.CastSpell(WILL_OF_THE_FORSAKEN, m_bot) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (m_bot->getRace() == RACE_DWARF && m_bot->HasAuraState(AURA_STATE_DEADLY_POISON) && m_ai->CastSpell(STONEFORM, *m_bot) == SPELL_CAST_OK)
+            if (m_bot.getRace() == RACE_DWARF && m_bot.HasAuraState(AURA_STATE_DEADLY_POISON) && m_ai.CastSpell(STONEFORM, m_bot) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (m_bot->getRace() == RACE_GNOME && m_bot->hasUnitState(UNIT_STAT_STUNNED) || m_bot->HasAuraType(SPELL_AURA_MOD_DECREASE_SPEED) && m_ai->CastSpell(ESCAPE_ARTIST, *m_bot) == SPELL_CAST_OK)
+            if (m_bot.getRace() == RACE_GNOME && m_bot.hasUnitState(UNIT_STAT_STUNNED) || m_bot.HasAuraType(SPELL_AURA_MOD_DECREASE_SPEED) && m_ai.CastSpell(ESCAPE_ARTIST, m_bot) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (m_bot->getRace() == RACE_ORC && !m_bot->HasAura(BLOOD_FURY, EFFECT_INDEX_0) && m_ai->CastSpell(BLOOD_FURY, *m_bot) == SPELL_CAST_OK)
+            if (m_bot.getRace() == RACE_ORC && !m_bot.HasAura(BLOOD_FURY, EFFECT_INDEX_0) && m_ai.CastSpell(BLOOD_FURY, m_bot) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
-            if (m_bot->getRace() == RACE_TROLL && !m_bot->HasAura(BERSERKING, EFFECT_INDEX_0) && m_ai->CastSpell(BERSERKING, *m_bot) == SPELL_CAST_OK)
+            if (m_bot.getRace() == RACE_TROLL && !m_bot.HasAura(BERSERKING, EFFECT_INDEX_0) && m_ai.CastSpell(BERSERKING, m_bot) == SPELL_CAST_OK)
                 return RETURN_CONTINUE;
             break;*/
 
@@ -477,7 +468,7 @@ CombatManeuverReturns PlayerbotWarriorAI::DoNextCombatManeuverPVE(Unit* pTarget)
 
 CombatManeuverReturns PlayerbotWarriorAI::DoNextCombatManeuverPVP(Unit* pTarget)
 {
-    if (m_ai->CastSpell(HEROIC_STRIKE) == SPELL_CAST_OK)
+    if (m_ai.CastSpell(HEROIC_STRIKE) == SPELL_CAST_OK)
         return RETURN_CONTINUE;
 
     return DoNextCombatManeuverPVE(pTarget); // TODO: bad idea perhaps, but better than the alternative
@@ -486,27 +477,21 @@ CombatManeuverReturns PlayerbotWarriorAI::DoNextCombatManeuverPVP(Unit* pTarget)
 //Buff and rebuff shouts
 void PlayerbotWarriorAI::CheckShouts()
 {
-    if (!m_ai)  return;
-    if (!m_bot) return;
-
-    if (!m_bot->HasAura(BATTLE_SHOUT, EFFECT_INDEX_0) && m_ai->CastSpell(BATTLE_SHOUT) == SPELL_CAST_OK)
+    if (!m_bot.HasAura(BATTLE_SHOUT, EFFECT_INDEX_0) && m_ai.CastSpell(BATTLE_SHOUT) == SPELL_CAST_OK)
         return;
 }
 
 void PlayerbotWarriorAI::DoNonCombatActions()
 {
-    if (!m_ai)  return;
-    if (!m_bot) return;
-
-    uint32 spec = m_bot->GetSpec();
+    uint32 spec = m_bot.GetSpec();
 
     //Stance Check
-    if (spec == WARRIOR_SPEC_ARMS && !m_bot->HasAura(BATTLE_STANCE, EFFECT_INDEX_0))
-        m_ai->CastSpell(BATTLE_STANCE);
-    else if (spec == WARRIOR_SPEC_FURY && !m_bot->HasAura(BERSERKER_STANCE, EFFECT_INDEX_0))
-        m_ai->CastSpell(BERSERKER_STANCE);
-    else if (spec == WARRIOR_SPEC_PROTECTION && !m_bot->HasAura(DEFENSIVE_STANCE, EFFECT_INDEX_0))
-        m_ai->CastSpell(DEFENSIVE_STANCE);
+    if (spec == WARRIOR_SPEC_ARMS && !m_bot.HasAura(BATTLE_STANCE, EFFECT_INDEX_0))
+        m_ai.CastSpell(BATTLE_STANCE);
+    else if (spec == WARRIOR_SPEC_FURY && !m_bot.HasAura(BERSERKER_STANCE, EFFECT_INDEX_0))
+        m_ai.CastSpell(BERSERKER_STANCE);
+    else if (spec == WARRIOR_SPEC_PROTECTION && !m_bot.HasAura(DEFENSIVE_STANCE, EFFECT_INDEX_0))
+        m_ai.CastSpell(DEFENSIVE_STANCE);
 
     // hp check
     if (EatDrinkBandage(false))
@@ -515,60 +500,54 @@ void PlayerbotWarriorAI::DoNonCombatActions()
     // Search and apply stones to weapons
     // Mainhand ...
     Item* stone, * weapon;
-    weapon = m_bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+    weapon = m_bot.GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
     if (weapon && weapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0)
     {
-        stone = m_ai->FindStoneFor(weapon);
+        stone = m_ai.FindStoneFor(weapon);
         if (stone)
         {
-            m_ai->UseItem(stone, EQUIPMENT_SLOT_MAINHAND);
-            m_ai->SetIgnoreUpdateTime(5);
+            m_ai.UseItem(stone, EQUIPMENT_SLOT_MAINHAND);
+            m_ai.SetIgnoreUpdateTime(5);
         }
     }
     //... and offhand (we add a check to avoid trying to apply stone if the warrior is wielding a shield)
-    weapon = m_bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
+    weapon = m_bot.GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
     if (weapon && (weapon->GetProto()->InventoryType == INVTYPE_WEAPONOFFHAND || weapon->GetProto()->InventoryType == INVTYPE_WEAPONMAINHAND)
             && weapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0)
     {
-        stone = m_ai->FindStoneFor(weapon);
+        stone = m_ai.FindStoneFor(weapon);
         if (stone)
         {
-            m_ai->UseItem(stone, EQUIPMENT_SLOT_OFFHAND);
-            m_ai->SetIgnoreUpdateTime(5);
+            m_ai.UseItem(stone, EQUIPMENT_SLOT_OFFHAND);
+            m_ai.SetIgnoreUpdateTime(5);
         }
     }
 
     // Nothing else to do, Night Elves will cast Shadowmeld to reduce their aggro versus patrols or nearby mobs
-    if (SHADOWMELD > 0 && !m_bot->isMovingOrTurning()
-        && !m_bot->IsMounted()
-        && !m_bot->HasAura(SHADOWMELD, EFFECT_INDEX_0))
+    if (SHADOWMELD > 0 && !m_bot.isMovingOrTurning()
+        && !m_bot.IsMounted()
+        && !m_bot.HasAura(SHADOWMELD, EFFECT_INDEX_0))
     {
-        m_ai->CastSpell(SHADOWMELD, *m_bot);
+        m_ai.CastSpell(SHADOWMELD, m_bot);
     }
 } // end DoNonCombatActions
 
 // Match up with "Pull()" below
 bool PlayerbotWarriorAI::CanPull()
 {
-    if (!m_bot) return false;
-    if (!m_ai) return false;
-
-    return m_bot->GetUInt32Value(PLAYER_AMMO_ID) != 0;
+    return m_bot.GetUInt32Value(PLAYER_AMMO_ID) != 0;
 }
 
 // Match up with "CanPull()" above
 bool PlayerbotWarriorAI::Pull()
 {
-    if (!m_bot) return false;
-    if (!m_ai)  return false;
-
     // In Classic, Warriors had 3 different spells for shooting with ranged weapons
     // So we need to determine which one to use
     // First step: look for the item equiped in ranged slot
-    Item* pItem = m_bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_RANGED);
+    Item* pItem = m_bot.GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_RANGED);
     if (!pItem)
     {
-        m_ai->TellMaster("I don't have a ranged weapon equiped.");
+        m_ai.TellMaster("I don't have a ranged weapon equiped.");
         return false;
     }
 
@@ -587,41 +566,41 @@ bool PlayerbotWarriorAI::Pull()
                 SHOOT = SHOOT_XBOW;
                 break;
             default:
-                m_ai->TellMaster("Can't pull: equiped range item is neither a gun, a bow nor a crossbow.");
+                m_ai.TellMaster("Can't pull: equiped range item is neither a gun, a bow nor a crossbow.");
                 return false;
         }
     }
     else
     {
-        m_ai->TellMaster("Can't pull: equiped range item is unkown.");
+        m_ai.TellMaster("Can't pull: equiped range item is unkown.");
         return false;
     }
 
-    if (m_bot->GetDistance(m_ai->GetCurrentTarget(), true, DIST_CALC_COMBAT_REACH_WITH_MELEE) > ATTACK_DISTANCE)
+    if (m_bot.GetDistance(m_ai.GetCurrentTarget(), true, DIST_CALC_COMBAT_REACH_WITH_MELEE) > ATTACK_DISTANCE)
     {
-        if (!m_ai->In_Reach(m_ai->GetCurrentTarget(), SHOOT))
+        if (!m_ai.In_Reach(m_ai.GetCurrentTarget(), SHOOT))
         {
-            m_ai->TellMaster("Can't pull: I'm out of range.");
+            m_ai.TellMaster("Can't pull: I'm out of range.");
             return false;
         }
-        if (!m_bot->IsWithinLOSInMap(m_ai->GetCurrentTarget()))
+        if (!m_bot.IsWithinLOSInMap(m_ai.GetCurrentTarget()))
         {
-            m_ai->TellMaster("Can't pull: target is out of sight.");
+            m_ai.TellMaster("Can't pull: target is out of sight.");
             return false;
         }
 
         // shoot at the target
-        m_ai->FaceTarget(m_ai->GetCurrentTarget());
-        m_bot->CastSpell(m_ai->GetCurrentTarget(), SHOOT, TRIGGERED_OLD_TRIGGERED);
-        m_ai->TellMaster("I'm PULLING %s.", m_ai->GetCurrentTarget()->GetName());
+        m_ai.FaceTarget(m_ai.GetCurrentTarget());
+        m_bot.CastSpell(m_ai.GetCurrentTarget(), SHOOT, TRIGGERED_OLD_TRIGGERED);
+        m_ai.TellMaster("I'm PULLING %s.", m_ai.GetCurrentTarget()->GetName());
         return true;
     }
     else // target is in melee range
     {
-        m_ai->Attack(m_ai->GetCurrentTarget());
+        m_ai.Attack(m_ai.GetCurrentTarget());
         return true;
     }
 
-    m_ai->TellMaster("I cannot pull my target for an unkown reason.");
+    m_ai.TellMaster("I cannot pull my target for an unkown reason.");
         return false;
 }

--- a/src/game/PlayerBot/AI/PlayerbotWarriorAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotWarriorAI.h
@@ -87,22 +87,22 @@ class MANGOS_DLL_SPEC PlayerbotWarriorAI : PlayerbotClassAI
         virtual ~PlayerbotWarriorAI();
 
         // all combat actions go here
-        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget);
-        bool CanPull();
-        bool Pull();
+        CombatManeuverReturns DoFirstCombatManeuver(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuver(Unit* pTarget) override;
+        bool CanPull() override;
+        bool Pull() override;
 
         // all non combat actions go here, ex buffs, heals, rezzes
-        void DoNonCombatActions();
+        void DoNonCombatActions() override;
 
         //Buff/rebuff shouts
         void CheckShouts();
 
     private:
-        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget);
-        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget);
-        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget);
+        CombatManeuverReturns DoFirstCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVE(Unit* pTarget) override;
+        CombatManeuverReturns DoFirstCombatManeuverPVP(Unit* pTarget) override;
+        CombatManeuverReturns DoNextCombatManeuverPVP(Unit* pTarget) override;
 
         // ARMS
         uint32 BATTLE_STANCE,

--- a/src/game/PlayerBot/AI/PlayerbotWarriorAI.h
+++ b/src/game/PlayerBot/AI/PlayerbotWarriorAI.h
@@ -83,7 +83,7 @@ enum WarriorSpells
 class MANGOS_DLL_SPEC PlayerbotWarriorAI : PlayerbotClassAI
 {
     public:
-        PlayerbotWarriorAI(Player* const master, Player* const bot, PlayerbotAI* const ai);
+        PlayerbotWarriorAI(Player& master, Player& bot, PlayerbotAI& ai);
         virtual ~PlayerbotWarriorAI();
 
         // all combat actions go here

--- a/src/game/PlayerBot/Base/PlayerbotAI.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotAI.cpp
@@ -73,7 +73,7 @@ class PlayerbotChatHandler : protected ChatHandler
         bool dropQuest(char* str) { return HandleQuestRemoveCommand(str); }
 };
 
-PlayerbotAI::PlayerbotAI(PlayerbotMgr* const mgr, Player* const bot) :
+PlayerbotAI::PlayerbotAI(PlayerbotMgr &mgr, Player* const bot) :
     m_mgr(mgr), m_bot(bot), m_classAI(0), m_ignoreAIUpdatesUntilTime(CurrentTime()),
     m_combatOrder(ORDERS_NONE), m_ScenarioType(SCENARIO_PVE),
     m_CurrentlyCastingSpellId(0), m_spellIdCommand(0),
@@ -95,18 +95,18 @@ PlayerbotAI::PlayerbotAI(PlayerbotMgr* const mgr, Player* const bot) :
 
     // set collection options
     m_collectionFlags = 0;
-    m_collectDist = m_mgr->m_confCollectDistance;
-    if (m_mgr->m_confCollectCombat)
+    m_collectDist = m_mgr.m_confCollectDistance;
+    if (m_mgr.m_confCollectCombat)
         SetCollectFlag(COLLECT_FLAG_COMBAT);
-    if (m_mgr->m_confCollectQuest)
+    if (m_mgr.m_confCollectQuest)
         SetCollectFlag(COLLECT_FLAG_QUEST);
-    if (m_mgr->m_confCollectProfession)
+    if (m_mgr.m_confCollectProfession)
         SetCollectFlag(COLLECT_FLAG_PROFESSION);
-    if (m_mgr->m_confCollectLoot)
+    if (m_mgr.m_confCollectLoot)
         SetCollectFlag(COLLECT_FLAG_LOOT);
-    if (m_mgr->m_confCollectSkin && m_bot->HasSkill(SKILL_SKINNING))
+    if (m_mgr.m_confCollectSkin && m_bot->HasSkill(SKILL_SKINNING))
         SetCollectFlag(COLLECT_FLAG_SKIN);
-    if (m_mgr->m_confCollectObjects)
+    if (m_mgr.m_confCollectObjects)
         SetCollectFlag(COLLECT_FLAG_NEAROBJECT);
 
     // start following master (will also teleport bot to master)
@@ -125,7 +125,7 @@ PlayerbotAI::~PlayerbotAI()
 
 Player* PlayerbotAI::GetMaster() const
 {
-    return m_mgr->GetMaster();
+    return m_mgr.GetMaster();
 }
 
 bool PlayerbotAI::CanReachWithSpellAttack(Unit* target)
@@ -793,7 +793,7 @@ void PlayerbotAI::SendOrders(Player& /*player*/)
     }
     out << ".";
 
-    if (m_mgr->m_confDebugWhisper)
+    if (m_mgr.m_confDebugWhisper)
     {
         out << " " << (IsInCombat() ? "I'm in COMBAT! " : "Not in combat. ");
         out << "Current state is ";
@@ -1489,13 +1489,13 @@ void PlayerbotAI::HandleBotOutgoingPacket(const WorldPacket& packet)
                     ItemPosCountVec dest;
                     if (m_bot->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, itemid, itemcount) == EQUIP_ERR_INVENTORY_FULL)
                     {
-                        if (GetManager()->m_confDebugWhisper)
+                        if (GetManager().m_confDebugWhisper)
                             TellMaster("I can't take %; my inventory is full.", pProto->Name1);
                         m_inventory_full = true;
                         continue;
                     }
 
-                    if (GetManager()->m_confDebugWhisper)
+                    if (GetManager().m_confDebugWhisper)
                         TellMaster("Store loot item %s", pProto->Name1);
 
                     WorldPacket* const packet = new WorldPacket(CMSG_AUTOSTORE_LOOT_ITEM, 1);
@@ -1504,12 +1504,12 @@ void PlayerbotAI::HandleBotOutgoingPacket(const WorldPacket& packet)
                 }
                 else
                 {
-                    if (GetManager()->m_confDebugWhisper)
+                    if (GetManager().m_confDebugWhisper)
                         TellMaster("Skipping loot item %s", pProto->Name1);
                 }
             }
 
-            if (GetManager()->m_confDebugWhisper)
+            if (GetManager().m_confDebugWhisper)
                 TellMaster("Releasing loot");
             // release loot
             m_lootPrev = m_lootCurrent;
@@ -1546,7 +1546,7 @@ void PlayerbotAI::HandleBotOutgoingPacket(const WorldPacket& packet)
                         if (skillValue >= reqSkillValue)
                         {
                             m_lootCurrent = m_lootPrev;
-                            if (GetManager()->m_confDebugWhisper)
+                            if (GetManager().m_confDebugWhisper)
                                 TellMaster("I will try to skin next loot attempt.");
 
                             SetIgnoreUpdateTime(1);
@@ -1672,7 +1672,7 @@ void PlayerbotAI::HandleBotOutgoingPacket(const WorldPacket& packet)
                 MovementInfo mi;
                 rp >> mi;
 
-                if (GetManager()->m_confDebugWhisper)
+                if (GetManager().m_confDebugWhisper)
                     TellMaster("Preparing to teleport");
 
                 if (m_bot->IsBeingTeleportedNear())
@@ -1701,7 +1701,7 @@ void PlayerbotAI::HandleBotOutgoingPacket(const WorldPacket& packet)
             }
             case SMSG_TRANSFER_PENDING:
             {
-                if (GetManager()->m_confDebugWhisper)
+                if (GetManager().m_confDebugWhisper)
                     TellMaster("World transfer is pending");
                 SetState(BOTSTATE_LOADING);
                 SetIgnoreUpdateTime(1);
@@ -1710,7 +1710,7 @@ void PlayerbotAI::HandleBotOutgoingPacket(const WorldPacket& packet)
             }
             case SMSG_NEW_WORLD:
             {
-                if (GetManager()->m_confDebugWhisper)
+                if (GetManager().m_confDebugWhisper)
                     TellMaster("Preparing to teleport far");
 
                 if (m_bot->IsBeingTeleportedFar())
@@ -2273,7 +2273,7 @@ void PlayerbotAI::GetCombatTarget(Unit* forcedTarget)
         {
             forcedTarget = candidateTarget;
             m_targetType = TARGET_THREATEN;
-            if (m_mgr->m_confDebugWhisper)
+            if (m_mgr.m_confDebugWhisper)
                 TellMaster("Changing target to %s to protect %s", forcedTarget->GetName(), m_targetProtect->GetName());
         }
     }
@@ -2285,7 +2285,7 @@ void PlayerbotAI::GetCombatTarget(Unit* forcedTarget)
         if (forcedTarget && forcedTarget == m_targetCombat)
             return;
 
-        if (m_mgr->m_confDebugWhisper)
+        if (m_mgr.m_confDebugWhisper)
             TellMaster("Changing target to %s by force!", forcedTarget->GetName());
         m_targetCombat = forcedTarget;
         m_ignoreNeutralizeEffect = true;    // Bypass IsNeutralized() checks on next updates
@@ -2320,7 +2320,7 @@ void PlayerbotAI::GetCombatTarget(Unit* forcedTarget)
         if (candidateTarget && !IsNeutralized(candidateTarget))
         {
             m_targetCombat = candidateTarget;
-            if (m_mgr->m_confDebugWhisper)
+            if (m_mgr.m_confDebugWhisper)
                 TellMaster("Attacking %s to assist %s", m_targetCombat->GetName(), m_targetAssist->GetName());
             m_targetType = (m_combatOrder & (ORDERS_TANK | ORDERS_MAIN_TANK) ? TARGET_THREATEN : TARGET_NORMAL);
             m_targetChanged = true;
@@ -2860,10 +2860,10 @@ void PlayerbotAI::DoLoot()
     WorldObject* wo = m_bot->GetMap()->GetWorldObject(m_lootCurrent);
 
     // clear invalid object or object that is too far from master
-    if (!wo || GetMaster()->GetDistance(wo) > float(m_mgr->m_confCollectDistanceMax))
+    if (!wo || GetMaster()->GetDistance(wo) > float(m_mgr.m_confCollectDistanceMax))
     {
         m_lootCurrent = ObjectGuid();
-        if (GetManager()->m_confDebugWhisper)
+        if (GetManager().m_confDebugWhisper)
             TellMaster("Object is too far away.");
         return;
     }
@@ -2879,7 +2879,7 @@ void PlayerbotAI::DoLoot()
     if ((c && c->IsDespawned()) || (go && !go->IsSpawned()) || (!c && !go))
     {
         m_lootCurrent = ObjectGuid();
-        if (GetManager()->m_confDebugWhisper)
+        if (GetManager().m_confDebugWhisper)
             TellMaster("Object is not spawned.");
         return;
     }
@@ -2904,7 +2904,7 @@ void PlayerbotAI::DoLoot()
         }
         else if (c->m_loot && !c->m_loot->CanLoot(m_bot) && !c->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SKINNABLE))
         {
-            if (GetManager()->m_confDebugWhisper)
+            if (GetManager().m_confDebugWhisper)
                 TellMaster("%s is not lootable by me.", wo->GetName());
             m_lootCurrent = ObjectGuid();
             // clear movement target, take next target on next update
@@ -2919,7 +2919,7 @@ void PlayerbotAI::DoLoot()
         m_bot->GetMotionMaster()->MovePoint(wo->GetMapId(), wo->GetPositionX(), wo->GetPositionY(), wo->GetPositionZ());
         // give time to move to point before trying again
         SetIgnoreUpdateTime(1);
-        if (GetManager()->m_confDebugWhisper)
+        if (GetManager().m_confDebugWhisper)
             TellMaster("Moving to loot %s", go ? go->GetName() : wo->GetName());
     }
 
@@ -2931,7 +2931,7 @@ void PlayerbotAI::DoLoot()
         bool skillFailed = false;
         bool forceFailed = false;
 
-        if (GetManager()->m_confDebugWhisper)
+        if (GetManager().m_confDebugWhisper)
             TellMaster("Beginning to loot %s", go ? go->GetName() : wo->GetName());
 
         if (c)  // creature
@@ -3842,7 +3842,7 @@ void PlayerbotAI::MovementReset()
         if (m_bot->IsAlive())
         {
             float angle = rand_float(0, M_PI_F);
-            float dist = rand_float(m_mgr->m_confFollowDistance[0], m_mgr->m_confFollowDistance[1]);
+            float dist = rand_float(m_mgr.m_confFollowDistance[0], m_mgr.m_confFollowDistance[1]);
             m_bot->GetMotionMaster()->MoveFollow(m_followTarget, dist, angle);
         }
     }
@@ -4706,7 +4706,7 @@ bool PlayerbotAI::PickPocket(Unit* pTarget)
         {
             m_bot->ModifyMoney(loot->GetGoldAmount());
 
-            if (m_mgr->m_confDebugWhisper)
+            if (m_mgr.m_confDebugWhisper)
             {
                 std::ostringstream out;
 
@@ -5228,7 +5228,7 @@ void PlayerbotAI::findNearbyGO()
 void PlayerbotAI::findNearbyCorpse()
 {
     UnitList corpseList;
-    float radius = float(m_mgr->m_confCollectDistance);
+    float radius = float(m_mgr.m_confCollectDistance);
 //    float radius = 40.0f;
     MaNGOS::AnyDeadUnitCheck corpse_check(m_bot);
     MaNGOS::UnitListSearcher<MaNGOS::AnyDeadUnitCheck> reaper(corpseList, corpse_check);
@@ -6569,12 +6569,12 @@ void PlayerbotAI::HandleCommand(const std::string& text, Player& fromPlayer)
     else if (text == "debug")
     {
         TellMaster("Debugging is on. Type 'no debug' to disable.");
-        GetManager()->m_confDebugWhisper = true;
+        GetManager().m_confDebugWhisper = true;
     }
     else if (text == "no debug")
     {
         TellMaster("Debugging is off.");
-        GetManager()->m_confDebugWhisper = false;
+        GetManager().m_confDebugWhisper = false;
     }
     else if (ExtractCommand("reset", input))
         _HandleCommandReset(input, fromPlayer);

--- a/src/game/PlayerBot/Base/PlayerbotAI.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotAI.cpp
@@ -694,22 +694,22 @@ void PlayerbotAI::ReloadAI()
         case CLASS_PRIEST:
             if (m_classAI) delete m_classAI;
             m_combatStyle = COMBAT_RANGED;
-            m_classAI = (PlayerbotClassAI*) new PlayerbotPriestAI(GetMaster(), m_bot, this);
+            m_classAI = (PlayerbotClassAI*) new PlayerbotPriestAI(*GetMaster(), *m_bot, *this);
             break;
         case CLASS_MAGE:
             if (m_classAI) delete m_classAI;
             m_combatStyle = COMBAT_RANGED;
-            m_classAI = (PlayerbotClassAI*) new PlayerbotMageAI(GetMaster(), m_bot, this);
+            m_classAI = (PlayerbotClassAI*) new PlayerbotMageAI(*GetMaster(), *m_bot, *this);
             break;
         case CLASS_WARLOCK:
             if (m_classAI) delete m_classAI;
             m_combatStyle = COMBAT_RANGED;
-            m_classAI = (PlayerbotClassAI*) new PlayerbotWarlockAI(GetMaster(), m_bot, this);
+            m_classAI = (PlayerbotClassAI*) new PlayerbotWarlockAI(*GetMaster(), *m_bot, *this);
             break;
         case CLASS_WARRIOR:
             if (m_classAI) delete m_classAI;
             m_combatStyle = COMBAT_MELEE;
-            m_classAI = (PlayerbotClassAI*) new PlayerbotWarriorAI(GetMaster(), m_bot, this);
+            m_classAI = (PlayerbotClassAI*) new PlayerbotWarriorAI(*GetMaster(), *m_bot, *this);
             break;
         case CLASS_SHAMAN:
             if (m_classAI) delete m_classAI;
@@ -719,17 +719,17 @@ void PlayerbotAI::ReloadAI()
             }
             else
                 m_combatStyle = COMBAT_RANGED;
-            m_classAI = (PlayerbotClassAI*) new PlayerbotShamanAI(GetMaster(), m_bot, this);
+            m_classAI = (PlayerbotClassAI*) new PlayerbotShamanAI(*GetMaster(), *m_bot, *this);
             break;
         case CLASS_PALADIN:
             if (m_classAI) delete m_classAI;
             m_combatStyle = COMBAT_MELEE;
-            m_classAI = (PlayerbotClassAI*) new PlayerbotPaladinAI(GetMaster(), m_bot, this);
+            m_classAI = (PlayerbotClassAI*) new PlayerbotPaladinAI(*GetMaster(), *m_bot, *this);
             break;
         case CLASS_ROGUE:
             if (m_classAI) delete m_classAI;
             m_combatStyle = COMBAT_MELEE;
-            m_classAI = (PlayerbotClassAI*) new PlayerbotRogueAI(GetMaster(), m_bot, this);
+            m_classAI = (PlayerbotClassAI*) new PlayerbotRogueAI(*GetMaster(), *m_bot, *this);
             break;
         case CLASS_DRUID:
             if (m_classAI) delete m_classAI;
@@ -739,12 +739,12 @@ void PlayerbotAI::ReloadAI()
             }
             else
                 m_combatStyle = COMBAT_RANGED;
-            m_classAI = (PlayerbotClassAI*) new PlayerbotDruidAI(GetMaster(), m_bot, this);
+            m_classAI = (PlayerbotClassAI*) new PlayerbotDruidAI(*GetMaster(), *m_bot, *this);
             break;
         case CLASS_HUNTER:
             if (m_classAI) delete m_classAI;
             m_combatStyle = COMBAT_RANGED;
-            m_classAI = (PlayerbotClassAI*) new PlayerbotHunterAI(GetMaster(), m_bot, this);
+            m_classAI = (PlayerbotClassAI*) new PlayerbotHunterAI(*GetMaster(), *m_bot, *this);
             break;
     }
 

--- a/src/game/PlayerBot/Base/PlayerbotAI.h
+++ b/src/game/PlayerBot/Base/PlayerbotAI.h
@@ -331,7 +331,7 @@ class MANGOS_DLL_SPEC PlayerbotAI
         };
 
     public:
-        PlayerbotAI(PlayerbotMgr& mgr, Player* const bot);
+        PlayerbotAI(PlayerbotMgr& mgr, Player* const bot, bool debugWhisper);
         virtual ~PlayerbotAI();
 
         // This is called from Unit.cpp and is called every second (I think)
@@ -353,7 +353,6 @@ class MANGOS_DLL_SPEC PlayerbotAI
         void SetCombatStyle(CombatStyle cs) { m_combatStyle = cs; }
 
         PlayerbotClassAI* GetClassAI() { return m_classAI; }
-        PlayerbotMgr& GetManager() { return m_mgr; }
         void ReloadAI();
 
         // finds spell ID for matching substring args
@@ -696,7 +695,7 @@ class MANGOS_DLL_SPEC PlayerbotAI
         SpellRanges m_spellRangeMap;
 
         float m_destX, m_destY, m_destZ; // latest coordinates for chase and point movement types
-
+        bool m_debugWhisper = false;
 };
 
 #endif

--- a/src/game/PlayerBot/Base/PlayerbotAI.h
+++ b/src/game/PlayerBot/Base/PlayerbotAI.h
@@ -331,7 +331,7 @@ class MANGOS_DLL_SPEC PlayerbotAI
         };
 
     public:
-        PlayerbotAI(PlayerbotMgr* const mgr, Player* const bot);
+        PlayerbotAI(PlayerbotMgr& mgr, Player* const bot);
         virtual ~PlayerbotAI();
 
         // This is called from Unit.cpp and is called every second (I think)
@@ -353,7 +353,7 @@ class MANGOS_DLL_SPEC PlayerbotAI
         void SetCombatStyle(CombatStyle cs) { m_combatStyle = cs; }
 
         PlayerbotClassAI* GetClassAI() { return m_classAI; }
-        PlayerbotMgr* GetManager() { return m_mgr; }
+        PlayerbotMgr& GetManager() { return m_mgr; }
         void ReloadAI();
 
         // finds spell ID for matching substring args
@@ -629,7 +629,7 @@ class MANGOS_DLL_SPEC PlayerbotAI
 
         // it is safe to keep these back reference pointers because m_bot
         // owns the "this" object and m_master owns m_bot. The owner always cleans up.
-        PlayerbotMgr* const m_mgr;
+        PlayerbotMgr& m_mgr;
         Player* const m_bot;
         PlayerbotClassAI* m_classAI;
 
@@ -696,6 +696,7 @@ class MANGOS_DLL_SPEC PlayerbotAI
         SpellRanges m_spellRangeMap;
 
         float m_destX, m_destY, m_destZ; // latest coordinates for chase and point movement types
+
 };
 
 #endif

--- a/src/game/PlayerBot/Base/PlayerbotClassAI.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotClassAI.cpp
@@ -24,11 +24,9 @@
 #include "Grids/GridNotifiers.h"
 #include "Grids/GridNotifiersImpl.h"
 
-PlayerbotClassAI::PlayerbotClassAI(Player* const master, Player* const bot, PlayerbotAI* const ai)
+PlayerbotClassAI::PlayerbotClassAI(Player& master, Player& bot, PlayerbotAI& ai)
+    : m_master(master), m_bot(bot), m_ai(ai)
 {
-    m_master = master;
-    m_bot = bot;
-    m_ai = ai;
 
     m_MinHealthPercentTank   = 80;
     m_MinHealthPercentHealer = 60;
@@ -56,32 +54,32 @@ bool PlayerbotClassAI::EatDrinkBandage(bool bMana, unsigned char foodPercent, un
 {
     Item* drinkItem = nullptr;
     Item* foodItem = nullptr;
-    if (bMana && m_ai->GetManaPercent() < drinkPercent)
-        drinkItem = m_ai->FindDrink();
-    if (m_ai->GetHealthPercent() < foodPercent)
-        foodItem = m_ai->FindFood();
+    if (bMana && m_ai.GetManaPercent() < drinkPercent)
+        drinkItem = m_ai.FindDrink();
+    if (m_ai.GetHealthPercent() < foodPercent)
+        foodItem = m_ai.FindFood();
     if (drinkItem || foodItem)
     {
         if (drinkItem)
         {
-            m_ai->TellMaster("I could use a drink.");
-            m_ai->UseItem(drinkItem);
+            m_ai.TellMaster("I could use a drink.");
+            m_ai.UseItem(drinkItem);
         }
         if (foodItem)
         {
-            m_ai->TellMaster("I could use some food.");
-            m_ai->UseItem(foodItem);
+            m_ai.TellMaster("I could use some food.");
+            m_ai.UseItem(foodItem);
         }
         return true;
     }
 
-    if (m_ai->GetHealthPercent() < bandagePercent && !m_bot->HasAura(RECENTLY_BANDAGED))
+    if (m_ai.GetHealthPercent() < bandagePercent && !m_bot.HasAura(RECENTLY_BANDAGED))
     {
-        Item* bandageItem = m_ai->FindBandage();
+        Item* bandageItem = m_ai.FindBandage();
         if (bandageItem)
         {
-            m_ai->TellMaster("I could use first aid.");
-            m_ai->UseItem(bandageItem);
+            m_ai.TellMaster("I could use first aid.");
+            m_ai.UseItem(bandageItem);
             return true;
         }
     }
@@ -97,9 +95,6 @@ bool PlayerbotClassAI::CastHoTOnTank()
 
 CombatManeuverReturns PlayerbotClassAI::HealPlayer(Player* target)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
     if (!target) return RETURN_NO_ACTION_INVALIDTARGET;
     if (target->IsInDuel() || !target->IsAlive()) return RETURN_NO_ACTION_INVALIDTARGET;
 
@@ -108,9 +103,6 @@ CombatManeuverReturns PlayerbotClassAI::HealPlayer(Player* target)
 
 CombatManeuverReturns PlayerbotClassAI::ResurrectPlayer(Player* target)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
     if (!target) return RETURN_NO_ACTION_INVALIDTARGET;
     if (target->IsAlive()) return RETURN_NO_ACTION_INVALIDTARGET;
 
@@ -119,9 +111,6 @@ CombatManeuverReturns PlayerbotClassAI::ResurrectPlayer(Player* target)
 
 CombatManeuverReturns PlayerbotClassAI::DispelPlayer(Player* target)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
     if (!target) return RETURN_NO_ACTION_INVALIDTARGET;
     if (target->IsInDuel() || !target->IsAlive()) return RETURN_NO_ACTION_INVALIDTARGET;
 
@@ -143,17 +132,15 @@ CombatManeuverReturns PlayerbotClassAI::DispelPlayer(Player* target)
  */
 CombatManeuverReturns PlayerbotClassAI::Buff(bool (*BuffHelper)(PlayerbotAI*, uint32, Unit*), uint32 spellId, uint32 type, bool mustBeOOC)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-    if (!m_bot->IsAlive() || m_bot->IsInDuel()) return RETURN_NO_ACTION_ERROR;
-    if (mustBeOOC && m_bot->IsInCombat()) return RETURN_NO_ACTION_ERROR;
+    if (!m_bot.IsAlive() || m_bot.IsInDuel()) return RETURN_NO_ACTION_ERROR;
+    if (mustBeOOC && m_bot.IsInCombat()) return RETURN_NO_ACTION_ERROR;
 
     if (spellId == 0) return RETURN_NO_ACTION_OK;
 
     // First, fill the list of targets
-    if (m_bot->GetGroup())
+    if (m_bot.GetGroup())
     {
-        Group::MemberSlotList const& groupSlot = m_bot->GetGroup()->GetMemberSlots();
+        Group::MemberSlotList const& groupSlot = m_bot.GetGroup()->GetMemberSlots();
         for (const auto & memberItr : groupSlot)
         {
             Player* member = sObjectMgr.GetPlayer(memberItr.guid);
@@ -165,7 +152,7 @@ CombatManeuverReturns PlayerbotClassAI::Buff(bool (*BuffHelper)(PlayerbotAI*, ui
             if (job & type ||
                 (type & JOB_MANAONLY && (member->getClass() == CLASS_DRUID || member->GetPowerType() == POWER_MANA)))
             {
-                if (BuffHelper(m_ai, spellId, member))
+                if (BuffHelper(&m_ai, spellId, member))
                     return RETURN_CONTINUE;
             }
         }
@@ -173,13 +160,13 @@ CombatManeuverReturns PlayerbotClassAI::Buff(bool (*BuffHelper)(PlayerbotAI*, ui
     else
     {
         // Buff master if he/she is eligible
-        if (m_master && !m_master->IsInDuel()
-            && (GetTargetJob(m_master) & type
-                || (type & JOB_MANAONLY && (m_master->getClass() == CLASS_DRUID || m_master->GetPowerType() == POWER_MANA))))
-            if (BuffHelper(m_ai, spellId, m_master))
+        if (!m_master.IsInDuel()
+            && (GetTargetJob(&m_master) & type
+                || (type & JOB_MANAONLY && (m_master.getClass() == CLASS_DRUID || m_master.GetPowerType() == POWER_MANA))))
+            if (BuffHelper(&m_ai, spellId, &m_master))
                 return RETURN_CONTINUE;
         // Do not check job or power type - any buff you have is always useful to self
-        if (BuffHelper(m_ai, spellId, m_bot))
+        if (BuffHelper(&m_ai, spellId, &m_bot))
             return RETURN_CONTINUE;
     }
 
@@ -197,14 +184,12 @@ CombatManeuverReturns PlayerbotClassAI::Buff(bool (*BuffHelper)(PlayerbotAI*, ui
  */
 bool PlayerbotClassAI::NeedGroupBuff(uint32 groupBuffSpellId, uint32 singleBuffSpellId)
 {
-    if (!m_bot) return false;
-
     uint8 unbuffedTargets = 0;
     // Check group players to avoid using reagent and mana with an expensive group buff
     // when only two players or less need it
-    if (m_bot->GetGroup())
+    if (m_bot.GetGroup())
     {
-        Group::MemberSlotList const& groupSlot = m_bot->GetGroup()->GetMemberSlots();
+        Group::MemberSlotList const& groupSlot = m_bot.GetGroup()->GetMemberSlots();
         for (const auto& memberItr : groupSlot)
         {
             Player* member = sObjectMgr.GetPlayer(memberItr.guid);
@@ -232,16 +217,14 @@ bool PlayerbotClassAI::NeedGroupBuff(uint32 groupBuffSpellId, uint32 singleBuffS
  */
 bool PlayerbotClassAI::FindTargetAndHeal()
 {
-    if (!m_ai)  return false;
-    if (!m_bot) return false;
-    if (!m_bot->IsAlive() || m_bot->IsInDuel() || !m_ai->IsHealer()) return false;
+    if (!m_bot.IsAlive() || m_bot.IsInDuel() || !m_ai.IsHealer()) return false;
 
     // Heal other players/bots first
     // Select a target based on orders and some context (pets are ignored because GetHealTarget() only works on players)
     Player* targetToHeal;
-    JOB_TYPE type = (m_ai->GetCombatOrder() & PlayerbotAI::ORDERS_NOT_MAIN_HEAL) ? JOB_ALL_NO_MT : JOB_ALL;
+    JOB_TYPE type = (m_ai.GetCombatOrder() & PlayerbotAI::ORDERS_NOT_MAIN_HEAL) ? JOB_ALL_NO_MT : JOB_ALL;
     // 1. bot has orders to focus on main tank
-    if (m_ai->IsMainHealer())
+    if (m_ai.IsMainHealer())
         targetToHeal = GetHealTarget(JOB_MAIN_TANK);
     // 2. Look at its own group (this implies raid leader creates balanced groups, except for the MT group)
     else
@@ -250,7 +233,7 @@ bool PlayerbotClassAI::FindTargetAndHeal()
     if (!targetToHeal)
         targetToHeal = GetHealTarget(type);
 
-    if (m_ai->GetClassAI()->HealPlayer(targetToHeal) & RETURN_CONTINUE)
+    if (m_ai.GetClassAI()->HealPlayer(targetToHeal) & RETURN_CONTINUE)
         return true;
 
     return false;   
@@ -270,23 +253,21 @@ bool PlayerbotClassAI::FindTargetAndHeal()
  */
 Player* PlayerbotClassAI::GetHealTarget(JOB_TYPE type, bool onlyPickFromSameGroup)
 {
-    if (!m_ai)  return nullptr;
-    if (!m_bot) return nullptr;
-    if (!m_bot->IsAlive() || m_bot->IsInDuel()) return nullptr;
+    if (!m_bot.IsAlive() || m_bot.IsInDuel()) return nullptr;
 
     // define seperately for sorting purposes - DO NOT CHANGE ORDER!
     std::vector<heal_priority> targets;
     uint8 uiHealthPercentage;
 
     // First, fill the list of targets
-    if (m_bot->GetGroup())
+    if (m_bot.GetGroup())
     {
-        Group::MemberSlotList const& groupSlot = m_bot->GetGroup()->GetMemberSlots();
+        Group::MemberSlotList const& groupSlot = m_bot.GetGroup()->GetMemberSlots();
         for (Group::member_citerator itr = groupSlot.begin(); itr != groupSlot.end(); itr++)
         {
             Player* groupMember = sObjectMgr.GetPlayer(itr->guid);
             if (!groupMember || !groupMember->IsAlive() || groupMember->IsInDuel()
-                || (!m_bot->GetGroup()->SameSubGroup(m_bot, groupMember) && onlyPickFromSameGroup))
+                || (!m_bot.GetGroup()->SameSubGroup(&m_bot, groupMember) && onlyPickFromSameGroup))
                 continue;
             JOB_TYPE job = GetTargetJob(groupMember);
             if (job & type)
@@ -298,11 +279,11 @@ Player* PlayerbotClassAI::GetHealTarget(JOB_TYPE type, bool onlyPickFromSameGrou
     }
     else
     {
-        targets.push_back(heal_priority(m_bot, m_bot->GetHealthPercent(), GetTargetJob(m_bot)));
-        if (m_master && !m_master->IsInDuel())
+        targets.push_back(heal_priority(&m_bot, m_bot.GetHealthPercent(), GetTargetJob(&m_bot)));
+        if (!m_master.IsInDuel())
         {
-            uiHealthPercentage = int(m_master->GetMaxHealth() != 0 ? m_master->GetHealth() * 100 / m_master->GetMaxHealth() : 0);
-            targets.push_back(heal_priority(m_master, uiHealthPercentage, GetTargetJob(m_master)));
+            uiHealthPercentage = int(m_master.GetMaxHealth() != 0 ? m_master.GetHealth() * 100 / m_master.GetMaxHealth() : 0);
+            targets.push_back(heal_priority(&m_master, uiHealthPercentage, GetTargetJob(&m_master)));
         }
     }
 
@@ -417,7 +398,6 @@ Player* PlayerbotClassAI::GetHealTarget(JOB_TYPE type, bool onlyPickFromSameGrou
  */
 bool PlayerbotClassAI::FleeFromAoEIfCan(uint32 spellId, Unit* pTarget)
 {
-    if (!m_bot) return false;
     if (!spellId) return false;
 
     // Step 1: Get radius from hostile AoE spell
@@ -428,7 +408,7 @@ bool PlayerbotClassAI::FleeFromAoEIfCan(uint32 spellId, Unit* pTarget)
 
     // Step 2: Get current bot position to move from it
     float curr_x, curr_y, curr_z;
-    m_bot->GetPosition(curr_x, curr_y, curr_z);
+    m_bot.GetPosition(curr_x, curr_y, curr_z);
     return FleeFromPointIfCan(radius, pTarget, curr_x, curr_y, curr_z);
 }
 
@@ -443,7 +423,6 @@ bool PlayerbotClassAI::FleeFromAoEIfCan(uint32 spellId, Unit* pTarget)
  */
 bool PlayerbotClassAI::FleeFromTrapGOIfCan(uint32 goEntry, Unit* pTarget)
 {
-    if (!m_bot) return false;
     if (!goEntry) return false;
 
     // Step 1: check if the GO exists and find its trap radius
@@ -456,10 +435,10 @@ bool PlayerbotClassAI::FleeFromTrapGOIfCan(uint32 goEntry, Unit* pTarget)
     // Step 2: find a GO in the range around player
     GameObject* pGo = nullptr;
 
-    MaNGOS::NearestGameObjectEntryInObjectRangeCheck go_check(*m_bot, goEntry, trapRadius);
+    MaNGOS::NearestGameObjectEntryInObjectRangeCheck go_check(m_bot, goEntry, trapRadius);
     MaNGOS::GameObjectLastSearcher<MaNGOS::NearestGameObjectEntryInObjectRangeCheck> searcher(pGo, go_check);
 
-    Cell::VisitGridObjects(m_bot, searcher, trapRadius);
+    Cell::VisitGridObjects(&m_bot, searcher, trapRadius);
 
     if (!pGo)
         return false;
@@ -479,7 +458,6 @@ bool PlayerbotClassAI::FleeFromTrapGOIfCan(uint32 goEntry, Unit* pTarget)
  */
 bool PlayerbotClassAI::FleeFromNpcWithAuraIfCan(uint32 NpcEntry, uint32 spellId, Unit* pTarget)
 {
-    if (!m_bot) return false;
     if (!NpcEntry) return false;
     if (!spellId) return false;
 
@@ -495,10 +473,10 @@ bool PlayerbotClassAI::FleeFromNpcWithAuraIfCan(uint32 NpcEntry, uint32 spellId,
     // Step 2: find a close creature with the right entry:
     Creature* pCreature = nullptr;
 
-    MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck creature_check(*m_bot, NpcEntry, false, false, radius, true);
+    MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck creature_check(m_bot, NpcEntry, false, false, radius, true);
     MaNGOS::CreatureLastSearcher<MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck> searcher(pCreature, creature_check);
 
-    Cell::VisitGridObjects(m_bot, searcher, radius);
+    Cell::VisitGridObjects(&m_bot, searcher, radius);
 
     if (!pCreature)
         return false;
@@ -520,17 +498,14 @@ bool PlayerbotClassAI::FleeFromNpcWithAuraIfCan(uint32 NpcEntry, uint32 spellId,
  */
 bool PlayerbotClassAI::FleeFromPointIfCan(uint32 radius, Unit* pTarget, float x0, float y0, float z0, float forcedAngle /* = 0.0f */)
 {
-    if (!m_bot) return false;
-    if (!m_ai) return false;
-
     // Get relative position to current target
     // the bot will try to move on a tangential axis from it
     float dist_from_target, angle_to_target;
     if (pTarget)
     {
-        dist_from_target = pTarget->GetDistance(m_bot);
+        dist_from_target = pTarget->GetDistance(&m_bot);
         if (dist_from_target > 0.2f)
-            angle_to_target = pTarget->GetAngle(m_bot);
+            angle_to_target = pTarget->GetAngle(&m_bot);
         else
             angle_to_target = frand(0, 2 * M_PI_F);
     }
@@ -564,23 +539,23 @@ bool PlayerbotClassAI::FleeFromPointIfCan(uint32 radius, Unit* pTarget, float x0
         z = z0 + 0.5f;
 
         // try to fix z
-        if (!m_bot->GetMap()->GetHeightInRange(x, y, z))
+        if (!m_bot.GetMap()->GetHeightInRange(x, y, z))
             foundCoords = false;
 
         // check any collision
         float testZ = z + 0.5f; // needed to avoid some false positive hit detection of terrain or passable little object
-        if (m_bot->GetMap()->GetHitPosition(x0, y0, z0 + 0.5f, x, y, testZ, -0.1f))
+        if (m_bot.GetMap()->GetHitPosition(x0, y0, z0 + 0.5f, x, y, testZ, -0.1f))
         {
             z = testZ;
-            if (!m_bot->GetMap()->GetHeightInRange(x, y, z))
+            if (!m_bot.GetMap()->GetHeightInRange(x, y, z))
                 foundCoords = false;
         }
 
         if (foundCoords)
         {
-            m_ai->InterruptCurrentCastingSpell();
-            m_bot->GetMotionMaster()->MovePoint(0, x, y, z);
-            m_ai->SetIgnoreUpdateTime(2);
+            m_ai.InterruptCurrentCastingSpell();
+            m_bot.GetMotionMaster()->MovePoint(0, x, y, z);
+            m_ai.SetIgnoreUpdateTime(2);
             return true;
         }
     }
@@ -600,18 +575,16 @@ bool PlayerbotClassAI::FleeFromPointIfCan(uint32 radius, Unit* pTarget, float x0
  */
 Player* PlayerbotClassAI::GetDispelTarget(DispelType dispelType, JOB_TYPE type, bool bMustBeOOC)
 {
-    if (!m_ai)  return nullptr;
-    if (!m_bot) return nullptr;
-    if (!m_bot->IsAlive() || m_bot->IsInDuel()) return nullptr;
-    if (bMustBeOOC && m_bot->IsInCombat()) return nullptr;
+    if (!m_bot.IsAlive() || m_bot.IsInDuel()) return nullptr;
+    if (bMustBeOOC && m_bot.IsInCombat()) return nullptr;
 
     // First, fill the list of targets
-    if (m_bot->GetGroup())
+    if (m_bot.GetGroup())
     {
         // define seperately for sorting purposes - DO NOT CHANGE ORDER!
         std::vector<heal_priority> targets;
 
-        Group::MemberSlotList const& groupSlot = m_bot->GetGroup()->GetMemberSlots();
+        Group::MemberSlotList const& groupSlot = m_bot.GetGroup()->GetMemberSlots();
         for (Group::member_citerator itr = groupSlot.begin(); itr != groupSlot.end(); itr++)
         {
             Player* groupMember = sObjectMgr.GetPlayer(itr->guid);
@@ -647,18 +620,16 @@ Player* PlayerbotClassAI::GetDispelTarget(DispelType dispelType, JOB_TYPE type, 
 
 Player* PlayerbotClassAI::GetResurrectionTarget(JOB_TYPE type, bool bMustBeOOC)
 {
-    if (!m_ai)  return nullptr;
-    if (!m_bot) return nullptr;
-    if (!m_bot->IsAlive() || m_bot->IsInDuel()) return nullptr;
-    if (bMustBeOOC && m_bot->IsInCombat()) return nullptr;
+    if (!m_bot.IsAlive() || m_bot.IsInDuel()) return nullptr;
+    if (bMustBeOOC && m_bot.IsInCombat()) return nullptr;
 
     // First, fill the list of targets
-    if (m_bot->GetGroup())
+    if (m_bot.GetGroup())
     {
         // define seperately for sorting purposes - DO NOT CHANGE ORDER!
         std::vector<heal_priority> targets;
 
-        Group::MemberSlotList const& groupSlot = m_bot->GetGroup()->GetMemberSlots();
+        Group::MemberSlotList const& groupSlot = m_bot.GetGroup()->GetMemberSlots();
         for (Group::member_citerator itr = groupSlot.begin(); itr != groupSlot.end(); itr++)
         {
             Player* groupMember = sObjectMgr.GetPlayer(itr->guid);
@@ -675,8 +646,8 @@ Player* PlayerbotClassAI::GetResurrectionTarget(JOB_TYPE type, bool bMustBeOOC)
         if (targets.size())
             return targets.at(0).p;
     }
-    else if (!m_master->IsAlive())
-        return m_master;
+    else if (!m_master.IsAlive())
+        return &m_master;
 
     return nullptr;
 }
@@ -709,63 +680,57 @@ JOB_TYPE PlayerbotClassAI::GetTargetJob(Player* target)
                 return JOB_HEAL;
             if (uSpec == PALADIN_SPEC_PROTECTION)
                 return JOB_TANK;
-            return (m_master == target) ? JOB_MASTER : JOB_DPS;
+            return (&m_master == target) ? JOB_MASTER : JOB_DPS;
         case CLASS_DRUID:
             if (uSpec == DRUID_SPEC_RESTORATION)
                 return JOB_HEAL;
             // Feral can be used for both Tank or DPS... play it safe and assume tank. If not... he best be good at threat management or he'll ravage the healer's mana
             else if (uSpec == DRUID_SPEC_FERAL)
                 return JOB_TANK;
-            return (m_master == target) ? JOB_MASTER : JOB_DPS;
+            return (&m_master == target) ? JOB_MASTER : JOB_DPS;
         case CLASS_PRIEST:
             // Since Discipline can be used for both healer or DPS assume DPS
             if (uSpec == PRIEST_SPEC_HOLY)
                 return JOB_HEAL;
-            return (m_master == target) ? JOB_MASTER : JOB_DPS;
+            return (&m_master == target) ? JOB_MASTER : JOB_DPS;
         case CLASS_SHAMAN:
             if (uSpec == SHAMAN_SPEC_RESTORATION)
                 return JOB_HEAL;
-            return (m_master == target) ? JOB_MASTER : JOB_DPS;
+            return (&m_master == target) ? JOB_MASTER : JOB_DPS;
         case CLASS_WARRIOR:
             if (uSpec == WARRIOR_SPEC_PROTECTION)
                 return JOB_TANK;
-            return (m_master == target) ? JOB_MASTER : JOB_DPS;
+            return (&m_master == target) ? JOB_MASTER : JOB_DPS;
         case CLASS_MAGE:
         case CLASS_WARLOCK:
         case CLASS_ROGUE:
         case CLASS_HUNTER:
         default:
-            return (m_master == target) ? JOB_MASTER : JOB_DPS;
+            return (&m_master == target) ? JOB_MASTER : JOB_DPS;
     }
 }
 
 CombatManeuverReturns PlayerbotClassAI::CastSpellNoRanged(uint32 nextAction, Unit* pTarget)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
     if (nextAction == 0)
         return RETURN_NO_ACTION_OK; // Asked to do nothing so... yeh... Dooone.
 
     if (pTarget != nullptr)
-        return (m_ai->CastSpell(nextAction, *pTarget) == SPELL_CAST_OK ? RETURN_CONTINUE : RETURN_NO_ACTION_ERROR);
+        return (m_ai.CastSpell(nextAction, *pTarget) == SPELL_CAST_OK ? RETURN_CONTINUE : RETURN_NO_ACTION_ERROR);
     else
-        return (m_ai->CastSpell(nextAction) == SPELL_CAST_OK ? RETURN_CONTINUE : RETURN_NO_ACTION_ERROR);
+        return (m_ai.CastSpell(nextAction) == SPELL_CAST_OK ? RETURN_CONTINUE : RETURN_NO_ACTION_ERROR);
 }
 
 CombatManeuverReturns PlayerbotClassAI::CastSpellWand(uint32 nextAction, Unit* pTarget, uint32 SHOOT)
 {
-    if (!m_ai)  return RETURN_NO_ACTION_ERROR;
-    if (!m_bot) return RETURN_NO_ACTION_ERROR;
-
-    if (SHOOT > 0 && m_bot->FindCurrentSpellBySpellId(SHOOT) && m_bot->GetWeaponForAttack(RANGED_ATTACK, true, true))
+    if (SHOOT > 0 && m_bot.FindCurrentSpellBySpellId(SHOOT) && m_bot.GetWeaponForAttack(RANGED_ATTACK, true, true))
     {
         if (nextAction == SHOOT)
             // At this point we're already shooting and are asked to shoot. Don't cause a global cooldown by stopping to shoot! Leave it be.
             return RETURN_CONTINUE; // ... We're asked to shoot and are already shooting so... Task accomplished?
 
         // We are shooting but wish to cast a spell. Stop 'casting' shoot.
-        m_bot->InterruptNonMeleeSpells(true, SHOOT);
+        m_bot.InterruptNonMeleeSpells(true, SHOOT);
         // ai->TellMaster("Interrupting auto shot.");
     }
 
@@ -775,15 +740,15 @@ CombatManeuverReturns PlayerbotClassAI::CastSpellWand(uint32 nextAction, Unit* p
 
     if (nextAction == SHOOT)
     {
-        if (SHOOT > 0 && m_ai->GetCombatStyle() == PlayerbotAI::COMBAT_RANGED && !m_bot->FindCurrentSpellBySpellId(SHOOT) && m_bot->GetWeaponForAttack(RANGED_ATTACK, true, true))
-            return (m_ai->CastSpell(SHOOT, *pTarget) == SPELL_CAST_OK ? RETURN_CONTINUE : RETURN_NO_ACTION_ERROR);
+        if (SHOOT > 0 && m_ai.GetCombatStyle() == PlayerbotAI::COMBAT_RANGED && !m_bot.FindCurrentSpellBySpellId(SHOOT) && m_bot.GetWeaponForAttack(RANGED_ATTACK, true, true))
+            return (m_ai.CastSpell(SHOOT, *pTarget) == SPELL_CAST_OK ? RETURN_CONTINUE : RETURN_NO_ACTION_ERROR);
         else
             // Do Melee attack
             return RETURN_NO_ACTION_UNKNOWN; // We're asked to shoot and aren't.
     }
 
     if (pTarget != nullptr)
-        return (m_ai->CastSpell(nextAction, *pTarget) == SPELL_CAST_OK ? RETURN_CONTINUE : RETURN_NO_ACTION_ERROR);
+        return (m_ai.CastSpell(nextAction, *pTarget) == SPELL_CAST_OK ? RETURN_CONTINUE : RETURN_NO_ACTION_ERROR);
     else
-        return (m_ai->CastSpell(nextAction) == SPELL_CAST_OK ? RETURN_CONTINUE : RETURN_NO_ACTION_ERROR);
+        return (m_ai.CastSpell(nextAction) == SPELL_CAST_OK ? RETURN_CONTINUE : RETURN_NO_ACTION_ERROR);
 }

--- a/src/game/PlayerBot/Base/PlayerbotClassAI.h
+++ b/src/game/PlayerBot/Base/PlayerbotClassAI.h
@@ -76,9 +76,6 @@ class MANGOS_DLL_SPEC PlayerbotClassAI
         bool EatDrinkBandage(bool bMana = true, unsigned char foodPercent = 50, unsigned char drinkPercent = 50, unsigned char bandagePercent = 70);
 
         // Utilities
-        Player* GetMaster() { return &m_master; }
-        Player* GetPlayerBot() { return &m_bot; }
-        PlayerbotAI* GetAI() { return &m_ai; }
         bool CastHoTOnTank();
         JOB_TYPE GetBotJob(Player* target);
         JOB_TYPE GetTargetJob(Player* target);

--- a/src/game/PlayerBot/Base/PlayerbotClassAI.h
+++ b/src/game/PlayerBot/Base/PlayerbotClassAI.h
@@ -61,7 +61,7 @@ struct heal_priority
 class MANGOS_DLL_SPEC PlayerbotClassAI
 {
     public:
-        PlayerbotClassAI(Player* const master, Player* const bot, PlayerbotAI* const ai);
+        PlayerbotClassAI(Player& master, Player& bot, PlayerbotAI& ai);
         virtual ~PlayerbotClassAI();
 
         // all combat actions go here
@@ -76,14 +76,14 @@ class MANGOS_DLL_SPEC PlayerbotClassAI
         bool EatDrinkBandage(bool bMana = true, unsigned char foodPercent = 50, unsigned char drinkPercent = 50, unsigned char bandagePercent = 70);
 
         // Utilities
-        Player* GetMaster() { return m_master; }
-        Player* GetPlayerBot() { return m_bot; }
-        PlayerbotAI* GetAI() { return m_ai; }
+        Player* GetMaster() { return &m_master; }
+        Player* GetPlayerBot() { return &m_bot; }
+        PlayerbotAI* GetAI() { return &m_ai; }
         bool CastHoTOnTank();
         JOB_TYPE GetBotJob(Player* target);
         JOB_TYPE GetTargetJob(Player* target);
         time_t GetWaitUntil() { return m_WaitUntil; }
-        void SetWait(uint8 t) { m_WaitUntil = m_ai->CurrentTime() + t; }
+        void SetWait(uint8 t) { m_WaitUntil = m_ai.CurrentTime() + t; }
         void ClearWait() { m_WaitUntil = 0; }
         //void SetWaitUntil(time_t t) { m_WaitUntil = t; }
 
@@ -118,9 +118,9 @@ class MANGOS_DLL_SPEC PlayerbotClassAI
 
         time_t m_WaitUntil;
 
-        Player* m_master;
-        Player* m_bot;
-        PlayerbotAI* m_ai;
+        Player& m_master;
+        Player& m_bot;
+        PlayerbotAI& m_ai;
 
         // first aid
         uint32 RECENTLY_BANDAGED;

--- a/src/game/PlayerBot/Base/PlayerbotMgr.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotMgr.cpp
@@ -786,7 +786,7 @@ void PlayerbotMgr::OnBotLogin(Player* const bot)
     bot->GetSession()->QueuePacket(std::move(std::unique_ptr<WorldPacket>(pMSG_MOVE_FALL_LAND)));
 
     // give the bot some AI, object is owned by the player class
-    PlayerbotAI* ai = new PlayerbotAI(*this, bot);
+    PlayerbotAI* ai = new PlayerbotAI(*this, bot, m_confDebugWhisper);
     bot->SetPlayerbotAI(ai);
 
     // tell the world session that they now manage this new bot

--- a/src/game/PlayerBot/Base/PlayerbotMgr.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotMgr.cpp
@@ -786,7 +786,7 @@ void PlayerbotMgr::OnBotLogin(Player* const bot)
     bot->GetSession()->QueuePacket(std::move(std::unique_ptr<WorldPacket>(pMSG_MOVE_FALL_LAND)));
 
     // give the bot some AI, object is owned by the player class
-    PlayerbotAI* ai = new PlayerbotAI(this, bot);
+    PlayerbotAI* ai = new PlayerbotAI(*this, bot);
     bot->SetPlayerbotAI(ai);
 
     // tell the world session that they now manage this new bot


### PR DESCRIPTION
## 🍰 Pullrequest
I found the Playerbot code to be difficult to comprehend, because it uses nullable parameters everywhere.
In this PR I changed manager, master, bot, and ai from nullable pointers to references. This makes dead code and redundantly defensive programming obvious (code like `if (!always_set_pointer) return ERROR` or `if (always_set_pointer && f())`.

The code repeats itself a lot, therefore the changes in this PR are unfortunately many, but follow a fixed pattern. They were mostly performed using regex patterns. Mostly `a->b` had to be changed to `a.b`, and tautologies were removed (`if (!m_ai) return ERROR)` etc).

In a future PR I intend to do the same with targets, but didn't want to make this PR too big. I have already noticed a couple of bugs that I intend to submit fixes for thanks to these changes.

By the way, I think the Playerbot code could be simplified a lot by using behavior trees instead of a state machines (https://arxiv.org/pdf/1709.00084.pdf). Not sure how well one could retrofit this into the existing implementation, but there's a lot of duplication among class AIs right now. Playing a dungeon together with the AI also didn't feel "production ready", as bots will stop reacting quite often, run into mob groups to loot something, fail to crowd control, crowd control their kill target, etc. Perhaps this logic could be shared among different classes more easily with behavior trees, while reducing the complexity.

### How2Test
- Play with Playerbot bots. I ran Lower Blackrock Spire with 8 bots in a raid for ~20 minutes.
