### PR TITLE
Set off-hand attack speed for mobs to the same speed as main hand, and delay off-hand attack by half of the speed instead of the full speed

### DIFF
--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -524,7 +524,7 @@ bool Creature::UpdateEntry(uint32 Entry, const CreatureData* data /*=nullptr*/, 
     uint32 attackTimer = GetCreatureInfo()->MeleeBaseAttackTime;
 
     SetAttackTime(BASE_ATTACK,  attackTimer);
-    SetAttackTime(OFF_ATTACK,   attackTimer - attackTimer / 4);
+    SetAttackTime(OFF_ATTACK,   attackTimer);
     SetAttackTime(RANGED_ATTACK, GetCreatureInfo()->RangedBaseAttackTime);
 
     uint32 unitFlags = GetCreatureInfo()->UnitFlags;

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -6073,9 +6073,9 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
     if (CanHaveThreatList())
         getThreatManager().setCurrentVictimByTarget(victim);
 
-    // delay offhand weapon attack to next attack time
+    // delay offhand weapon attack to half of offhand attack speed
     if (hasOffhandWeaponForAttack())
-        resetAttackTimer(OFF_ATTACK);
+        setAttackTimer(OFF_ATTACK, (GetAttackTime(OFF_ATTACK) * m_modAttackSpeedPct[OFF_ATTACK]) / 2);
 
     if (meleeAttack)
         MeleeAttackStart(m_attacking);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This is something I noticed while testing other things, but the sniffer and parser aren't updated yet so I had to get a bit creative. Please bear with me.

This PR fixes two bugs:
- When you start attacking a mob while close to it (so that no attack errors like "out of range" are triggered) and for creatures, the off hand attack is delayed by half its own attack speed, not by the full attack speed.
- Mobs do not do off hand attacks 1/4 faster than main hand attacks.

I needed a way to measure it as precisely as possible. Enter 120 fps videos and [Avidemux](http://avidemux.sourceforge.net/) (video player that shows the frame time in milliseconds).


First example: 2.4 speed MH, 2.5 speed OH

https://user-images.githubusercontent.com/99603810/156881720-ef253838-9575-45e2-a859-9de2aee8bb3e.mp4

00:00:08:066: MH attack
00:00:09:316: OH attack
00:00:10:466: MH attack
OH attack happens 1250 ms after MH attack. 1250 * 2 = 2500 ms.


Second example: 1.6 speed MH, 1.8 speed OH

https://user-images.githubusercontent.com/99603810/156881756-f5a95ff8-8e23-4be6-9d7c-3bb5d405c776.mp4

00:00:06:491: MH attack
00:00:07:358: OH attack
00:00:08:091: MH attack
OH attack happens 867 ms after MH attack. 867 * 2 = 1734 ms (consider that this method of measuring can have an error of a few milliseconds).


Third example: 1.6 speed MH, 2.5 speed OH

https://user-images.githubusercontent.com/99603810/156881816-9a4f06c6-47f1-46ed-abc9-0c87a4d27b56.mp4

00:00:09:125: MH attack
00:00:10:375: OH attack
00:00:10:725: MH attack
OH attack happens 1250 ms after MH attack. 1250 * 2 = 2500 ms.

In all three cases, the OH attack happens exactly (OH weapon speed / 2) milliseconds after the main hand attack.


Now for the case that concerns mobs (MeleeBaseAttackTime = 2000 for this specific mob):

https://user-images.githubusercontent.com/99603810/156881859-608f191f-dc82-4749-b2e8-e7f4829978e3.mp4

00:00:06:450: MH attack
00:00:07:433: OH attack
00:00:08:450: MH attack
00:00:09:450: OH attack
00:00:10:466: MH attack
Ignore the Backstabs, I had to avoid parries because they increase the attacker's attack speed.
OH attack happens 983 ms after MH attack. 983 * 2 = 1966 ms.

In this case, the mob has attack speed = 2 seconds. The offhand attack happens one second after the main hand attack.
And, related to the second fix, notice how the offhand attacks happens exactly 2 seconds after the previous one. So it's not reduced to 1500 ms speed like the current code does.


Compare it to the current CMaNGOS behavior:

https://user-images.githubusercontent.com/99603810/156881987-5efddeb7-6e09-407a-bd3c-734273cf79c8.mp4

00:00:05:925: MH attack
00:00:07:325: OH attack
00:00:07:975: MH attack
00:00:08:858: OH attack
OH attack happens 1400 ms after MH attack. The delay between each OH attack is 1533 ms. Wrong on both accounts compared to retail.


And something that's not covered by this PR but have been wondering about: on retail, if you right-click a mob from far away, you get an "out of range" error. Then, if you get closer to the mob, you attack with both MH and OH instantly.

https://user-images.githubusercontent.com/99603810/156882123-409d7d99-ec29-437b-9ab2-318d5bb1d455.mp4

On CMaNGOS Classic you get no errors when you right-click a mob from far away, so this behavior does not happen. You do get errors when you turn around to face your back to the mob (you get a "wrong facing" error"), and when you turn back you correctly attack the mob with both weapons instantly. I was wondering if you should get errors and attack timing set to 100 when right-clicking a mob from far away in 1.12.1, because the character just staying there and without errors seems strange to me.

This could seem like a nitpick, but it's a big deal for any dual-wielding class.

### Proof
<!-- Link resources as proof -->
- Linked above.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Attack a mob while dual-wielding, preferably with a way to measure the timing with milliseconds precision.