### PR TITLE
Mails sent to characters within the same account are subject to the same one-hour delay in Classic

### DIFF
--- a/src/game/Mails/MailHandler.cpp
+++ b/src/game/Mails/MailHandler.cpp
@@ -219,8 +219,6 @@ void WorldSession::HandleSendMail(WorldPacket& recv_data)
     
     pl->ModifyMoney(-int32(reqmoney));
 
-    bool needItemDelay = false;
-
     MailDraft draft(subject, body);
 
     if (itemGuid || money > 0)
@@ -248,9 +246,6 @@ void WorldSession::HandleSendMail(WorldPacket& recv_data)
             CharacterDatabase.CommitTransaction();
 
             draft.AddItem(item);
-
-            // if item send to character at another account, then apply item delivery delay
-            needItemDelay = pl->GetSession()->GetAccountId() != rc_account;
         }
 
         if (money > 0 &&  GetSecurity() > SEC_PLAYER && sWorld.getConfig(CONFIG_BOOL_GM_LOG_TRADE))
@@ -260,8 +255,8 @@ void WorldSession::HandleSendMail(WorldPacket& recv_data)
         }
     }
 
-    // If theres is an item, there is a one hour delivery delay if sent to another account's character.
-    uint32 deliver_delay = needItemDelay ? sWorld.getConfig(CONFIG_UINT32_MAIL_DELIVERY_DELAY) : 0;
+    // Delivery delay is always applied, even if we're sending mails to our own characters
+    uint32 deliver_delay = sWorld.getConfig(CONFIG_UINT32_MAIL_DELIVERY_DELAY);
 
     // will delete item or place to receiver mail list
     draft


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

In Classic, mails sent between characters of your account should not be instant, but still subject to the one-hour delay.

The "instant mail within the same account" change was introduced in 2.1.3 as an undocumented change.

### Proof
<!-- Link resources as proof -->
- https://wowpedia.fandom.com/wiki/Patch_2.1.3

> Any mail between characters on the same account is now instant regardless of money or items attached.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create two characters, log into one, send the other an item via mail, log into the other character and check your mailbox.