### PR TITLE
Implement command .tele warp to teleport the user along a specified axis by a specified value

### DIFF
--- a/sql/updates/mangos/z2788_01_mangos_command.sql
+++ b/sql/updates/mangos/z2788_01_mangos_command.sql
@@ -1,0 +1,4 @@
+DELETE FROM `command` WHERE `name`="tele warp";
+INSERT INTO `command` (`name`, `security`, `help`) VALUES
+("tele warp", 1, "Syntax: .tele warp #axis #value\n\nTeleports the user by the specified value along the specified axis.\nUse a positive value to move forward the axis, and a negative value to move backward the axis.\nValid axis are x (+forward/-backward), y (+right/-left), z (+above/-below), o (orientation, value is specified in degrees).");
+

--- a/sql/updates/mangos/z2788_01_mangos_command.sql
+++ b/sql/updates/mangos/z2788_01_mangos_command.sql
@@ -1,4 +1,4 @@
-DELETE FROM `command` WHERE `name`="tele warp";
+DELETE FROM `command` WHERE `name`="go warp";
 INSERT INTO `command` (`name`, `security`, `help`) VALUES
-("tele warp", 1, "Syntax: .tele warp #axis #value\n\nTeleports the user by the specified value along the specified axis.\nUse a positive value to move forward the axis, and a negative value to move backward the axis.\nValid axis are x (+forward/-backward), y (+right/-left), z (+above/-below), o (orientation, value is specified in degrees).");
+("go warp", 1, "Syntax: .go warp #axis #value\n\nTeleports the user by the specified value along the specified axis.\nUse a positive value to move forward the axis, and a negative value to move backward the axis.\nValid axis are x (+forward/-backward), y (+right/-left), z (+above/-below), o (orientation, value is specified in degrees).");
 

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -787,6 +787,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "del",            SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleTeleDelCommand,             "", nullptr },
         { "name",           SEC_MODERATOR,      true,  &ChatHandler::HandleTeleNameCommand,            "", nullptr },
         { "group",          SEC_MODERATOR,      false, &ChatHandler::HandleTeleGroupCommand,           "", nullptr },
+        { "warp",           SEC_MODERATOR,      false, &ChatHandler::HandleTeleWarpCommand,            "", nullptr },
         { "",               SEC_MODERATOR,      false, &ChatHandler::HandleTeleCommand,                "", nullptr },
         { nullptr,          0,                  false, nullptr,                                        "", nullptr }
     };

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -301,6 +301,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "object",         SEC_MODERATOR,      false, &ChatHandler::HandleGoObjectCommand,            "", nullptr },
         { "taxinode",       SEC_MODERATOR,      false, &ChatHandler::HandleGoTaxinodeCommand,          "", nullptr },
         { "trigger",        SEC_MODERATOR,      false, &ChatHandler::HandleGoTriggerCommand,           "", nullptr },
+        { "warp",           SEC_MODERATOR,      false, &ChatHandler::HandleGoWarpCommand,              "", nullptr },
         { "zonexy",         SEC_MODERATOR,      false, &ChatHandler::HandleGoZoneXYCommand,            "", nullptr },
         { "xy",             SEC_MODERATOR,      false, &ChatHandler::HandleGoXYCommand,                "", nullptr },
         { "xyz",            SEC_MODERATOR,      false, &ChatHandler::HandleGoXYZCommand,               "", nullptr },
@@ -787,7 +788,6 @@ ChatCommand* ChatHandler::getCommandTable()
         { "del",            SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleTeleDelCommand,             "", nullptr },
         { "name",           SEC_MODERATOR,      true,  &ChatHandler::HandleTeleNameCommand,            "", nullptr },
         { "group",          SEC_MODERATOR,      false, &ChatHandler::HandleTeleGroupCommand,           "", nullptr },
