### PR TITLE
Fix GO collision height

### DIFF
--- a/src/game/Entities/GameObject.h
+++ b/src/game/Entities/GameObject.h
@@ -849,6 +849,7 @@ class GameObject : public WorldObject
         float GetCapturePointSliderValue() const { return m_captureSlider; }
 
         float GetInteractionDistance() const;
+        float GetCollisionHeight() const override { return 1.f; } // to get away with ground collision
 
         GridReference<GameObject>& GetGridRef() { return m_gridRef; }
 


### PR DESCRIPTION
Backport from tbc, fixes BG traps and maybe something else

### Issues
- Fixes GO ground collision that makes GO like BG Buffs (TYPE_TRAP) not find targets.

### How2Test
Enter WSG and try any buff

### Todo / Checklist
Affects all GOs, but I took it from tbc core so I guess is safe
