### PR TITLE
Fix log file timestamps

### DIFF
--- a/src/shared/Log.cpp
+++ b/src/shared/Log.cpp
@@ -352,7 +352,8 @@ std::string Log::GetTimestampStr()
     //       MM     minutes (2 digits 00-59)
     //       SS     seconds (2 digits 00-59)
     char buf[20];
-    if (snprintf(buf, 20, "%04d-%02d-%02d_%02d-%02d-%02d", aTm->tm_year + 1900, aTm->tm_mon + 1, aTm->tm_mday, aTm->tm_hour, aTm->tm_min, aTm->tm_sec))
+    int snRes = snprintf(buf, 20, "%04d-%02d-%02d_%02d-%02d-%02d", aTm->tm_year + 1900, aTm->tm_mon + 1, aTm->tm_mday, aTm->tm_hour, aTm->tm_min, aTm->tm_sec);
+    if (snRes < 0 || snRes >= sizeof(buf))
         return "";
     return std::string(buf);
 }

--- a/src/shared/Util.cpp
+++ b/src/shared/Util.cpp
@@ -252,7 +252,8 @@ std::string TimeToTimestampStr(time_t t)
     //       MM     minutes (2 digits 00-59)
     //       SS     seconds (2 digits 00-59)
     char buf[20];
-    if (snprintf(buf, 20, "%04d-%02d-%02d_%02d-%02d-%02d", aTm->tm_year + 1900, aTm->tm_mon + 1, aTm->tm_mday, aTm->tm_hour, aTm->tm_min, aTm->tm_sec))
+    int snRes = snprintf(buf, 20, "%04d-%02d-%02d_%02d-%02d-%02d", aTm->tm_year + 1900, aTm->tm_mon + 1, aTm->tm_mday, aTm->tm_hour, aTm->tm_min, aTm->tm_sec);
+    if (snRes < 0 || snRes >= sizeof(buf))
         return "";
     return std::string(buf);
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

Fix log file timestamps the same way vmap extraction was fixed in https://github.com/cmangos/mangos-classic/commit/b5baa9f8931f9751928de5e3ace70cd9c7a6c447.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Closes https://github.com/cmangos/issues/issues/2778.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Set LogTimestamp = 1 in realmd.conf, start realmd.exe, check created log's file name.