### PR TITLE
Disable AB graveyards inside bases during BG

### DIFF
--- a/src/game/BattleGround/BattleGroundAB.cpp
+++ b/src/game/BattleGround/BattleGroundAB.cpp
@@ -155,8 +155,12 @@ void BattleGroundAB::StartingEventOpenDoors()
     OpenDoorEvent(BG_EVENT_DOOR);
 
     // setup graveyards
+    // enable gy near base after bg start
     GetBgMap()->GetGraveyardManager().SetGraveYardLinkTeam(AB_GRAVEYARD_ALLIANCE, BG_AB_ZONE_MAIN, ALLIANCE);
     GetBgMap()->GetGraveyardManager().SetGraveYardLinkTeam(AB_GRAVEYARD_HORDE, BG_AB_ZONE_MAIN, HORDE);
+    // disable gy inside base after bg start
+    GetBgMap()->GetGraveyardManager().SetGraveYardLinkTeam(AB_GRAVEYARD_ALLIANCE_BASE, BG_AB_ZONE_MAIN, TEAM_INVALID);
+    GetBgMap()->GetGraveyardManager().SetGraveYardLinkTeam(AB_GRAVEYARD_HORDE_BASE, BG_AB_ZONE_MAIN, TEAM_INVALID);
 }
 
 void BattleGroundAB::AddPlayer(Player* player)

--- a/src/game/BattleGround/BattleGroundAB.h
+++ b/src/game/BattleGround/BattleGroundAB.h
@@ -153,6 +153,8 @@ enum ABGraveyards
 
     AB_GRAVEYARD_ALLIANCE               = 898,
     AB_GRAVEYARD_HORDE                  = 899,
+    AB_GRAVEYARD_ALLIANCE_BASE = 890,
+    AB_GRAVEYARD_HORDE_BASE = 889,
 
     BG_AB_ZONE_MAIN                     = 3358,
 };


### PR DESCRIPTION
## 🍰 Pullrequest
Disables graveyards inside bases (where you spawn on teleporting into bg) after BG starts. Players who die near base or if all bases are captured by enemy should teleport to the graveyard to the side of the base, where Spirit Healer is. (Without fix closest GY is in most cases = inside base, which is not correct).