### PR TITLE
Implement command .debug areatriggers to make areatrigger scripting easier by informing gamemasters when they enter an areatrigger

### DIFF
--- a/sql/updates/mangos/z2788_01_mangos_command.sql
+++ b/sql/updates/mangos/z2788_01_mangos_command.sql
@@ -1,0 +1,10 @@
+DELETE FROM `command` WHERE `name`="debug areatriggers";
+INSERT INTO `command` (`name`, `security`, `help`) VALUES
+("debug areatriggers", 1, "Syntax: .debug areatriggers\n\nToggle debug mode for areatriggers. In debug mode GM will be notified if reaching an areatrigger.");
+
+DELETE FROM `mangos_string` WHERE `entry` IN (183, 184, 185);
+INSERT INTO `mangos_string` (`entry`, `content_default`) VALUES
+(183, "Areatrigger debugging turned on."),
+(184, "Areatrigger debugging turned off."),
+(185, "You have reached areatrigger %u.");
+

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -232,6 +232,7 @@ ChatCommand* ChatHandler::getCommandTable()
     static ChatCommand debugCommandTable[] =
     {
         { "anim",           SEC_GAMEMASTER,     false, &ChatHandler::HandleDebugAnimCommand,                "", nullptr },
+        { "areatriggers",   SEC_MODERATOR,      false, &ChatHandler::HandleDebugAreaTriggersCommand,        "", nullptr },
         { "bg",             SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugBattlegroundCommand,        "", nullptr },
         { "getitemstate",   SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugGetItemStateCommand,        "", nullptr },
         { "lootrecipient",  SEC_GAMEMASTER,     false, &ChatHandler::HandleDebugGetLootRecipientCommand,    "", nullptr },

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -289,6 +289,8 @@ class ChatHandler
 
         bool HandleDebugPetDismissSound(char* args);
 
+        bool HandleDebugAreaTriggersCommand(char* args);
+
         bool HandleDebugSendBuyErrorCommand(char* args);
         bool HandleDebugSendChannelNotifyCommand(char* args);
         bool HandleDebugSendChatMsgCommand(char* args);

--- a/src/game/Chat/debugcmds.cpp
+++ b/src/game/Chat/debugcmds.cpp
@@ -321,6 +321,22 @@ bool ChatHandler::HandleDebugPetDismissSound(char* args)
     return true;
 }
 
+bool ChatHandler::HandleDebugAreaTriggersCommand(char* /*args*/)
+{
+    Player* player = m_session->GetPlayer();
+    if (!player->isDebuggingAreaTriggers())
+    {
+        PSendSysMessage(LANG_DEBUG_AREATRIGGER_ON);
+        player->SetDebuggingAreaTriggers(true);
+    }
+    else
+    {
+        PSendSysMessage(LANG_DEBUG_AREATRIGGER_OFF);
+        player->SetDebuggingAreaTriggers(false);
+    }
+    return true;
+}
+
 // Send notification in channel
 bool ChatHandler::HandleDebugSendChannelNotifyCommand(char* args)
 {

--- a/src/game/Entities/MiscHandler.cpp
+++ b/src/game/Entities/MiscHandler.cpp
@@ -695,6 +695,9 @@ void WorldSession::HandleAreaTriggerOpcode(WorldPacket& recv_data)
         return;
     }
 
+    if (player->isDebuggingAreaTriggers())
+        ChatHandler(player->GetSession()).PSendSysMessage(LANG_DEBUG_AREATRIGGER_REACHED, Trigger_ID);
+
     if (sScriptDevAIMgr.OnAreaTrigger(player, atEntry))
         return;
 

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -629,6 +629,8 @@ Player::Player(WorldSession* session): Unit(), m_taxiTracker(*this), m_mover(thi
 
     m_consumedMods = nullptr;
     m_modsSpell = nullptr;
+
+    m_isDebuggingAreaTriggers = false;
 }
 
 Player::~Player()

--- a/src/game/Entities/Player.h
+++ b/src/game/Entities/Player.h
@@ -951,6 +951,8 @@ class Player : public Unit
         bool isGMVisible() const { return !(m_ExtraFlags & PLAYER_EXTRA_GM_INVISIBLE); }
         void SetGMVisible(bool on);
         void SetPvPDeath(bool on) { if (on) m_ExtraFlags |= PLAYER_EXTRA_PVP_DEATH; else m_ExtraFlags &= ~PLAYER_EXTRA_PVP_DEATH; }
+        bool isDebuggingAreaTriggers() { return m_isDebuggingAreaTriggers; }
+        void SetDebuggingAreaTriggers(bool on) { m_isDebuggingAreaTriggers = on; }
 
         // Cannot be detected by creature (Should be tested in AI::MoveInLineOfSight)
         void SetCannotBeDetectedTimer(uint32 milliseconds) { m_cannotBeDetectedTimer = milliseconds; };
@@ -2411,6 +2413,8 @@ class Player : public Unit
         ObjectGuid m_summoner;
 
         std::map<uint32, uint32> m_forgottenSkills;
+
+        bool m_isDebuggingAreaTriggers;
 
     private:
         // internal common parts for CanStore/StoreItem functions

--- a/src/game/Tools/Language.h
+++ b/src/game/Tools/Language.h
@@ -188,7 +188,11 @@ enum MangosStrings
 
     LANG_COMMAND_CHANNELS_NO_CHANNELS   = 181,              // "There are no matching custom channels at the moment"
     LANG_COMMAND_CHANNELS_LIST_HEADER   = 182,              // "Listing up to %u custom channels matching criterea:"
-    // Room for more level 1              183-199 not used
+
+    LANG_DEBUG_AREATRIGGER_ON           = 183,
+    LANG_DEBUG_AREATRIGGER_OFF          = 184,
+    LANG_DEBUG_AREATRIGGER_REACHED      = 185,
+    // Room for more level 1              186-199 not used
 
     // level 2 chat
     LANG_NO_SELECTION                   = 200,


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

Taken from TrinityCore, so all credits to them.

The command .debug areatriggers is a toggle that starts off. When it's activated, whenever the GM enters an areatrigger it will send a chat message containing the areatrigger's id. This makes identifying areatriggers far easier.
To disable it, use the command again.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .debug area
- .tele zul'gurub
- Enter the raid.
- Walk forward: there's an areatrigger just in front of the entrance, before the stairs.
- Once you enter the areatrigger, you will see a chat message.
- Type .debug area to disable it.