### PR TITLE
Unsummon active Warlock demons when trying to summon a new one

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -2853,6 +2853,12 @@ void Spell::Prepare()
 
     OnSuccessfulStart();
 
+    // Unsummon active Warlock demons when trying to summon a new one
+    if (Unit* unitCaster = dynamic_cast<Unit*>(m_trueCaster))
+        if (m_spellInfo->HasAttribute(SPELL_ATTR_EX_DISMISS_PET))
+            if (Pet* pet = unitCaster->GetPet())
+                pet->Unsummon(PET_SAVE_NOT_IN_SLOT, unitCaster);
+
     // add non-triggered (with cast time and without)
     if (!m_IsTriggeredSpell)
     {
@@ -3056,11 +3062,6 @@ SpellCastResult Spell::cast(bool skipCheck)
     }
 
     spellModController.SetSuccess();
-
-    if (Unit* unitCaster = dynamic_cast<Unit*>(m_trueCaster))
-        if (m_spellInfo->HasAttribute(SPELL_ATTR_EX_DISMISS_PET))
-            if (Pet* pet = unitCaster->GetPet())
-                pet->Unsummon(PET_SAVE_NOT_IN_SLOT, unitCaster);
 
     // CAST SPELL
     SendSpellCooldown();


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
On Classic and Classic only, trying to summon a Warlock demon while you already have one summoned will force the current one to despawn as soon as you start casting the new demon's summoning spell.

Added this check here in Spell::CheckCast() instead of Spell::prepare() because there's already code handling pets in the former, and TC handles the Summoning Disorientation stun in there too.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes https://github.com/cmangos/issues/issues/2762

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create a Warlock.
- Summon a pet.
- Try to summon another pet.