### PR TITLE
Improve mmap generator

### DIFF
--- a/contrib/extractor_scripts/ExtractResources.sh
+++ b/contrib/extractor_scripts/ExtractResources.sh
@@ -12,7 +12,7 @@
 
 ## Expected param 1 to be 'a' for all, else ask some questions
 
-## Normal log file (if not overwritten by second param
+## Normal log file (if not overwritten by second param)
 LOG_FILE="MaNGOSExtractor.log"
 ## Detailed log file
 DETAIL_LOG_FILE="MaNGOSExtractor_detailed.log"

--- a/contrib/extractor_scripts/ExtractResources.sh
+++ b/contrib/extractor_scripts/ExtractResources.sh
@@ -39,7 +39,7 @@ else
   ## do some questioning!
   echo
   echo "Welcome to helper script to extract required dataz for MaNGOS!"
-  echo "Should all dataz (dbc, maps, vmaps and mmaps be extracted? (y/n)"
+  echo "Should all dataz (dbc, maps, vmaps and mmaps) be extracted? (y/n)"
   read line
   if [ "$line" = "y" ]
   then
@@ -60,7 +60,7 @@ else
 
     echo
     echo "Should mmaps be extracted? (y/n)"
-    echo "WARNING! This will take several hours! (you can later tell to start delayed)"
+    echo "WARNING! This may take several hours with small number of CPU threads!"
     read line
     if [ "$line" = "y" ]
     then
@@ -80,7 +80,7 @@ fi
 ## Special case: Only reextract offmesh tiles
 if [ "$USE_MMAPS_OFFMESH" = "1" ]
 then
-  echo "Only extracting offmesh meshes"
+  echo "Only extracting offmesh tiles"
   MoveMapGen.sh offmesh $LOG_FILE $DETAIL_LOG_FILE
   exit 0
 fi

--- a/contrib/extractor_scripts/ExtractResources.sh
+++ b/contrib/extractor_scripts/ExtractResources.sh
@@ -17,9 +17,6 @@ LOG_FILE="MaNGOSExtractor.log"
 ## Detailed log file
 DETAIL_LOG_FILE="MaNGOSExtractor_detailed.log"
 
-## Change this to a value fitting for your sys!
-NUM_THREAD="2"
-
 ## ! Use below only for finetuning or if you know what you are doing !
 
 USE_AD="0"
@@ -29,6 +26,7 @@ USE_MMAPS_OFFMESH="0"
 USE_MMAPS_DELAY=""
 AD_RES=""
 VMAP_RES=""
+NUM_THREAD=""
 
 if [ "$1" = "a" ]
 then
@@ -91,14 +89,18 @@ fi
 if [ "$USE_MMAPS" = "1" ]
 then
   ## Obtain number of processes
-  echo "How many CPU threads should be used for extracting mmaps? (1, 2, 4, 8)"
+  echo "How many CPU threads should be used for extracting mmaps? (leave empty to use all available threads)"
   read line
   echo
-  if [ $line -eq 1 ] || [ $line -eq 2 ] || [ $line -eq 4 ] || [ $line -eq 8 ]; then
-    NUM_THREAD=$line
+  if [[ ! -z $line ]]; then
+    if [[ $line =~ ^[1-9+]$ ]]; then
+      NUM_THREAD=$line
+    else
+      echo "Only numbers are allowed!"
+      exit 1
+    fi
   else
-    echo "Only numbers 1,2,4 and 8 are supported!"
-    exit 1
+    NUM_THREAD="all"
   fi
   ## Extract MMaps delayed?
   if [ "$USE_MMAPS_DELAY" != "no" ]; then
@@ -174,13 +176,13 @@ else
 fi
 if [ "$USE_MMAPS" = "1" ]
 then
-  echo "Mmaps will be extracted with $NUM_THREAD processes" | tee -a $LOG_FILE
+  echo "Mmaps will be extracted using $NUM_THREAD CPU threads" | tee -a $LOG_FILE
 else
   echo "Mmaps files won't be extracted!" | tee -a $LOG_FILE
 fi
 echo | tee -a $LOG_FILE
 
-echo "$(date): Start extracting dataz for MaNGOS, DBCs/maps $USE_AD, vmaps $USE_VMAPS, mmaps $USE_MMAPS on $NUM_THREAD processes" | tee $DETAIL_LOG_FILE
+echo "$(date): Start extracting MaNGOS data: DBCs/maps $USE_AD, vmaps $USE_VMAPS, mmaps $USE_MMAPS using $NUM_THREAD CPU threads" | tee $DETAIL_LOG_FILE
 echo | tee -a $DETAIL_LOG_FILE
 
 ## Extract dbcs and maps