-        { "warp",           SEC_MODERATOR,      false, &ChatHandler::HandleTeleWarpCommand,            "", nullptr },
         { "",               SEC_MODERATOR,      false, &ChatHandler::HandleTeleCommand,                "", nullptr },
         { nullptr,          0,                  false, nullptr,                                        "", nullptr }
     };

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -348,6 +348,7 @@ class ChatHandler
         bool HandleGoObjectCommand(char* args);
         bool HandleGoTaxinodeCommand(char* args);
         bool HandleGoTriggerCommand(char* args);
+        bool HandleGoWarpCommand(char* args);
         bool HandleGoXYCommand(char* args);
         bool HandleGoXYZCommand(char* args);
         bool HandleGoZoneXYCommand(char* args);
@@ -635,7 +636,6 @@ class ChatHandler
         bool HandleTeleDelCommand(char* args);
         bool HandleTeleGroupCommand(char* args);
         bool HandleTeleNameCommand(char* args);
-        bool HandleTeleWarpCommand(char* args);
 
         bool HandleTriggerActiveCommand(char* args);
         bool HandleTriggerNearCommand(char* args);

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -635,6 +635,7 @@ class ChatHandler
         bool HandleTeleDelCommand(char* args);
         bool HandleTeleGroupCommand(char* args);
         bool HandleTeleNameCommand(char* args);
+        bool HandleTeleWarpCommand(char* args);
 
         bool HandleTriggerActiveCommand(char* args);
         bool HandleTriggerNearCommand(char* args);

--- a/src/game/Chat/Level1.cpp
+++ b/src/game/Chat/Level1.cpp
@@ -1249,62 +1249,6 @@ bool ChatHandler::HandleTeleCommand(char* args)
     return HandleGoHelper(_player, tele->mapId, tele->position_x, tele->position_y, &tele->position_z, &tele->orientation);
 }
 
-bool ChatHandler::HandleTeleWarpCommand(char* args)
-{
-    if (!*args)
-        return false;
-
-    Player* player = m_session->GetPlayer();
-
-    char* arg1 = strtok((char*)args, " ");
-    char* arg2 = strtok(NULL, " ");
-
-    if (!arg1 || !arg2)
-        return false;
-
-    char dir = arg1[0];
-    int32 value = (int32)atoi(arg2);
-    float x = player->GetPositionX();
-    float y = player->GetPositionY();
-    float z = player->GetPositionZ();
-    float o = player->GetOrientation();
-
-    switch (dir)
-    {
-        case 'x':
-        {
-            x = x + cosf(o) * value;
-            y = y + sinf(o) * value;
-            break;
-        }
-        case 'y':
-        {
-            x = x + cos(o - (M_PI / 2)) * value;
-            y = y + sin(o - (M_PI / 2)) * value;
-            break;
-        }
-        case 'z':
-        {
-            z = z + value;
-            break;
-        }
-        case 'o':
-        {
-            o = o - (value * M_PI / 180.0f);
-            if (o < 0.0f)
-                o += value * M_PI;
-            else if (o > 2 * M_PI)
-                o -= value * M_PI;
-            break;
-        }
-        default:
-            return false;
-    }
-
-    player->NearTeleportTo(x, y, z, o);
-    return true;
-}
-
 bool ChatHandler::HandleLookupAreaCommand(char* args)
 {
     if (!*args)
@@ -1938,6 +1882,62 @@ bool ChatHandler::HandleGoGridCommand(char* args)
     float y = (grid_y - CENTER_GRID_ID + 0.5f) * SIZE_OF_GRIDS;
 
     return HandleGoHelper(_player, mapid, x, y);
+}
+
+bool ChatHandler::HandleGoWarpCommand(char* args)
+{
+    if (!*args)
+        return false;
+
+    Player* player = m_session->GetPlayer();
+
+    char* arg1 = strtok((char*)args, " ");
+    char* arg2 = strtok(NULL, " ");
+
+    if (!arg1 || !arg2)
+        return false;
+
+    char dir = arg1[0];
+    int32 value = (int32)atoi(arg2);
+    float x = player->GetPositionX();
+    float y = player->GetPositionY();
+    float z = player->GetPositionZ();
+    float o = player->GetOrientation();
+
+    switch (dir)
+    {
+        case 'x':
+        {
+            x = x + cosf(o) * value;
+            y = y + sinf(o) * value;
+            break;
+        }
+        case 'y':
+        {
+            x = x + cos(o - (M_PI_F / 2)) * value;
+            y = y + sin(o - (M_PI_F / 2)) * value;
+            break;
+        }
+        case 'z':
+        {
+            z = z + value;
+            break;
+        }
+        case 'o':
+        {
+            o = o - (value * M_PI_F / 180.0f);
+            if (o < 0.0f)
+                o += value * M_PI_F;
+            else if (o > 2 * M_PI_F)
+                o -= value * M_PI_F;
+            break;
+        }
+        default:
+            return false;
+    }
+
+    player->NearTeleportTo(x, y, z, o);
+    return true;
 }
 
 bool ChatHandler::HandleModifyDrunkCommand(char* args)

