### PR TITLE
Fix compilation of WorldState.cpp missing GameEventMgr.h

### DIFF
--- a/src/game/World/WorldState.cpp
+++ b/src/game/World/WorldState.cpp
@@ -20,6 +20,7 @@
 #include "World/World.h"
 #include "Maps/MapManager.h"
 #include "Entities/Object.h"
+#include "GameEvents/GameEventMgr.h"
 #include <algorithm>
 #include <map>
 #include <World/WorldStateDefines.h>


### PR DESCRIPTION
## 🍰 Pullrequest
I was unable to compile mangos under Fedora Linux with Ninja due to a missing GameEventMgr.h include in WorldState.cpp when configuring the build with
```bash
cmake -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_INSTALL_PREFIX=mangos-classic-install -DDEBUG=0 -DBUILD_EXTRACTORS=ON -DPCH=OFF -S mangos-classic-source -B mangos-classic-build
```

### Proof
Error was:

```cpp
    [366/419] Building CXX object src/game/CMakeFiles/game.dir/World/WorldState.cpp.o
    FAILED: src/game/CMakeFiles/game.dir/World/WorldState.cpp.o
    /usr/bin/ccache /home/bogglez/bin/g++  -DBUILD_SCRIPTDEV -DDO_MYSQL -DDT_POLYREF64 -DMANGOS_DEBUG -DSYSCONFDIR=\"../etc/\" -D_DEBUG -D__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=0 -I/home/bogglez/projects/mangos/mangos-classic-source/src/game -I/home/bogglez/projects/mangos/mangos-classic-source/src/game/vmap -I/home/bogglez/projects/mangos/mangos-classic-source/src/game/AuctionHouseBot -I/home/bogglez/projects/mangos/mangos-classic-source/src/game/BattleGround -I/home/bogglez/projects/mangos/mangos-classic-source/src/game/OutdoorPvP -I/home/bogglez/projects/mangos/mangos-classic-source/src/game/PlayerBot -I. -I/home/bogglez/projects/mangos/mangos-classic-source/src/shared -I/usr/include/mysql -I/home/bogglez/projects/mangos/mangos-classic-source/src/framework -I/home/bogglez/projects/mangos/mangos-classic-source/dep/include/utf8cpp -I/home/bogglez/projects/mangos/mangos-classic-source/dep/src/utf8cpp -I/home/bogglez/projects/mangos/mangos-classic-source/dep/g3dlite -I/home/bogglez/projects/mangos/mangos-classic-source/dep/recastnavigation/Detour/Include -I/home/bogglez/projects/mangos/mangos-classic-source/dep/recastnavigation -std=c++11 -Wno-unused-result -Wno-psabi -g -MD -MT src/game/CMakeFiles/game.dir/World/WorldState.cpp.o -MF src/game/CMakeFiles/game.dir/World/WorldState.cpp.o.d -o src/game/CMakeFiles/game.dir/World/WorldState.cpp.o -c /home/bogglez/projects/mangos/mangos-classic-source/src/game/World/WorldState.cpp
    /home/bogglez/projects/mangos/mangos-classic-source/src/game/World/WorldState.cpp: In member function ‘void WorldState::StopWarEffortEvent()’:
    /home/bogglez/projects/mangos/mangos-classic-source/src/game/World/WorldState.cpp:568:43: error: ‘sGameEventMgr’ was not declared in this scope; did you mean ‘GameEvents’?
      568 |         case PHASE_1_GATHERING_RESOURCES: sGameEventMgr.StopEvent(GAME_EVENT_AHN_QIRAJ_EFFORT_PHASE_1); break;
          |                                           ^~~~~~~~~~~~~
          |                                           GameEvents
    /home/bogglez/projects/mangos/mangos-classic-source/src/game/World/WorldState.cpp: In member function ‘void WorldState::StartWarEffortEvent()’:
    /home/bogglez/projects/mangos/mangos-classic-source/src/game/World/WorldState.cpp:581:43: error: ‘sGameEventMgr’ was not declared in this scope; did you mean ‘GameEvents’?
      581 |         case PHASE_1_GATHERING_RESOURCES: sGameEventMgr.StartEvent(GAME_EVENT_AHN_QIRAJ_EFFORT_PHASE_1); break;
          |                                           ^~~~~~~~~~~~~
          |                                           GameEvents
    /home/bogglez/projects/mangos/mangos-classic-source/src/game/World/WorldState.cpp: In member function ‘void WorldState::FillInitialWorldStates(ByteBuffer&, uint32&, uint32)’:
    /home/bogglez/projects/mangos/mangos-classic-source/src/game/World/WorldState.cpp:608:9: error: ‘sGameEventMgr’ was not declared in this scope; did you mean ‘GameEvents’?
      608 |     if (sGameEventMgr.IsActiveHoliday(HOLIDAY_LOVE_IS_IN_THE_AIR))
          |         ^~~~~~~~~~~~~
          |         GameEvents
```

### How2Test
```bash
cmake -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_INSTALL_PREFIX=mangos-classic-install -DDEBUG=0 -DBUILD_EXTRACTORS=ON -DPCH=OFF -S mangos-classic-source -B mangos-classic-build
cd mangos-classic-build
ninja
```
