### PR TITLE
EffectMiscValueB1 replaced with EffectMiscValue1

### DIFF
--- a/sql/base/dbc/cmangos_fixes/Spell.sql
+++ b/sql/base/dbc/cmangos_fixes/Spell.sql
@@ -151,7 +151,7 @@ UPDATE `spell_template` SET `EffectImplicitTargetA1` = 6 WHERE `Id` IN (25744,25
 UPDATE spell_template SET EffectImplicitTargetA1=38 WHERE id=16007; -- 46
 
 -- Stationary Dark Iron Land Mine 8035
-UPDATE `spell_template` SET `EffectMiscValueB1` = 64 WHERE `Id` = 11802;
+UPDATE `spell_template` SET `EffectMiscValue1` = 64 WHERE `Id` = 11802;
 
 -- Flare - no delay is present here for stealth breaking - confirmed on classic
 UPDATE spell_template SET Speed=0 WHERE id=1543; -- 5
@@ -163,14 +163,14 @@ UPDATE spell_template SET EffectRadiusIndex1=15 WHERE Id IN(126);
 UPDATE spell_template SET ManaCost=0 WHERE Id IN(20647);
 
 -- Stationary Advanced Target Dummy 2674
-UPDATE `spell_template` SET `EffectMiscValueB1` = 64 WHERE `Id` = 4072;
+UPDATE `spell_template` SET `EffectMiscValue1` = 64 WHERE `Id` = 4072;
 
 -- Baron Rivendare 10440 does not enter combat and move while "channeling" Unholy Aura 17467
 UPDATE `spell_template` SET `AttributesEx3`=AttributesEx3|0x00020000 WHERE `Id` = 17466; -- SPELL_ATTR_EX3_NO_INITIAL_AGGRO
 UPDATE `spell_template` SET `AttributesEx` = `AttributesEx`&~0x00000004 WHERE `Id` = 17467; -- SPELL_ATTR_EX_CHANNELED_1
 
 -- Stationary Scarshield Portal 9707
-UPDATE `spell_template` SET `EffectMiscValueB1` = 64 WHERE `Id` = 15125;
+UPDATE `spell_template` SET `EffectMiscValue1` = 64 WHERE `Id` = 15125;
 
 -- Remove SPELL_INTERRUPT_FLAG_ABORT_ON_DMG from Spells falsly interrupted by damage
 UPDATE `spell_template` SET `InterruptFlags` = `InterruptFlags`&~0x00000010 WHERE `Id` IN (


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
While setting up Cmangos from the scratch, DB setup failed at some point with 

`ERROR 1054 (42S22) at line 154: Unknown column 'EffectMiscValueB1' in 'field list'`

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create new `classicmangos` DB and apply all the patches. You can also try with InstallDB script, all should be good

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