@@ -216,5 +218,5 @@ then
     echo "Current time: $(date)"
     sleep $USE_MMAPS_DELAY
   fi
-  sh MoveMapGen.sh $NUM_THREAD $LOG_FILE $DETAIL_LOG_FILE
+  sh MoveMapGen.sh "maps" $LOG_FILE $DETAIL_LOG_FILE $NUM_THREAD
 fi

--- a/contrib/extractor_scripts/MoveMapGen.sh
+++ b/contrib/extractor_scripts/MoveMapGen.sh
@@ -102,8 +102,8 @@ case "$1" in
     ./MoveMapGen $MAPS_LIST $PARAMS $OFFMESH --buildGameObjects | tee -a $DETAIL_LOG_FILE
    ;;
  "offmesh" )
-   echo "`date`: Recreate offmeshs from file $OFFMESH_FILE" | tee -a $LOG_FILE
-   echo "Recreate offmeshs from file $OFFMESH_FILE" | tee -a $DETAIL_LOG_FILE
+   echo "`date`: Recreate offmeshes from file $OFFMESH_FILE" | tee -a $LOG_FILE
+   echo "Recreate offmeshes from file $OFFMESH_FILE" | tee -a $DETAIL_LOG_FILE
    while read map tile line
    do
      ./MoveMapGen $PARAMS $OFFMESH $map --tile $tile | tee -a $DETAIL_LOG_FILE

--- a/contrib/extractor_scripts/MoveMapGen.sh
+++ b/contrib/extractor_scripts/MoveMapGen.sh
@@ -11,9 +11,10 @@
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 ## Syntax of this helper
-## First param must be number of to be used CPUs (only 1, 2, 3, 4 supported) or "offmesh" to recreate the special tiles from the OFFMESH_FILE
-## Second param can be an additional filename for storing log
-## Third param can be an addition filename for storing detailed log
+## 1st param must be "maps" to generate the maps and offmesh or "offmesh" to recreate the special tiles from the OFFMESH_FILE
+## 2nd param may be an additional filename for storing log
+## 3rd param may be an addition filename for storing detailed log
+## 4th param may be a number of threads to use for maps processing
 
 ## Additional Parameters to be forwarded to MoveMapGen, see mmaps/readme for instructions
 PARAMS="--silent --configInputPath config.json"
@@ -30,18 +31,10 @@ LOG_FILE="MoveMapGen.log"
 ## Detailed log file
 DETAIL_LOG_FILE="MoveMapGen_detailed.log"
 
-## ! Use below only for finetuning or if you know what you are doing !
+## ! Edit the script below only if you know what you are doing !
 
 ## All maps
-LIST_A="1"
-LIST_B="0"
-LIST_C="169"
-LIST_D="269 533 35 44 389 129 109 450 34 249 48"
-LIST_E="531 37 309 369"
-LIST_F="229 409 43 70 90 189"
-LIST_G="36 33 209 451 47"
-LIST_H="509 30 289 230"
-LIST_I="42 449 25 529 489 329 429 349 469 13"
+MAPS_LIST="1 0 169 269 533 35 44 389 129 109 450 34 249 48 531 37 309 369 229 409 43 70 90 189 36 33 209 451 47 509 30 289 230 42 449 25 529 489 329 429 349 469 13"
 
 badParam()
 {
@@ -49,20 +42,26 @@ badParam()
  echo "You can (re)extract mmaps with this helper script,"
  echo "or recreate only the tiles from the offmash file"
  echo
- echo "Call with number of processes (1 - 4) to create mmaps"
+ echo "Call with 'maps' to create mmaps"
  echo "Call with 'offmesh' to reextract the tiles from offmash file"
- echo
- echo "For further fine-tuning edit this helper script"
  echo
 }
 
-if [ "$#" = "3" ]
+if [ "$#" = "4" ]
 then
- LOG_FILE=$2
- DETAIL_LOG_FILE=$3
+  LOG_FILE=$2
+  DETAIL_LOG_FILE=$3
+  if [ "$4" != "all" ]
+  then
+    PARAMS="${PARAMS} --threads $4"
+  fi
+elif [ "$#" = "3" ]
+then
+  LOG_FILE=$2
+  DETAIL_LOG_FILE=$3
 elif [ "$#" = "2" ]
 then
