### PR TITLE
ZG: high priests reduce Hakkar's strength properly on death

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/zulgurub/boss_hakkar.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/zulgurub/boss_hakkar.cpp
@@ -82,6 +82,13 @@ struct boss_hakkarAI : public ScriptedAI
         m_uiAspectOfArlokkTimer    = 18000;
     }
 
+    void JustReachedHome() override
+    {
+        // have to redo Hakkar Power stacks after reset
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_HAKKAR, FAIL);
+    }
+
     void Aggro(Unit* /*who*/) override
     {
         DoScriptText(SAY_AGGRO, m_creature);

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/zulgurub/zulgurub.h
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/zulgurub/zulgurub.h
@@ -18,6 +18,7 @@ enum
     TYPE_OHGAN              = 5,                            // Do not change, used by Acid
     TYPE_LORKHAN            = 6,
     TYPE_ZATH               = 7,
+    TYPE_HAKKAR             = 8,
 
     NPC_LORKHAN             = 11347,
     NPC_ZATH                = 11348,
@@ -35,10 +36,10 @@ enum
     SAY_MINION_DESTROY      = -1309022,
     SAY_HAKKAR_PROTECT      = -1309023,
 
-    HP_LOSS_PER_PRIEST      = 60000,
-
     AREATRIGGER_ENTER       = 3958,
     AREATRIGGER_ALTAR       = 3960,
+
+    SPELL_HAKKAR_POWER      = 24692,
 };
 
 static const float aMandokirDownstairsPos[3] = { -12196.30f, -1948.37f, 130.31f};
@@ -67,7 +68,7 @@ class instance_zulgurub : public ScriptedInstance
         Creature* SelectRandomPantherTrigger(bool bIsLeft);
 
     protected:
-        void DoLowerHakkarHitPoints();
+        void DoHakkarPowerStacks();
 
         uint32 m_auiEncounter[MAX_ENCOUNTER];
         std::string m_strInstData;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
High priests in ZG remove a flat amount of health from Hakkar on death, instead they should remove a stack of [Hakkar Power](https://classic.wowhead.com/spell=24692/) aura. This results in Hakkar having incorrect health, size and damage modifier.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes cmangos/issues#2189

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Go to Hakkar in ZG (.go creature 49678)
- Inspect health, size and damage ( /run DEFAULT_CHAT_FRAME:AddMessage(UnitHealth("target")) )
- Kill high priest(s) (.go creature 49194/49199/49258/49310 , .go object 3090209)
- Repeat

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
