### PR TITLE
Fix warrior overpower de-proc.

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -17682,13 +17682,14 @@ void Player::SendComboPoints()
         SetGuidValue(PLAYER_FIELD_COMBO_TARGET, combotarget->GetObjectGuid());
         SetByteValue(PLAYER_FIELD_BYTES, 1, GetComboPoints());
     }
-    /*else
+    else
     {
-        // can be nullptr, and then points=0. Use unknown; to reset points of some sort?
-        data << PackedGuid();
-        data << uint8(0);
-        GetSession()->SendPacket(data);
-    }*/
+		// can be nullptr, and then points=0. Use unknown; to reset points of some sort?		
+		// Overpower should be disabled after use (0 combo points) or when ReactiveTimer finishes.
+		// Spell grayed/notproced on client side as it should be if the warrior has no combo points, which they use for this spell to proc after victim dodges.
+		if (getClass() == CLASS_WARRIOR)
+			SetByteValue(PLAYER_FIELD_BYTES, 1, GetComboPoints());
+    }
 }
 
 void Player::SetGroup(Group* group, int8 subgroup)


### PR DESCRIPTION
## 🍰 Pullrequest
Overpower spell should not stay active in the client after combo points have been depleted or reactive timer ended.
When the target is nullptr we still update the byte field, which will de-proc the spell if combo points equal 0.

### Proof
- None

### Issues
- Read description.

### How2Test
- Create a warrior
- .learn all
- Hit a mob until it dodges and procs overpower.
- Use overpower
- Overpower spell remains active but unable to use due to no combo points.

### Todo / Checklist
- [x] None
