### PR TITLE
Deeprun Tram crash fix on heavy server load.

### DIFF
--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -982,6 +982,7 @@ void Map::GameObjectRelocation(GameObject* go, float x, float y, float z, float 
         RemoveFromGrid(go, oldGrid, old_cell);
         AddToGrid(go, newGrid, new_cell);
         go->GetViewPoint().Event_GridChanged(&(*newGrid)(new_cell.CellX(), new_cell.CellY()));
+		go->Relocate(x, y, z, orientation);
     }
     else
     {


### PR DESCRIPTION
## 🍰 Pullrequest
Fixes a crash caused by deeprun tram or other similar moving active game objects during heavy server load.
To prevent a grid and location mis-match the coordinates of objects are always updated even when moving to a different cell.

### Proof
When checking if a grid may be unloaded m_activeNonPlayers are evaluated based on a cell corresponding to their current coordinates.
https://github.com/cmangos/mangos-classic/blob/845272940585285c796792e243205d99b26f0589/src/game/Maps/Map.cpp#L1383
However during unloading objects are deleted based on their current grid reference.
https://github.com/cmangos/mangos-classic/blob/845272940585285c796792e243205d99b26f0589/src/game/Maps/Map.cpp#L1043
This causes a crash when the reference cell/grid an object is located in is beyond the visibility distance of the cell/grid the objects current coordinates are located in.

When relocating game objects the modification of the objects coordinates is delayed when the object moves to a new grid/cell.
https://github.com/cmangos/mangos-classic/blob/845272940585285c796792e243205d99b26f0589/src/game/Maps/Map.cpp#L977
During heavy server load it is possible to reach a point fast moving objects constantly move from cell to cell. The result is the coordinates will remain the same while the grid that object is in will eventually move.

### Issues
Fixes an exception in https://github.com/cmangos/mangos-classic/blob/845272940585285c796792e243205d99b26f0589/src/game/Maps/Map.cpp#L771
m_activeNonPlayers will contain a references to an object that was deleted while unloading the grid.

### How2Test
-Put the server under heavy load.
-Enter the deeprun tram instance (and for optimal results move through the instance to load all grids and spawn both trams)
-Leave the instance.
-Wait for all grids to unload.
-Repeat. 

Unfortunately the tram has to be physically (coordinates) located in an unloading grid for this crash to trigger which is chance.

### Todo / Checklist
Perhaps ActiveObjectsNearGrid should look at m_currentCell instead of coordinates if unloading effects objects based on the former instead of the latter.