--- a/src/game/Chat/Level1.cpp
+++ b/src/game/Chat/Level1.cpp
@@ -1249,6 +1249,62 @@ bool ChatHandler::HandleTeleCommand(char* args)
     return HandleGoHelper(_player, tele->mapId, tele->position_x, tele->position_y, &tele->position_z, &tele->orientation);
 }
 
+bool ChatHandler::HandleTeleWarpCommand(char* args)
+{
+    if (!*args)
+        return false;
+
+    Player* player = m_session->GetPlayer();
+
+    char* arg1 = strtok((char*)args, " ");
+    char* arg2 = strtok(NULL, " ");
+
+    if (!arg1 || !arg2)
+        return false;
+
+    char dir = arg1[0];
+    int32 value = (int32)atoi(arg2);
+    float x = player->GetPositionX();
+    float y = player->GetPositionY();
+    float z = player->GetPositionZ();
+    float o = player->GetOrientation();
+
+    switch (dir)
+    {
+        case 'x':
+        {
+            x = x + cosf(o) * value;
+            y = y + sinf(o) * value;
+            break;
+        }
+        case 'y':
+        {
+            x = x + cos(o - (M_PI / 2)) * value;
+            y = y + sin(o - (M_PI / 2)) * value;
+            break;
+        }
+        case 'z':
+        {
+            z = z + value;
+            break;
+        }
+        case 'o':
+        {
+            o = o - (value * M_PI / 180.0f);
+            if (o < 0.0f)
+                o += value * M_PI;
+            else if (o > 2 * M_PI)
+                o -= value * M_PI;
+            break;
+        }
+        default:
+            return false;
+    }
+
+    player->NearTeleportTo(x, y, z, o);
+    return true;
+}
+
 bool ChatHandler::HandleLookupAreaCommand(char* args)
 {
     if (!*args)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

The command .tele warp teleports the user along a specified axis by a specified amount. This allows forward/backward/left/right/above/below movement, as well as changing the current orientation by a certain amount of degrees.
Currently it is impossible for a gamemaster to teleport below the terrain level of a map; with this command, it is as easy as typing ".tele warp z -5" (not really useful for Vanilla as you can't use .gm fly there, so you fall until you get ported to the nearest graveyard, but good for TBC and WotLK).
Want to see what lies beyond an instance portal? ".tele warp x 20" will allow you to teleport beyond the instance portal.

Credit for the involved math to [this forum post](https://www.getmangos.eu/forums/topic/5918-solved-warp-command-in-all-directions-this-damn-math-caclulations/#comment-58246) by [lillecarl](https://www.getmangos.eu/profile/2666-lillecarl/).

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Forward: .tele warp x 10
- Backward: .tele warp x -10
- Right: .tele warp y 10
- Left: .tele warp y -10
- Above: .tele warp z 10
- Below: .tele warp z -10
- Face opposite direction: .tele warp o 180
- 360 no scope!: .tele warp o 360