### PR TITLE
Fix health/mana/armor stat calculation for Warlock pets

### DIFF
--- a/src/game/Entities/Pet.cpp
+++ b/src/game/Entities/Pet.cpp
@@ -1361,8 +1361,8 @@ void Pet::InitStatsForLevel(uint32 petlevel)
             sLog.outError("Pet have incorrect type (%u) for level handling.", getPetType());
     }
 
-    // Hunter's pets' should NOT use creature's original modifiers/multipliers
-    if (getPetType() != HUNTER_PET)
+    // Hunter and Warlock pets should NOT use creature's original modifiers/multipliers
+    if (getPetType() != HUNTER_PET && getPetType() != SUMMON_PET)
     {
         health *= cInfo->HealthMultiplier;
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

Currently, Warlock pets are subjected to multiplier values in creature_template. This makes them have less or more hp/mana/armor than intended, because those values should not be used for player-controlled pets.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes [#2756](https://github.com/cmangos/issues/issues/2756)

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create a Warlock, level it up to 60.
- Summon Warlock pets one by one and check them against the values in pet_levelstats.