### PR TITLE
Allow gameobjects activated via ANIMATE_CUSTOM GameObjectAction to trigger scripts

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -4701,8 +4701,14 @@ void Spell::EffectActivateObject(SpellEffectIndex effIdx)
         case GameObjectActions::ANIMATE_CUSTOM_1:
         case GameObjectActions::ANIMATE_CUSTOM_2:
         case GameObjectActions::ANIMATE_CUSTOM_3:
+        {
             gameObjTarget->SendGameObjectCustomAnim(gameObjTarget->GetObjectGuid(), uint32(action) - uint32(GameObjectActions::ANIMATE_CUSTOM_0));
+            
+            bool scriptReturnValue = m_caster->GetTypeId() == TYPEID_PLAYER && sScriptDevAIMgr.OnGameObjectUse((Player*)m_caster, gameObjTarget);
+            if (!scriptReturnValue)
+                m_caster->GetMap()->ScriptsStart(sGameObjectTemplateScripts, gameObjTarget->GetEntry(), m_caster, gameObjTarget);
             break;
+        }
         case GameObjectActions::DISTURB: // What's the difference with Open?
         case GameObjectActions::OPEN:
             switch (m_spellInfo->Id)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

Commit https://github.com/cmangos/mangos-classic/commit/ad13e6770a99a6682ff7119929f15f731111520d made it so gameobjects activated via a spell effect using action AnimateCustom0/1/2/3 (example: [Lucky Lunar Rocket](https://classic.wowhead.com/spell=26521/lucky-lunar-rocket) no longer call GameObject::Use().
This prevents activation of gameobject scripts, both from SD2 and from DB.

I can't say whether or not that specific activation should call Use() too, but having it still be scriptable is needed for some scripts.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create a Horde character (since I'm giving the guid of a NPC in Orgrimmar)
- .event start 7
- .go creature 91608
- Accept the quest Lunar Fireworks
- Buy fireworks from the Lunar Festival Vendor at her right

This quest was fixed in https://github.com/cmangos/tbc-db/commit/2a0ae8ff47014b5ef640f116983c5ec4bc7fad09, it relies on this behavior to work.