### PR TITLE
Port BG corpse looting from vmangos

### DIFF
--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -1729,8 +1729,12 @@ void BattleGround::HandleTriggerBuff(ObjectGuid go_guid)
 */
 void BattleGround::HandleKillPlayer(Player* player, Player* killer)
 {
-    // add +1 deaths
-    UpdatePlayerScore(player, SCORE_DEATHS, 1);
+    if (!player->HasAura(27827)) // do not count spirit of redemption
+    {
+        // add +1 deaths
+        UpdatePlayerScore(player, SCORE_DEATHS, 1);
+        player->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SKINNABLE);
+    }
 
     // add +1 kills to group and +1 killing_blows to killer
     if (killer)

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -7566,6 +7566,10 @@ void Player::RemovedInsignia(Player* looterPlr)
     if (!corpse)
         return;
 
+    WorldPacket data(SMSG_PLAYER_SKINNED, 1);
+    data << uint8(0);
+    GetSession()->SendPacket(data);
+
     // We have to convert player corpse to bones, not to be able to resurrect there
     // SpawnCorpseBones isn't handy, 'cos it saves player while he in BG
     Corpse* bones = sObjectAccessor.ConvertCorpseForPlayer(GetObjectGuid(), true);
@@ -7574,6 +7578,7 @@ void Player::RemovedInsignia(Player* looterPlr)
 
     // Now we must make bones lootable, and send player loot
     bones->SetFlag(CORPSE_FIELD_DYNAMIC_FLAGS, CORPSE_DYNFLAG_LOOTABLE);
+    bones->ForceValuesUpdateAtIndex(CORPSE_DYNFLAG_LOOTABLE);
 
     // We store the level of our player in the gold field
     // We retrieve this information at Player::SendLoot()

--- a/src/game/Globals/ObjectAccessor.cpp
+++ b/src/game/Globals/ObjectAccessor.cpp
@@ -268,7 +268,7 @@ ObjectAccessor::ConvertCorpseForPlayer(ObjectGuid player_guid, bool insignia)
         bones->Relocate(corpse->GetPositionX(), corpse->GetPositionY(), corpse->GetPositionZ(), corpse->GetOrientation());
 
         bones->SetUInt32Value(CORPSE_FIELD_FLAGS, CORPSE_FLAG_UNK2 | CORPSE_FLAG_BONES);
-        bones->SetOwnerGuid(ObjectGuid());
+        bones->SetOwnerGuid(player_guid);
 
         for (int i = 0; i < EQUIPMENT_SLOT_END; ++i)
         {

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -5844,11 +5844,47 @@ void Spell::EffectSpiritHeal(SpellEffectIndex /*eff_idx*/)
 void Spell::EffectSkinPlayerCorpse(SpellEffectIndex /*eff_idx*/)
 {
     DEBUG_LOG("Effect: SkinPlayerCorpse");
-    if ((m_caster->GetTypeId() != TYPEID_PLAYER) || (unitTarget->GetTypeId() != TYPEID_PLAYER) || (unitTarget->IsAlive()))
+    Player* playerCaster = m_caster->IsPlayer() ? (Player*)m_caster : nullptr;
+    if (!playerCaster)
         return;
+    
+    Unit* target = unitTarget;
+    if (!target && corpseTarget)
+        target = sObjectAccessor.FindPlayer(corpseTarget->GetOwnerGuid());
 
-    ((Player*)unitTarget)->RemovedInsignia((Player*)m_caster);
-    m_spellLog.AddLog(uint32(SPELL_EFFECT_SKIN_PLAYER_CORPSE), unitTarget->GetObjectGuid());
+    if (!target)
+    {
+        Corpse* bones = sObjectAccessor.ConvertCorpseForPlayer(corpseTarget->GetOwnerGuid(), true);
+        if (!bones)
+            return;
+
+        // Now we must make bones lootable, and send player loot
+        bones->SetFlag(CORPSE_FIELD_DYNAMIC_FLAGS, CORPSE_DYNFLAG_LOOTABLE);
+
+        // We store the level of our player in the gold field
+        // We retrieve this information at Player::SendLoot()
+        bones->lootRecipient = playerCaster;
+
+        Loot*& bonesLoot = bones->m_loot;
+        if (!bonesLoot)
+            bonesLoot = new Loot(playerCaster, bones, LOOT_INSIGNIA);
+        else
+        {
+            if (bonesLoot->GetLootType() != LOOT_INSIGNIA)
+            {
+                delete bonesLoot;
+                bonesLoot = new Loot(playerCaster, bones, LOOT_INSIGNIA);
+            }
+        }
+
+        bonesLoot->ShowContentTo(playerCaster);
+
+        DEBUG_LOG("Effect SkinPlayerCorpse: corpse owner was not found");
+        return;
+    }
+
+    ((Player*)target)->RemovedInsignia((Player*)m_caster);
+    m_spellLog.AddLog(uint32(SPELL_EFFECT_SKIN_PLAYER_CORPSE), target->GetObjectGuid());
 }
 
 void Spell::EffectBind(SpellEffectIndex /*eff_idx*/)


### PR DESCRIPTION
## 🍰 Pullrequest
Port of vmangos code that fixes following issues:
a) server crash when looting ("skinning") enemy player corpse (was nullptr issue)
b) adds AV quest items to corpses, some depend on enemy pvp rank
c) fixes loot (default is money based on target level)
d) fixes players getting 2 deaths if they have spirit of redemption
e) fixes dead unreleased players have no skinning flag

This is a direct port with 1 exception: removed items that only dropped before 1.10
Also I was thinking if it's possible to spawn loot based on conditions, but I'm not sure conditions support checking corpse info rather than looter.
Corpse (bones) player_guid mod was necessary to find player by corpse->GetOwnerGuid() to get race/rank info as looting player/player corpse in BG results in conversion into bones and bones didn't have owner guid.

If code for AV loot is rejected I can make a PR with just crashfix so that ppl can at least loot money from players in BGs