### PR TITLE
BUGFIX Camera extraction broken

### DIFF
--- a/contrib/extractor/System.cpp
+++ b/contrib/extractor/System.cpp
@@ -99,6 +99,7 @@ float CONF_flat_liquid_delta_limit = 0.001f; // If max - min less this value - l
 // List MPQ for extract from
 const char* CONF_mpq_list[] =
 {
+    "model.MPQ",
     "dbc.MPQ",
     "terrain.MPQ",
     "patch.MPQ",


### PR DESCRIPTION
MPQ with the actual Camera files is missing from search list
(except for the human flyby camera with apparently was in patch/patch-2.MPQ)
Solution: Just add the missing MPQ to the list to search
Note that first MPQ on the list is last one searched (reverse order) so this shouldn't affect any other extractions [not tested.]

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- relates #XXX
-->
- fixes [Bug Report] Camera extraction on *nix systems is broken #2123

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
cd to directory with client files and remove the Camera files
$ rm -rf Cameras/*
run the camera extraction again and check that cameras are extracted now
$ ls -l
```
-rw-r--r-- 1 cmangos0 cmangos0 3920 Oct  5 19:24 FlyByGnome.m2
-rw-r--r-- 1 cmangos0 cmangos0 3728 Oct  5 19:24 FlyByHuman.m2
-rw-r--r-- 1 cmangos0 cmangos0 4832 Oct  5 19:24 FlybyNightElf.m2
-rw-r--r-- 1 cmangos0 cmangos0 3856 Oct  5 19:24 FlybyOrc.m2
-rw-r--r-- 1 cmangos0 cmangos0 3680 Oct  5 19:24 FlyByTauren.m2
-rw-r--r-- 1 cmangos0 cmangos0 3840 Oct  5 19:24 FlyByTroll.m2
-rw-r--r-- 1 cmangos0 cmangos0 3696 Oct  5 19:24 FlybyUndead.m2
-rw-r--r-- 1 cmangos0 cmangos0 2576 Oct  5 19:24 PalantirOfAzora.m2
-rw-r--r-- 1 cmangos0 cmangos0 2144 Oct  5 19:24 Scry_cam.m2
```

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
