### PR TITLE
Fix Scourge Invasion mail spam

### DIFF
--- a/src/game/World/WorldState.cpp
+++ b/src/game/World/WorldState.cpp
@@ -216,7 +216,7 @@ void WorldState::Load()
     SpawnWarEffortGos();
     if (m_siData.m_state == STATE_1_ENABLED)
     {
-        StartScourgeInvasion();
+        StartScourgeInvasion(false);
         HandleDefendedZones();
     }
     RespawnEmeraldDragons();
@@ -994,15 +994,15 @@ void WorldState::SetScourgeInvasionState(SIState state)
     
     m_siData.m_state = state;
     if (oldState == STATE_0_DISABLED)
-        StartScourgeInvasion();
+        StartScourgeInvasion(true);
     else if (state == STATE_0_DISABLED)
         StopScourgeInvasion();
     Save(SAVE_ID_SCOURGE_INVASION);
 }
 
-void WorldState::StartScourgeInvasion()
+void WorldState::StartScourgeInvasion(bool sendMail)
 {
-    sGameEventMgr.StartEvent(GAME_EVENT_SCOURGE_INVASION);
+    sGameEventMgr.StartEvent(GAME_EVENT_SCOURGE_INVASION, false, !sendMail);
     BroadcastSIWorldstates();
     if (m_siData.m_state == STATE_1_ENABLED)
     {

--- a/src/game/World/WorldState.h
+++ b/src/game/World/WorldState.h
@@ -358,7 +358,7 @@ class WorldState
         std::string GetAQPrintout();
 
         void SetScourgeInvasionState(SIState state);
-        void StartScourgeInvasion();
+        void StartScourgeInvasion(bool sendMail);
         void StopScourgeInvasion();
         uint32 GetSIRemaining(SIRemaining remaining) const;
         uint32 GetSIRemainingByZone(uint32 zoneId) const;


### PR DESCRIPTION
Fixes Scourge invasion letters being sent on every server start

### Issues
- Event mail with quest item is sent on every server start if scourge invasion is enabled. E.g. start server 30 times = get 30 letters to every character.

### How2Test
- Start Scourge Invasion (.worldstate scourge state 1), you receive 1 letter with quest item, restart server. You now have 2 identical letters (only first one will have item though).