### PR TITLE
Fix BG score list & queue update

### DIFF
--- a/src/game/BattleGround/BattleGroundHandler.cpp
+++ b/src/game/BattleGround/BattleGroundHandler.cpp
@@ -213,6 +213,8 @@ void WorldSession::HandleBattlemasterJoinOpcode(WorldPacket& recv_data)
         SendPacket(data);
         DEBUG_LOG("Battleground: player joined queue for bg queue type %u bg type %u: GUID %u, NAME %s", bgQueueTypeId, bgTypeId, _player->GetGUIDLow(), _player->GetName());
     }
+
+    sBattleGroundMgr.ScheduleQueueUpdate(bgQueueTypeId, bgTypeId, _player->GetBattleGroundBracketIdFromLevel(bgTypeId));
 }
 
 // Sent by client while inside battleground; depends on the battleground type

--- a/src/game/BattleGround/BattleGroundMgr.cpp
+++ b/src/game/BattleGround/BattleGroundMgr.cpp
@@ -1047,7 +1047,6 @@ void BattleGroundMgr::BuildPvpLogDataPacket(WorldPacket& data, BattleGround* bg)
         data << uint32(plr ? plr->GetHonorRankInfo().visualRank : 0);
         data << uint32(itr->second->killingBlows);
         data << uint32(itr->second->honorableKills);
-        data << uint32(itr->second->dishonorableKills);
         data << uint32(itr->second->deaths);
         data << uint32(itr->second->bonusHonor);
 

--- a/src/game/BattleGround/BattleGroundMgr.cpp
+++ b/src/game/BattleGround/BattleGroundMgr.cpp
@@ -1044,7 +1044,7 @@ void BattleGroundMgr::BuildPvpLogDataPacket(WorldPacket& data, BattleGround* bg)
 
         Player* plr = sObjectMgr.GetPlayer(itr->first);
 
-        data << uint32(plr ? plr->GetHonorRankInfo().visualRank : 0);
+        data << uint32(plr ? plr->GetHonorRankInfo().rank : 4);
         data << uint32(itr->second->killingBlows);
         data << uint32(itr->second->honorableKills);
         data << uint32(itr->second->deaths);


### PR DESCRIPTION
## 🍰 Pullrequest
 - Fix: empty BG scores
 - Fix: BG queue is not updated when player joins queue

Note:  To fix score list I compared cmangos-classic with mangos_zero + vmangos.
Note:  To fix BG queue I compared mangos-classic with mangos-tbc/wotlk
Note:  Rank fix is from vmangos
### Proof
BG Queue - https://github.com/cmangos/mangos-tbc/blob/4098a6ca19bee27f808a85565ee5b2915bbced48/src/game/BattleGround/BattleGroundHandler.cpp#L219
Scores - https://github.com/vmangos/core/blob/ca6dd2f02dc7cf24b38a4e55db1c3ec34b8fea6c/src/game/Battlegrounds/BattleGroundMgr.cpp#L1052
Rank display in score (character Orcadmin has HW rank):
Pre fix (look at icon): https://cdn.discordapp.com/attachments/788137519665381407/836902020198825984/unknown.png
Post fix: https://cdn.discordapp.com/attachments/788137519665381407/836932710886277130/unknown.png

### How2Test
1) Test queue : start classic, do .debug bg, and queue. BG invite will not appear.
2) Test scores : enter BG - list is empty even after win.
3) Test rank : give yourself any rank, enter BG - your rank in list will be 4 ranks lower than actual rank