### PR TITLE
Add ability to switch gossip menus of npcs.

### DIFF
--- a/src/game/DBScripts/ScriptMgr.cpp
+++ b/src/game/DBScripts/ScriptMgr.cpp
@@ -845,6 +845,16 @@ void ScriptMgr::LoadScripts(ScriptMapMapName& scripts, const char* tablename)
 
                 break;
             }
+            case SCRIPT_COMMAND_SET_GOSSIP_MENU:
+            {
+                if (!sObjectMgr.IsExistingGossipMenuId(tmp.setGossipMenu.gossipMenuId))
+                {
+                    sLog.outErrorDb("Table `%s` using nonexistent gossip menu (id: %u) in SCRIPT_COMMAND_SET_GOSSIP_MENU for script id %u",
+                        tablename, tmp.setGossipMenu.gossipMenuId, tmp.id);
+                    continue;
+                }
+                break;
+            }
             default:
             {
                 sLog.outErrorDb("Table `%s` unknown command %u, skipping.", tablename, tmp.command);
@@ -2860,6 +2870,14 @@ bool ScriptAction::ExecuteDbscriptCommand(WorldObject* pSource, WorldObject* pTa
                     break;
             }
 
+            break;
+        }
+        case SCRIPT_COMMAND_SET_GOSSIP_MENU:                // 52
+        {
+            if (LogIfNotCreature(pTarget))
+                break;
+
+            ((Creature*)pTarget)->SetDefaultGossipMenuId(m_script->setGossipMenu.gossipMenuId);
             break;
         }
         default:

--- a/src/game/DBScripts/ScriptMgr.h
+++ b/src/game/DBScripts/ScriptMgr.h
@@ -133,6 +133,7 @@ enum ScriptCommand                                          // resSource, resTar
     SCRIPT_COMMAND_SET_DATA_64              = 49,           // datalong = set data param 1, datalong2 = set data param 2
     SCRIPT_COMMAND_ZONE_PULSE               = 50,           //
     SCRIPT_COMMAND_SPAWN_GROUP              = 51,           // dalalong = command
+    SCRIPT_COMMAND_SET_GOSSIP_MENU          = 52,           // datalong = gossip_menu_id
 };
 
 #define MAX_TEXT_ID 4                                       // used for SCRIPT_COMMAND_TALK, SCRIPT_COMMAND_EMOTE, SCRIPT_COMMAND_CAST_SPELL, SCRIPT_COMMAND_TERMINATE_SCRIPT
@@ -447,6 +448,11 @@ struct ScriptInfo
             uint32 data1;                                   // datalong2
             uint32 data2;                                   // datalong3
         } formationData;
+
+        struct                                              // SCRIPT_COMMAND_SET_GOSSIP_MENU (84)
+        {
+            uint32 gossipMenuId;                            // datalong
+        } setGossipMenu;
 
         struct                                              // SCRIPT_COMMAND_LOG_KILL (99)
         {

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -134,7 +134,7 @@ bool CreatureCreatePos::Relocate(Creature* cr) const
 }
 
 Creature::Creature(CreatureSubtype subtype) : Unit(),
-    m_lootMoney(0), m_lootGroupRecipientId(0),
+    m_gossipMenuId(0), m_lootMoney(0), m_lootGroupRecipientId(0),
     m_lootStatus(CREATURE_LOOT_STATUS_NONE),
     m_corpseAccelerationDecayDelay(MINIMUM_LOOTING_TIME),
     m_respawnTime(0), m_respawnDelay(25), m_respawnOverriden(false), m_respawnOverrideOnce(false), m_corpseDelay(60), m_canAggro(false),
