### PR TITLE
Fix build on Windows with multi-config generators like ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,10 +145,17 @@ set(LIBS_DIR ${CMAKE_INSTALL_PREFIX}/${LIBS_FOLDER_NAME})
 
 # On windows define more developpement folders and install provided libs
 if(WIN32)
+  # Determine whether generator generates multiple builds or only one
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.9)
+	get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+  elseif(CMAKE_CONFIGURATION_TYPES)
+	set(IS_MULTI_CONFIG TRUE)
+  endif()
+
   set(BIN_DIR ${CMAKE_INSTALL_PREFIX})
   set(LIBS_DIR ${BIN_DIR})
   set(CONF_DIR ${BIN_DIR})
-  if(MSVC)
+  if(MSVC AND IS_MULTI_CONFIG)
     set(DEV_BIN_DIR ${CMAKE_SOURCE_DIR}/${BIN_FOLDER_NAME}/${DEP_ARCH}_$(Configuration))
     set(DEV_PROVIDED_LIBS_FOLDER ${CMAKE_SOURCE_DIR}/dep/lib/${DEP_ARCH}_$(Configuration))
   else()


### PR DESCRIPTION
## 🍰 Pullrequest
Multi-config generators like MSVC support using multiple configurations like debug and release at the same time.
Meanwhile single-config generators like ninja and make only support one build config per generated cmake build.
This fix makes it possible to use ninja together with the MSVC compiler cl to compile windows builds.

### Issues
```sh
$ git checkout master
$ cmake -GNinja -DCMAKE_INSTALL_PREFIX=D:\projects\mangos\build -DDEBUG=ON -DBUILD_PLAYERBOT=OFF -DPCH=OFF -DBOOST_ROOT=D:\projects\mangos\boost-install -S D:\projects\mangos\mangos-classic-source -B D:\projects\mangos\build
$ ninja -C build
ninja: error: build.ninja:1682: bad $-escape (literal $ must be written as $$)
```

### How2Test
```sh
$ git checkout feature_fix_ninja_build
$ cmake -GNinja -DCMAKE_INSTALL_PREFIX=D:\projects\mangos\build -DDEBUG=ON -DBUILD_PLAYERBOT=OFF -DPCH=OFF -DBOOST_ROOT=D:\projects\mangos\boost-install -S D:\projects\mangos\mangos-classic-source -B D:\projects\mangos\build
$ ninja -C build
ninja: Entering directory `D:\projects\mangos\mangos-classic-build-windows-msvc'
[205/484] Building CXX object src\game\CMakeFiles\game.dir\AuctionHouseBot\AuctionHouseBot.cpp.obj
D:\projects\mangos\mangos-classic-source\src\game\AuctionHouseBot\AuctionHouseBot.cpp(181): warning C4018: '<': signed/unsigned mismatch
D:\projects\mangos\mangos-classic-source\src\game\AuctionHouseBot\AuctionHouseBot.cpp(463): warning C4018: '<': signed/unsigned mismatch
[233/484] Building CXX object src\game\CMakeFiles\game.dir\Entities\GameObject.cpp.obj
D:\projects\mangos\mangos-classic-source\src\game\Entities\GameObject.cpp(432): warning C4018: '>=': signed/unsigned mismatch
[356/484] Linking CXX static library src\shared\shared.lib
D:\projects\mangos\mangos-classic-source\dep\lib\x64_Debug\libcrypto-1_1-x64.dll
D:\projects\mangos\mangos-classic-source\dep\lib\x64_Debug\libmySQL.dll
2 File(s) copied
[464/484] Building RC object src\mangosd\CMakeFiles\mangosd.dir\mangosd.rc.res
Microsoft (R) Windows (R) Resource Compiler Version 10.0.10011.16384
Copyright (C) Microsoft Corporation.  All rights reserved.

[468/484] Building RC object src\realmd\CMakeFiles\realmd.dir\realmd.rc.res
Microsoft (R) Windows (R) Resource Compiler Version 10.0.10011.16384
Copyright (C) Microsoft Corporation.  All rights reserved.

[484/484] Linking CXX executable D:\projects\mangos\mangos-classic-source\bin\x64_Debug\mangosd.exe
   Creating library src\mangosd\mangosd.lib and object src\mangosd\mangosd.exp
