### PR TITLE
Add Slot field to npc_vendor and npc_vendor_template and use it to determine order of items in vendor window

### DIFF
--- a/sql/updates/mangos/z2786_01_mangos_npc_vendor.sql
+++ b/sql/updates/mangos/z2786_01_mangos_npc_vendor.sql
@@ -1,0 +1,4 @@
+ALTER TABLE db_version CHANGE COLUMN required_z2785_01_mangos_waypoint_path z2786_01_mangos_npc_vendor bit;
+
+ALTER TABLE `npc_vendor` ADD COLUMN `slot` TINYINT(3) UNSIGNED DEFAULT 0 NOT NULL AFTER `incrtime`;
+ALTER TABLE `npc_vendor_template` ADD COLUMN `slot` TINYINT(3) UNSIGNED DEFAULT 0 NOT NULL AFTER `incrtime`;

--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -8536,7 +8536,7 @@ void ObjectMgr::LoadVendors(char const* tableName, bool isTemplates)
 
     std::set<uint32> skip_vendors;
 
-    QueryResult* result = WorldDatabase.PQuery("SELECT entry, item, maxcount, incrtime, condition_id FROM %s", tableName);
+    QueryResult* result = WorldDatabase.PQuery("SELECT entry, item, maxcount, incrtime, condition_id FROM %s ORDER BY slot", tableName);
     if (!result)
     {
         BarGoLink bar(1);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

Vendors in Retail show the items they sell in a specific order. No matter how much I tried, I could not find a generic rule or method that decides in what order they appear, so in order to simulate this behavior we need a slot field to sort the vendor items in a specific way.

Vendor from Retail:
![WoWScrnShot_022222_012128](https://user-images.githubusercontent.com/99603810/155041511-80c017cd-8f82-42cc-ba91-7b2a4b5a0333.jpg)

Same vendor from CMaNGOS:
![WoWScrnShot_022222_012133](https://user-images.githubusercontent.com/99603810/155041517-9ed6930c-966a-4abc-b1a4-7f5b18a0cab0.jpg)


### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create a Horde character.
- .event start 7
- .go creature 91593
- Talk with that vendor, see the order in which he lists his items
- Apply the queries below to the mangos database:

```sql
-- Lunar Festival Vendor
UPDATE `npc_vendor` SET `slot`=1 WHERE `item`=21721; -- Moonglow
UPDATE `npc_vendor` SET `slot`=2 WHERE `item`=21747; -- Festival Firecracker
UPDATE `npc_vendor` SET `slot`=3 WHERE `item`=21558; -- Small Blue Rocket
UPDATE `npc_vendor` SET `slot`=4 WHERE `item`=21559; -- Small Green Rocket 
UPDATE `npc_vendor` SET `slot`=5 WHERE `item`=21557; -- Small Red Rocket
UPDATE `npc_vendor` SET `slot`=6 WHERE `item`=21571; -- Blue Rocket Cluster
UPDATE `npc_vendor` SET `slot`=7 WHERE `item`=21574; -- Green Rocket Cluster
UPDATE `npc_vendor` SET `slot`=8 WHERE `item`=21576; -- Red Rocket Cluster


```

- Do the above steps again, see the difference in ordering.