- LOG_FILE=$2
+  LOG_FILE=$2
 fi
 
 # Offmesh file provided?
@@ -79,23 +78,6 @@ then
  fi
 fi
 
-# Function to process a list
-createMMaps()
-{
- for i in $@
- do
-   for j in $EXCLUDE_MAPS
-   do
-     if [ "$i" = "$j" ]
-     then
-       continue 2
-     fi
-   done
-   ./MoveMapGen $PARAMS $OFFMESH $i | tee -a $DETAIL_LOG_FILE
-   echo "`date`: (Re)created map $i" | tee -a $LOG_FILE
- done
-}
-
 createHeader()
 {
  echo "`date`: Start creating MoveMaps" | tee -a $LOG_FILE
@@ -103,7 +85,7 @@ createHeader()
  echo "Detailed log can be found in $DETAIL_LOG_FILE" | tee -a $LOG_FILE
  echo "Start creating MoveMaps" | tee -a $DETAIL_LOG_FILE
  echo
- echo "Be PATIENT - This will take a long time and might also have gaps between visible changes on the console."
+ echo "Be PATIENT - This may take a long time with small number of threads and might also have gaps between visible changes on the console."
  echo "WAIT until you are informed that 'creating MoveMaps' is 'finished'!"
 }
 
@@ -115,36 +97,9 @@ fi
 
 # Param control
 case "$1" in
- "1" )
-   createHeader $1
-   createMMaps $LIST_A $LIST_B $LIST_C $LIST_D $LIST_F $LIST_G $LIST_H $LIST_I &
-   ./MoveMapGen $PARAMS $OFFMESH --onlyGO
-   ;;
- "2" )
-   createHeader $1
-   createMMaps $LIST_A $LIST_E $LIST_H $LIST_I &
-   createMMaps $LIST_B $LIST_C $LIST_D $LIST_F $LIST_G &
-   ./MoveMapGen $PARAMS $OFFMESH --onlyGO
-   ;;
- "4" )
-   createHeader $1
-   createMMaps $LIST_A &
-   createMMaps $LIST_B &
-   createMMaps $LIST_C $LIST_F $LIST_G &
-   createMMaps $LIST_D $LIST_E $LIST_H $LIST_I &
-   ./MoveMapGen $PARAMS $OFFMESH --onlyGO
-   ;;
- "8" )
-   createHeader $1
-   createMMaps $LIST_A &
-   createMMaps $LIST_B &
-   createMMaps $LIST_C &
-   createMMaps $LIST_D &
-   createMMaps $LIST_E &
-   createMMaps $LIST_F $LIST_H &
-   createMMaps $LIST_G &
-   createMMaps $LIST_I &
-   ./MoveMapGen $PARAMS $OFFMESH --onlyGO
+ "maps" )
+    createHeader
+    ./MoveMapGen $MAPS_LIST $PARAMS $OFFMESH --buildGameObjects | tee -a $DETAIL_LOG_FILE
    ;;
  "offmesh" )
    echo "`date`: Recreate offmeshs from file $OFFMESH_FILE" | tee -a $LOG_FILE

--- a/contrib/extractor_scripts/MoveMapGen.sh
+++ b/contrib/extractor_scripts/MoveMapGen.sh
@@ -19,10 +19,6 @@
 ## Additional Parameters to be forwarded to MoveMapGen, see mmaps/readme for instructions
 PARAMS="--silent --configInputPath config.json"
 
-## Already a few map extracted, and don't care anymore
-EXCLUDE_MAPS=""
-#EXCLUDE_MAPS="0 1 530 571" # example to exclude the continents
-
 ## Offmesh file
 OFFMESH_FILE="offmesh.txt"
 

--- a/contrib/mmap/src/MapBuilder.cpp
+++ b/contrib/mmap/src/MapBuilder.cpp
@@ -526,6 +526,7 @@ namespace MMAP
             if (dtStatusFailed(dtResult))
             {
                 printf("[Map %03i] Failed to copy navmesh!                   \n", mapID);
+                printf("%s\n", dtGetReason(dtResult));
                 continue;
             }
 
@@ -645,6 +646,7 @@ namespace MMAP
         if (dtStatusFailed(dtResult))
         {
             printf("[Map %03i] Failed creating navmesh!                   \n", mapID);
+            printf("%s\n", dtGetReason(dtResult));
             return;
         }
 
@@ -875,6 +877,7 @@ namespace MMAP
             if (!tileRef || dtStatusFailed(dtResult))
             {
                 printf("%s Failed adding tile to navmesh!                     \n", tileString);
+                printf("%s\n", dtGetReason(dtResult));
                 continue;
             }
 

