### PR TITLE
Playerbot Mage AI: Fix Polymorph immunity check on wrong target

### DIFF
--- a/src/game/PlayerBot/AI/PlayerbotMageAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotMageAI.cpp
@@ -187,7 +187,7 @@ CombatManeuverReturns PlayerbotMageAI::DoNextCombatManeuverPVE(Unit* pTarget)
                 Creature* creature = (Creature*) newTarget;
                 if (creature->GetCreatureInfo()->CreatureType == CREATURE_TYPE_HUMANOID || creature->GetCreatureInfo()->CreatureType == CREATURE_TYPE_BEAST)
                 {
-                    if (POLYMORPH > 0 && !PlayerbotAI::IsImmuneToSchool(pTarget, SPELL_SCHOOL_MASK_ARCANE) && CastSpell(POLYMORPH, newTarget))
+                    if (POLYMORPH > 0 && !PlayerbotAI::IsImmuneToSchool(newTarget, SPELL_SCHOOL_MASK_ARCANE) && CastSpell(POLYMORPH, newTarget))
                         return RETURN_CONTINUE;
                 }
 


### PR DESCRIPTION
## 🍰 Pullrequest
The Playerbot mage AI will attempt to sheep elite mobs attacking it.
However the arcane magic immunity check is performed on the combat target, not on the attacking "target". This isn't necessarily the same.

### How2Test
- Add mage playerbot.
- Have mage attack a target immune to arcane magic.
- Have mage draw aggro from a beast.
- Mage will not try to sheep the beast, because his main target is immune to arcane magic.