### PR TITLE
Prevent stealth ability from getting stuck when Fearie Fired

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -4214,6 +4214,17 @@ SpellCastResult Spell::CheckCast(bool strict)
         return SPELL_FAILED_CASTER_AURASTATE;
 
     Unit* target = m_targets.getUnitTarget();
+    uint32 affectedMask = GetCheckCastEffectMask(m_spellInfo);
+    // Check if caster is prevented from entering stealth/invisibility (e.g. Faerie Fire)
+    if (!target)
+    {
+        uint32 selfImmuneMask = GetCheckCastSelfEffectMask(m_spellInfo);
+        if (selfImmuneMask)
+        {
+            target = m_caster;
+            affectedMask = selfImmuneMask;
+        }
+    }
     if (target)
     {
         // TARGET_UNIT_SCRIPT_NEAR_CASTER fills unit target per client requirement but should not be checked against common things

--- a/src/game/Spells/Spell.h
+++ b/src/game/Spells/Spell.h
@@ -383,6 +383,53 @@ class Spell
         void TakeReagents();
         void TakeCastItem();
 
+        inline bool HasSpellTarget(SpellEntry const* spellInfo, uint32 target)
+        {
+            for (uint32 i = 0; i < MAX_EFFECT_INDEX; ++i)
+                if (spellInfo->EffectImplicitTargetA[i] == target)
+                    return true;
+
+            return false;
+        }
+
+        inline uint32 GetCheckCastSelfEffectMask(SpellEntry const* spellInfo)
+        {
+            uint32 resultingMask = 0;
+            for (uint32 i = 0; i < MAX_EFFECT_INDEX; ++i)
+                if (HasSpellTarget(spellInfo, TARGET_UNIT_CASTER))
+                    resultingMask |= (1 << i);
+            return resultingMask;
+        }
+
+        inline uint32 GetCheckCastEffectMask(SpellEntry const* spellInfo)
+        {
+            uint32 resultingMask = 0;
+            for (uint32 i = 0; i < MAX_EFFECT_INDEX; ++i)
+                if (IsCheckCastTarget(spellInfo->EffectImplicitTargetA[i]) || IsCheckCastTarget(spellInfo->EffectImplicitTargetB[i]))
+                    resultingMask |= (1 << i);
+            return resultingMask;
+        }
+
+        inline bool IsCheckCastTarget(uint32 target)
+        {
+            // copy of checkcast block for attackability and assistability
+            auto& data = SpellTargetInfoTable[target];
+            if (data.type == TARGET_TYPE_UNIT && data.filter != TARGET_SCRIPT && (data.enumerator == TARGET_ENUMERATOR_SINGLE || data.enumerator == TARGET_ENUMERATOR_CHAIN))
+            {
+                switch (target)
+                {
+                    case TARGET_UNIT_ENEMY_NEAR_CASTER:
+                    case TARGET_UNIT_FRIEND_NEAR_CASTER:
+                    case TARGET_UNIT_NEAR_CASTER:
+                    case TARGET_UNIT_CASTER_MASTER:
+                    case TARGET_UNIT_CASTER: break; // never check anything
+                    default: return true;
+                }
+            }
+
+            return false;
+        }
+
         SpellCastResult CheckCast(bool strict);
         SpellCastResult CheckPetCast(Unit* target);
 


### PR DESCRIPTION
## 🍰 Pullrequest
Attempting to cast Stealth while under the influence of Faerie Fire resulted in Stealth ability becoming permanently locked until the player relogged.
This may not be a perfect solution, but it does improve on an annoying bug.
I've tested Prowl (Druid), Shadowmeld (Night Elf), Stealth (Rogue), Vanish (Rogue) and "Lesser Invisibility Potion".
Prowl, Shadowmeld, Stealth and the potion were all prevented from being used. Potion was not lost.
Vanish was not prevented, ability entered cooldown and a Flash Powder was consumed. It looks like it's correct behavior that Faerie Fire prevents Vanish from working, but I'm uncertain whether it's correct that ability should enter cooldown and a reagent to be consumed.

Credit where credit is due; @darklordsqk wrote the patch for resolving this issue. I slightly modified the code and moved it to `CheckCast()` rather than `CheckCasterAuras()`, but I'm not sure whether that was an improvement.

### Proof
- None

### Issues
- Fixes https://github.com/cmangos/issues/issues/1880

### How2Test
- .aura 9907 (Faerie Fire debuff)
- Attempt to stealth, fails with "You can't do that yet", stealth ability will not become permanently locked after this patch

### Todo / Checklist
- See pull description