### PR TITLE
Spell: prevent Lunar Fortune from stacking with itself

### DIFF
--- a/src/game/Spells/SpellMgr.h
+++ b/src/game/Spells/SpellMgr.h
@@ -1791,7 +1791,7 @@ inline bool IsStackableAuraEffect(SpellEntry const* entry, SpellEntry const* ent
             nonmui = true;
             break;
         case SPELL_AURA_MOD_INCREASE_HEALTH:
-            if (entry->Id == 26522) // Lunar Fortune
+            if (entry->Id == 26522 && entry2->Id == 26522) // Lunar Fortune
                 return false;
             break;
         case SPELL_AURA_MOD_HEALING_DONE:

--- a/src/game/Spells/SpellMgr.h
+++ b/src/game/Spells/SpellMgr.h
@@ -1790,6 +1790,10 @@ inline bool IsStackableAuraEffect(SpellEntry const* entry, SpellEntry const* ent
         case SPELL_AURA_MOD_PERCENT_STAT:
             nonmui = true;
             break;
+        case SPELL_AURA_MOD_INCREASE_HEALTH:
+            if (entry->Id == 26522) // Lunar Fortune
+                return false;
+            break;
         case SPELL_AURA_MOD_HEALING_DONE:
         case SPELL_AURA_MOD_HEALING_PCT:
             // Do not stack similar debuffs: Mortal Strike, Aimed Shot, Hex of Weakness


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

[Lunar Fortune](https://classic.wowhead.com/spell=26522/lunar-fortune) should not stack with itself. Depending on luck (you have a 50% chance of obtaining this item from the mail you receive when you do the Elder quests during the Lunar Festival) you could get 30+ of those items, giving a 7500 increase of hp if it was allowed to stack.

### Proof
<!-- Link resources as proof -->
Tested on TBC PTR, it does not stack when using two of those.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .event start 7
- .add 21744 2
- .go obj id 180859
- Use the two Lucky Rocket Clusters.