### PR TITLE
Implement areatrigger event involving Justine Demalier and Melris Malagan in Stormwind

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -34,6 +34,7 @@ INSERT INTO scripted_areatrigger VALUES
 (2046,'at_blackrock_spire'),
 (2066,'at_blackrock_spire'),
 (2067,'at_blackrock_spire'),
+(2746,'at_stormwind_recruiter'),
 (3066,'at_ravenholdt'),
 (3146,'at_hive_tower'),
 -- Darnassian bank

--- a/src/game/AI/ScriptDevAI/scripts/world/areatrigger_scripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/world/areatrigger_scripts.cpp
@@ -387,11 +387,12 @@ enum
 
 bool AreaTrigger_at_stormwind_recruiter(Player* player, AreaTriggerEntry const* /*at*/)
 {
-    if (player->IsGameMaster() || player->GetLevel() < 56 || player->GetQuestRewardStatus(QUEST_THE_FIRST_AND_THE_LAST))
+    if (player->IsGameMaster() || player->GetTeam() != ALLIANCE || player->GetLevel() < 56 || player->GetQuestRewardStatus(QUEST_THE_FIRST_AND_THE_LAST))
         return false;
 
     if (Creature* justineDemalier = GetClosestCreatureWithEntry(player, NPC_JUSTINE_DEMALIER, 20.0f))
-        justineDemalier->AI()->SendAIEvent(AI_EVENT_CUSTOM_EVENTAI_A, player, justineDemalier);
+        if (!justineDemalier->IsInCombat())
+            justineDemalier->AI()->SendAIEvent(AI_EVENT_CUSTOM_EVENTAI_A, player, justineDemalier);
 
     return false;
 }

--- a/src/game/AI/ScriptDevAI/scripts/world/areatrigger_scripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/world/areatrigger_scripts.cpp
@@ -33,6 +33,7 @@ at_huldar_miran                 171
 at_twilight_grove               4017
 at_hive_tower                   3146
 at_wondervolt                   4030,4032,4026,4029,4027,4028,4031
+at_stormwind_recruiter          2746
 EndContentData */
 
 #include "AI/ScriptDevAI/include/sc_common.h"
@@ -374,6 +375,27 @@ bool AreaTrigger_at_wondervolt(Player* player, AreaTriggerEntry const* /*at*/)
     return false;
 }
 
+/*######
+## at_stormwind_recruiter
+######*/
+
+enum
+{
+    NPC_JUSTINE_DEMALIER         = 12481,
+    QUEST_THE_FIRST_AND_THE_LAST = 6182
+};
+
+bool AreaTrigger_at_stormwind_recruiter(Player* player, AreaTriggerEntry const* /*at*/)
+{
+    if (player->IsGameMaster() || player->GetLevel() < 56 || player->GetQuestRewardStatus(QUEST_THE_FIRST_AND_THE_LAST))
+        return false;
+
+    if (Creature* justineDemalier = GetClosestCreatureWithEntry(player, NPC_JUSTINE_DEMALIER, 20.0f))
+        justineDemalier->AI()->SendAIEvent(AI_EVENT_CUSTOM_EVENTAI_A, player, justineDemalier);
+
+    return false;
+}
+
 void AddSC_areatrigger_scripts()
 {
     Script* pNewScript = new Script;
@@ -419,5 +441,10 @@ void AddSC_areatrigger_scripts()
     pNewScript = new Script;
     pNewScript->Name = "at_wondervolt";
     pNewScript->pAreaTrigger = &AreaTrigger_at_wondervolt;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "at_stormwind_recruiter";
+    pNewScript->pAreaTrigger = &AreaTrigger_at_stormwind_recruiter;
     pNewScript->RegisterSelf();
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
When a player enters areatrigger 2746, if they satisfy certain conditions (level at or above 56 and quest [The First and the Last](https://tbc.wowhead.com/quest=6182/the-first-and-the-last) not rewarded), [Justine Demalier](https://classic.wowhead.com/npc=12481/justine-demalier) and [Melris Malagan](https://classic.wowhead.com/npc=12480/melris-malagan) do a small roleplay event (they turn toward player, talk and do some emotes). This event then won't be triggered again for roughly 8 minutes after Melris Malagan resets his orientation (the last event they do).

I don't know if that cooldown would be shortened if a different player enters the areatrigger - I only have one account on the PTR to test it and Stormwind is always empty.

This is valid for Classic and TBC. I don't think it's valid for WotLK since the male NPC's text explicitly references Bolvar Fordragon, which in WotLK is no longer the acting king of Stormwind. The relay_script id I used is free on both DBs as of the time of this PR.

### Proof
<!-- Link resources as proof -->
- A lot of comment on [Justine Demalier's Wowhead page](https://classic.wowhead.com/npc=12481/justine-demalier#comments).

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Have your character be at level 56 or higher, and without having done the quest [The First and the Last](https://tbc.wowhead.com/quest=6182/the-first-and-the-last).
- .go creature id 12481
- Notice the NPCs do their event.
- If you want, try to retrigger the event before its cooldown is up by exiting and re-entering the areatrigger (it covers a small patch of land in front of the tree - not big by any means. Move to the innkeeper and back to retrigger it for sure). I already made sure it wouldn't retrigger before the cooldown was up.