### PR TITLE
Replaced "my_bool" with "bool" used by newer MySQL

### DIFF
--- a/src/shared/Database/DatabaseMysql.cpp
+++ b/src/shared/Database/DatabaseMysql.cpp
@@ -417,7 +417,7 @@ void MySqlPreparedStatement::addParam(unsigned int nIndex, const SqlStmtFieldDat
 
     MYSQL_BIND& pData = m_pInputArgs[nIndex];
 
-    my_bool bUnsigned = 0;
+    bool bUnsigned = 0;
     enum_field_types dataType = ToMySQLType(data, bUnsigned);
 
     // setup MYSQL_BIND structure
@@ -462,7 +462,7 @@ bool MySqlPreparedStatement::execute()
     return true;
 }
 
-enum_field_types MySqlPreparedStatement::ToMySQLType(const SqlStmtFieldData& data, my_bool& bUnsigned)
+enum_field_types MySqlPreparedStatement::ToMySQLType(const SqlStmtFieldData& data, bool& bUnsigned)
 {
     bUnsigned = 0;
     enum_field_types dataType = MYSQL_TYPE_NULL;

--- a/src/shared/Database/DatabaseMysql.h
+++ b/src/shared/Database/DatabaseMysql.h
@@ -47,7 +47,7 @@ class MySqlPreparedStatement : public SqlPreparedStatement
         // bind parameters
         void addParam(unsigned int nIndex, const SqlStmtFieldData& data);
 
-        static enum_field_types ToMySQLType(const SqlStmtFieldData& data, my_bool& bUnsigned);
+        static enum_field_types ToMySQLType(const SqlStmtFieldData& data, bool& bUnsigned);
 
     private:
         void RemoveBinds();


### PR DESCRIPTION
## 🍰 Pullrequest
The cores use an outdated `my_bool` datatype which was removed from MySQL in version 8.0.1.
According to a MySQL dev: «The recommended fix is to use bool or int, which will work both in 8.0 and older versions.»

### Proof
- https://bugs.mysql.com/bug.php?id=85131

### Issues
- https://github.com/cmangos/issues/issues/2285

### How2Test
- None

### Todo / Checklist
- I've not built any cores on Windows, but classic core compiles fine both in Ubuntu:focal (libmysqlclient-dev) and ubuntu:bionic (libmysqlclient20) when datatype is changed from "my_bool" to "bool".
- [ ] Check for (unprotected) usage of reserved words in MySQL (there are no issues with MariaDB), e.g: https://github.com/cmangos/mangos-classic/commit/b2a4ffbf2bad3b7a1d515edd6bca71dc1d3c080d