### PR TITLE
Fix saving of NPCs spawned via .npc add command to DB

### DIFF
--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -1216,7 +1216,7 @@ void Creature::SaveToDB(uint32 mapid)
        << GetGUIDLow() << ","
        << data.id << ","
        << data.mapid << ","
-       << data.spawnMask << ","
+       << static_cast<uint32>(data.spawnMask) << ","
        << data.modelid_override << ","
        << data.equipmentId << ","
        << data.posX << ","
@@ -1225,12 +1225,12 @@ void Creature::SaveToDB(uint32 mapid)
        << data.orientation << ","
        << data.spawntimesecsmin << ","                     // respawn time minimum
        << data.spawntimesecsmax << ","                     // respawn time maximum
-       << (float) data.spawndist << ","                    // spawn distance (float)
+       << static_cast<float>(data.spawndist) << ","        // spawn distance (float)
        << data.currentwaypoint << ","                      // currentwaypoint
        << data.curhealth << ","                            // curhealth
        << data.curmana << ","                              // curmana
        << (data.is_dead  ? 1 : 0) << ","                   // is_dead
-       << uint32(data.movementType) << ")";                // default movement generator type, cast to prevent save as symbol
+       << static_cast<uint32>(data.movementType) << ")";   // default movement generator type, cast to prevent save as symbol
 
     WorldDatabase.PExecuteLog("%s", ss.str().c_str());
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Using .npc add to spawn a NPC gives a console error about the insert query failing to execute, and the spawned NPC would not be saved in the database. The generated logSQL file would not work when running it, either.

This is because spawnMask is an uint8, which in C++ is a character type and interpreted as such. So the query would be executed with an invalid character instead of the spawnMask integer, and fail to run.

Also converted the two nearby C-style casts to static_casts as I noticed those are preferred for newer code, sorry if I did wrong.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .npc add 1
- Check console output and logSQL file created in server dir.