@@ -518,6 +518,7 @@ bool Creature::UpdateEntry(uint32 Entry, const CreatureData* data /*=nullptr*/, 
         faction = data->spawnTemplate->faction;
     setFaction(faction);
 
+    SetDefaultGossipMenuId(GetCreatureInfo()->GossipMenuId);
     SetUInt32Value(UNIT_NPC_FLAGS, GetCreatureInfo()->NpcFlags);
 
     uint32 attackTimer = GetCreatureInfo()->MeleeBaseAttackTime;

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -768,6 +768,9 @@ class Creature : public Unit
         bool HasQuest(uint32 quest_id) const override;
         bool HasInvolvedQuest(uint32 quest_id)  const override;
 
+        void SetDefaultGossipMenuId(uint32 menuId) { m_gossipMenuId = menuId; }
+        uint32 GetDefaultGossipMenuId() const { return m_gossipMenuId; }
+
         GridReference<Creature>& GetGridRef() { return m_gridRef; }
         bool IsRegeneratingHealth() const { return (GetCreatureInfo()->RegenerateStats & REGEN_FLAG_HEALTH) != 0; }
         bool IsRegeneratingPower() const;
@@ -875,6 +878,7 @@ class Creature : public Unit
         // vendor items
         VendorItemCounts m_vendorItemCounts;
 
+        uint32 m_gossipMenuId;
         uint32 m_lootMoney;
         ObjectGuid m_lootRecipientGuid;                     // player who will have rights for looting if m_lootGroupRecipient==0 or group disbanded
         uint32 m_lootGroupRecipientId;                      // group who will have rights for looting if set and exist

--- a/src/game/Entities/NPCHandler.cpp
+++ b/src/game/Entities/NPCHandler.cpp
@@ -332,7 +332,7 @@ void WorldSession::HandleGossipHelloOpcode(WorldPacket& recv_data)
 
     if (!sScriptDevAIMgr.OnGossipHello(_player, pCreature))
     {
-        _player->PrepareGossipMenu(pCreature, pCreature->GetCreatureInfo()->GossipMenuId);
+        _player->PrepareGossipMenu(pCreature, pCreature->GetDefaultGossipMenuId());
         _player->SendPreparedGossip(pCreature);
     }
 }

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -11822,7 +11822,7 @@ uint32 Player::GetGossipTextId(uint32 menuId, WorldObject* pSource)
 uint32 Player::GetDefaultGossipMenuForSource(WorldObject* pSource) const
 {
     if (pSource->GetTypeId() == TYPEID_UNIT)
-        return ((Creature*)pSource)->GetCreatureInfo()->GossipMenuId;
+        return ((Creature*)pSource)->GetDefaultGossipMenuId();
     if (pSource->GetTypeId() == TYPEID_GAMEOBJECT)
         return ((GameObject*)pSource)->GetGOInfo()->GetGossipMenuId();
 

--- a/src/game/Globals/ObjectMgr.h
+++ b/src/game/Globals/ObjectMgr.h
@@ -1081,6 +1081,10 @@ class ObjectMgr
         // check if an entry on some map have is an encounter
         bool IsEncounter(uint32 creditEntry, uint32 mapId) const;
 
+        bool IsExistingGossipMenuId(uint32 menuId)
+        {
+            return m_mGossipMenusMap.find(menuId) != m_mGossipMenusMap.end();
+        }
         GossipMenusMapBounds GetGossipMenusMapBounds(uint32 uiMenuId) const
         {
             return m_mGossipMenusMap.equal_range(uiMenuId);

--- a/src/game/Quests/QuestHandler.cpp
+++ b/src/game/Quests/QuestHandler.cpp
@@ -107,7 +107,7 @@ void WorldSession::HandleQuestgiverHelloOpcode(WorldPacket& recv_data)
     if (sScriptDevAIMgr.OnGossipHello(_player, pCreature))
         return;
 
-    _player->PrepareGossipMenu(pCreature, pCreature->GetCreatureInfo()->GossipMenuId);
+    _player->PrepareGossipMenu(pCreature, pCreature->GetDefaultGossipMenuId());
     _player->SendPreparedGossip(pCreature);
 }
 


### PR DESCRIPTION
## 🍰 Pullrequest
Implements a db script command to change the default gossip menu of creatures. There are multiple npcs in Classic which do this, so this should be supported by the scripting system.

### Proof
Stuff like this can now be handled in db - https://github.com/cmangos/mangos-tbc/commit/81d3fa72187eafc1cd35a9865819127c059e5252