```

Benchmark
=========
While I was at it I benchmarked ninja, msbuild, and devenv with and without PCH:

Result
------
1. 30.4s ninja PCH
2. 39.2s devenv PCH
3. 40.8s msbuild PCH
4. 193.5s ninja
5. 202.1s devenv
6. 203.4s msbuild

Preparation
-------------
The benchmark software is `hyperfine`, and can be installed with Rust's `cargo install hyperfine`.
The disk cache is warmed up first, then 3 runs are averaged. The build directory `bench` is deleted before each run.
Call `vcvars64.bat` first for Visual Studio environment.

```sh
"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
```

Benchmark 1: ninja
--------------------------
```sh
$ hyperfine --warmup 2 --runs 3 --prepare "if exist bench rd /q /s bench" "cmake -GNinja -DCMAKE_INSTALL_PREFIX=bench -DDEBUG=ON -DPCH=OFF -DBOOST_ROOT=D:\projects\mangos\boost-install -S mangos-classic-source -B bench && ninja -C bench"
  Time (mean ± σ):     193.499 s ±  0.679 s    [User: 0.0 ms, System: 13.8 ms]                                                                                                                                                                           
  Range (min … max):   192.956 s … 194.260 s    3 runs
```


Benchmark 2: ninja PCH
----------------------
```sh
$ hyperfine --warmup 2 --runs 3 --prepare "if exist bench rd /q /s bench" "cmake -GNinja -DCMAKE_INSTALL_PREFIX=bench -DDEBUG=ON -DPCH=ON -DBOOST_ROOT=D:\projects\mangos\boost-install -S mangos-classic-source -B bench && ninja -C bench"
  Time (mean ± σ):     30.408 s ±  0.119 s    [User: 4.9 ms, System: 12.8 ms]                                                                                                                                                                            
  Range (min … max):   30.322 s … 30.543 s    3 runs
```

Benchmark 3: msbuild
-------------------------
```sh
$ hyperfine --warmup 2 --runs 3 --prepare "if exist bench rd /q /s bench" "cmake -DCMAKE_INSTALL_PREFIX=bench -DDEBUG=ON -DPCH=OFF -DBOOST_ROOT=D:\projects\mangos\boost-install -S mangos-classic-source -B bench && msbuild bench\CMaNGOS_Classic.sln -p:Configuration=Debug"
  Time (mean ± σ):     203.357 s ±  0.229 s    [User: 4.9 ms, System: 8.4 ms]                                                                                                            
  Range (min … max):   203.123 s … 203.582 s    3 runs
```

Benchmark 4: msbuild PCH
----------------------
```sh
$ hyperfine --warmup 2 --runs 3 --prepare "if exist bench rd /q /s bench" "cmake -DCMAKE_INSTALL_PREFIX=bench -DDEBUG=ON -DPCH=ON -DBOOST_ROOT=D:\projects\mangos\boost-install -S mangos-classic-source -B bench && msbuild bench\CMaNGOS_Classic.sln -p:Configuration=Debug"
  Time (mean ± σ):     40.772 s ±  0.051 s    [User: 0.0 ms, System: 8.5 ms]                                                                                                             
  Range (min … max):   40.716 s … 40.816 s    3 runs
```

Benchmark 5: devenv
------------------------
```sh
$ hyperfine --warmup 2 --runs 3 --prepare "if exist bench rd /q /s bench" "cmake -DCMAKE_INSTALL_PREFIX=bench -DDEBUG=ON -DPCH=OFF -DBOOST_ROOT=D:\projects\mangos\boost-install -S mangos-classic-source -B bench && devenv.com bench\CMaNGOS_Classic.sln /Build Debug"
  Time (mean ± σ):     202.051 s ±  0.636 s    [User: 0.0 ms, System: 14.0 ms]                                                                                                           
  Range (min … max):   201.345 s … 202.580 s    3 runs
```

Benchmark 6: devenv PCH
------------------------
```sh
$ hyperfine --warmup 2 --runs 3 --prepare "if exist bench rd /q /s bench" "cmake -DCMAKE_INSTALL_PREFIX=bench -DDEBUG=ON -DPCH=ON -DBOOST_ROOT=D:\projects\mangos\boost-install -S mangos-classic-source -B bench && devenv.com bench\CMaNGOS_Classic.sln /Build Debug"
  Time (mean ± σ):     39.239 s ±  0.497 s    [User: 0.0 ms, System: 0.0 ms]                                                                                                             
  Range (min … max):   38.751 s … 39.745 s    3 runs
```