--- a/contrib/mmap/src/MapBuilder.cpp
+++ b/contrib/mmap/src/MapBuilder.cpp
@@ -641,7 +641,8 @@ namespace MMAP
 
         navMesh = dtAllocNavMesh();
         printf("[Map %03i] Creating navMesh...                        \r", mapID);
-        if (!navMesh->init(&navMeshParams))
+        dtStatus dtResult = navMesh->init(&navMeshParams);
+        if (dtStatusFailed(dtResult))
         {
             printf("[Map %03i] Failed creating navmesh!                   \n", mapID);
             return;

--- a/contrib/mmap/src/MapBuilder.h
+++ b/contrib/mmap/src/MapBuilder.h
@@ -76,6 +76,7 @@ namespace MMAP
     {
         public:
             MapBuilder(const char* configInputPath,
+                       int threads,
                        bool skipLiquid          = false,
                        bool skipContinents      = false,
                        bool skipJunkMaps        = true,
@@ -136,6 +137,8 @@ namespace MMAP
 
             // build performance - not really used for now
             rcContext* m_rcContext;
+
+            int m_threads;
     };
 }
 

--- a/contrib/mmap/src/MapBuilder.h
+++ b/contrib/mmap/src/MapBuilder.h
@@ -21,7 +21,6 @@
 
 #include <vector>
 #include <set>
-#include <map>
 
 #include "TerrainBuilder.h"
 #include "IntermediateValues.h"

--- a/contrib/mmap/src/generator.cpp
+++ b/contrib/mmap/src/generator.cpp
@@ -16,6 +16,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#include <sstream>
+
 #include "MMapCommon.h"
 #include "MapBuilder.h"
 
@@ -61,8 +63,8 @@ bool checkDirectories(bool debugOutput)
 void printUsage()
 {
     printf("Generator command line args\n\n");
-    printf("-? or /? or -h : This help\n");
-    printf("[#] : Build only the map specified by #.\n");
+    printf("-? or /? or -h : Show this help\n");
+    printf("\"[#]\" : Build maps using specified map IDs.\n");
     printf("--tile [#,#] : Build the specified tile\n");
     printf("--skipLiquid : liquid data for maps\n");
     printf("--skipContinents : skip continents\n");
@@ -72,15 +74,16 @@ void printUsage()
     printf("--silent : Make script friendly. No wait for user input, error, completion.\n");
     printf("--offMeshInput [file.*] : Path to file containing off mesh connections data.\n\n");
     printf("--configInputPath [file.*] : Path to json configuration file.\n\n");
-    printf("--onlyGO : builds only gameobject models for transports\n\n");
+    printf("--buildGameObjects : builds only gameobject models for transports\n\n");
+    printf("--threads [#]: specifies number of threads to use for maps processing\n\n");
     printf("Example:\nmovemapgen (generate all mmap with default arg\n"
-           "movemapgen 0 (generate map 0)\n"
+           "movemapgen \"1 0 169\" (generate maps 1, 0 and 169)\n"
            "movemapgen 0 --tile 34,46 (builds only tile 34,46 of map 0)\n\n");
     printf("Please read readme file for more information and examples.\n");
 }
 
 bool handleArgs(int argc, char** argv,
-                int& mapId,
+                std::vector<uint32>& mapIds,
                 int& tileX,
                 int& tileY,
                 bool& skipLiquid,
@@ -89,9 +92,10 @@ bool handleArgs(int argc, char** argv,
                 bool& skipBattlegrounds,
                 bool& debugOutput,
                 bool& silent,
-                bool& buildOnlyGameobjectModels,
+                bool& buildGameObjects,
                 char*& offMeshInputPath,
-                char*& configInputPath)
+                char*& configInputPath,
+                int& threads)
 {
     char* param = NULL;
     for (int i = 1; i < argc; ++i)
@@ -143,9 +147,9 @@ bool handleArgs(int argc, char** argv,
         {
             silent = true;
         }
-        else if (strcmp(argv[i], "--onlyGO") == 0)
+        else if (strcmp(argv[i], "--buildGameObjects") == 0)
         {
-            buildOnlyGameobjectModels = true;
+            buildGameObjects = true;
         }
         else if (strcmp(argv[i], "--offMeshInput") == 0)
         {
@@ -163,6 +167,25 @@ bool handleArgs(int argc, char** argv,
 
             configInputPath = param;
         }
+        else if (strcmp(argv[i], "--threads") == 0)
+        {
+            param = argv[++i];
+            if (!param)
+                return false;
+
+            threads = 0;
+            try
+            {
+                threads = std::stoi(param);
+            }
+            catch (std::invalid_argument& e) {}
+            catch (std::out_of_range& e) {}
+            if (threads <= 0)
+            {
+                printf("Invalid number of threads.\n");
+                return false;
+            }
+        }
         else if ((strcmp(argv[i], "-?") == 0) || (strcmp(argv[i], "/?") == 0) || (strcmp(argv[i], "-h") == 0))
         {
             printUsage();
@@ -170,12 +193,18 @@ bool handleArgs(int argc, char** argv,
         }
         else
         {
-            int map = atoi(argv[i]);
-            if (map > 0 || (map == 0 && (strcmp(argv[i], "0") == 0)))
-                mapId = map;
-            else if (!buildOnlyGameobjectModels)
-            {
-                printf("invalid map id\n");
+            std::istringstream iss(argv[i]);
+            std::string token;
+            while (std::getline(iss, token, ' ')) {
+                try
+                {
+                    mapIds.push_back(std::stoi(token));
+                }
+                catch (std::invalid_argument& e) {}
+                catch (std::out_of_range& e) {}
+            }
+            if (!mapIds.size()) {
+                printf("Invalid map IDs provided.\n");
                 return false;
             }
         }
@@ -193,7 +222,8 @@ int finish(const char* message, int returnValue)
 
 int main(int argc, char** argv)
 {
-    int mapId = -1;
+    std::vector<uint32> mapIds;
+    int threads = -1;
     int tileX = -1, tileY = -1;
 
     bool skipLiquid = false;
@@ -202,24 +232,28 @@ int main(int argc, char** argv)
     bool skipBattlegrounds = false;
     bool debug = false;
     bool silent = false;
-    bool buildOnlyGameobjectModels = false;
+    bool buildGameObjects = false;
 
     char* offMeshInputPath = "offmesh.txt";
     char* configInputPath = "config.json";
 
-    bool validParam = handleArgs(argc, argv, mapId, tileX, tileY, skipLiquid,
+    bool validParam = handleArgs(argc, argv, mapIds, tileX, tileY, skipLiquid,
                                  skipContinents, skipJunkMaps, skipBattlegrounds,
-                                 debug, silent, buildOnlyGameobjectModels, offMeshInputPath, configInputPath);
+                                 debug, silent, buildGameObjects, offMeshInputPath, configInputPath, threads);
 
     if (!validParam)
         return silent ? -1 : finish("You have specified invalid parameters (use -? for more help)", -1);
 
-    if (mapId == -1 && debug && !buildOnlyGameobjectModels)
+    if (threads == -1) {
+        threads = std::thread::hardware_concurrency();
+    }
+
+    if ((mapIds.size() == 0) && debug)
     {
         if (silent)
             return -2;
 
-        printf("You have specifed debug output, but didn't specify a map to generate.\n");
+        printf("You have specifed debug output, but didn't specify maps to generate.\n");
         printf("This will generate debug output for ALL maps.\n");
         printf("Are you sure you want to continue? (y/n) ");
         if (getchar() != 'y')
@@ -229,17 +263,28 @@ int main(int argc, char** argv)
     if (!checkDirectories(debug))
         return silent ? -3 : finish("Press any key to close...", -3);
 
-    MapBuilder builder(configInputPath, skipLiquid, skipContinents, skipJunkMaps, skipBattlegrounds, debug, offMeshInputPath);
+    MapBuilder builder(configInputPath, threads, skipLiquid, skipContinents, skipJunkMaps, skipBattlegrounds, debug, offMeshInputPath);
 
-    if (buildOnlyGameobjectModels)
-        builder.buildTransports();
-    else if (tileX > -1 && tileY > -1 && mapId >= 0)
-        builder.buildSingleTile(mapId, tileX, tileY);
-    else if (mapId >= 0)
-        builder.buildMap(uint32(mapId));
+    if (mapIds.size() == 1)
+    {
+        uint32 const mapId = mapIds.front();
+        if (tileX > -1 && tileY > -1)
+            builder.buildSingleTile(mapId, tileX, tileY);
+        else
+            builder.buildMap(mapId);
+    }
+    else if (mapIds.size() > 1)
+    {
+        for (uint32 const mapId : mapIds)
+            builder.buildMap(mapId);
+    }
     else
     {
         builder.buildAllMaps();
+    }
+
+    if (buildGameObjects)
+    {
         builder.buildTransports();
     }
 

--- a/dep/recastnavigation/Detour/Include/DetourStatus.h
+++ b/dep/recastnavigation/Detour/Include/DetourStatus.h
@@ -62,4 +62,23 @@ inline bool dtStatusDetail(dtStatus status, unsigned int detail)
 	return (status & detail) != 0;
 }
 
+inline char* dtGetReason(dtStatus status) {
+	if ((status & DT_WRONG_MAGIC) != 0)
+		return "Reason: 'Input data is not recognized'\n";
+	if ((status & DT_WRONG_VERSION) != 0)
+		return "Reason: 'Input data is in wrong version'\n";
+	if ((status & DT_OUT_OF_MEMORY) != 0)
+		return "Reason: 'Operation ran out of memory'\n";
+	if ((status & DT_INVALID_PARAM) != 0)
+		return "Reason: 'An input parameter was invalid'\n";
+	if ((status & DT_BUFFER_TOO_SMALL) != 0)
+		return "Reason: 'Result buffer for the query was too small to store all results'\n";
+	if ((status & DT_OUT_OF_NODES) != 0)
+		return "Reason: 'Query ran out of nodes during search'\n";
+	if ((status & DT_PARTIAL_RESULT) != 0)
+		return "Reason: 'Query did not reach the end location, returning best guess'\n";
+	if ((status & DT_ALREADY_OCCUPIED) != 0)
+		return "Reason: 'A tile has already been assigned to the given x,y coordinate'\n";
+}
+
 #endif // DETOURSTATUS_H


### PR DESCRIPTION
## 🍰 Pullrequest
The pull request introduces simple multithreading support to the mmap generator and consolidates some threading and generation logic from the bash scripts.
With multithreading support, the mmap generation takes ~18 minutes with 12 threads, while with current implementation it takes >2hr due to large maps being processed by a single CPU thread (even though maps are distributed between multiple mmap generator instances).

### Proof
Test configuration:
CPU: AMD Ryzen 5 2600 @ 4.00 GHz 6 cores / 12 threads
RAM: DDR4-2933 32GB
OS: Windows 10 Pro 21H1

Run with no mmaps generated - ~18 minutes:
[MaNGOSExtractor_detailed.log](https://github.com/cmangos/mangos-classic/files/6855970/MaNGOSExtractor_detailed.log)

Run with all mmaps generated - 1min 30s:
[MaNGOSExtractor_detailed.log](https://github.com/cmangos/mangos-classic/files/6855784/MaNGOSExtractor_detailed.log)

Memory consumption: approx. 20-30mb per thread (i.e., with 12 threads may reach up to 450mb in total depending on a map).
CPU utilization: approx. 70-80% depending on a map.

Before:
![image](https://user-images.githubusercontent.com/6103913/126541792-5942d9be-706f-4724-bb3f-a8a1713e3df8.png)

After:
![image](https://user-images.githubusercontent.com/6103913/126537318-d05a66a2-6b87-4dde-a3aa-85d39c47727e.png)

### Issues
- None

### How2Test
- Copy prebuilt extractors to the client directory and run `./ExtractResources.sh`.
- Choose extraction options and wait until the generation finishes.
- Verify that all mmaps and offmeshes generated (should be 1999 elements in total, tested on 1.21.1 client), record the extraction time.

### Todo / Checklist
- New argument and changes arguments positioning in the `MoveMapGen.sh`. Current order is:
  1. Extraction mode (`maps` or `offmesh`).
  2. Log file.
  3. Detailed log file.
  4. Number of threads.
- `MoveMapGen.sh` no longer spawns new processes to multiprocess the maps. `MoveMapGen.exe` is now responsible for multiprocessing.
- `ExtractResources.sh` accepts any number of threads. If the number is not provided - all threads will be used (the argument `--threads` will not be passed to `MoveMapGen.exe` in this case).
- In `MoveMapGen.exe`:
  * `--onlyGO` was renamed to `--buildGameObjects`.
  * Added new `--threads [#]` argument that accepts a number of CPU threads. If not provided, will be equal to `thread::hardware_concurrency()`.
  * `--buildGameObjects` now may be additionally supplied to build game objects, while ` --onlyGO` was building only game objects. This way we can build game objects only (by supplying only this argument), or in combination with map IDs (what was not possible in current implementation, a separate process was launched).
  * Map IDs are now accepted as a space-separated list instead of a single number.