### PR TITLE
Update DatabaseMysql.h for mySQL 8.x.x or MariaDB 

### DIFF
--- a/src/shared/Database/DatabaseMysql.h
+++ b/src/shared/Database/DatabaseMysql.h
@@ -27,6 +27,10 @@
 
 #include <mysql.h>
 
+#if MYSQL_VERSION_ID >= 80001
+typedef bool my_bool;
+#endif
+
 // MySQL prepared statement class
 class MySqlPreparedStatement : public SqlPreparedStatement
 {


### PR DESCRIPTION
## 🍰 Pullrequest
Juste allow mySQL 8.x.x or MariaDB

### Issues
Fixes this error on last mySQL or MariaDB version
```
error: ‘my_bool’ has not been declared
   50 |         static enum_field_types ToMySQLType(const SqlStmtFieldData& data, my_bool& bUnsigned);
```

### How2Test
- Just compile ;)
