### PR TITLE
Fix unavailable trainer spells show up in list

### DIFF
--- a/src/game/Entities/NPCHandler.cpp
+++ b/src/game/Entities/NPCHandler.cpp
@@ -107,13 +107,13 @@ static void SendTrainerSpellHelper(WorldPacket& data, TrainerSpell const* tSpell
     data << uint8(state == TRAINER_SPELL_GREEN_DISABLED ? TRAINER_SPELL_GREEN : state);
     data << uint32(floor(tSpell->spellCost * fDiscountMod));
 
-    data << uint32(0); // spells don't cost talent points
+    data << uint32(primary_prof_first_rank && can_learn_primary_prof ? 1 : 0);
     data << uint32(primary_prof_first_rank ? 1 : 0);    // must be equal prev. field to have learn button in enabled state
     data << uint8(reqLevel);
     data << uint32(tSpell->reqSkill);
     data << uint32(tSpell->reqSkillValue);
-    data << uint32(!tSpell->IsCastable() && chain_node ? (chain_node->prev ? chain_node->prev : chain_node->req) : 0);
-    data << uint32(!tSpell->IsCastable() && chain_node && chain_node->prev ? chain_node->req : 0);
+    data << uint32(chain_node ? (chain_node->req ? chain_node->req : chain_node->prev) : 0);
+    data << uint32(chain_node ? (chain_node->req ? chain_node->prev : 0) : 0);
     data << uint32(0);
 }
 


### PR DESCRIPTION
Fixes "red" spells show up as "green" in trainer list
Used vmangos as reference

### Issues
- Unavailable "red" spells (e.g. non-learned talent ranks) show up in available ("green") spell list and button to learn them is active. It does not work, but still having these spells there is wrong (if disabled in filter) and interrupts learning process as "Train" button does not switch to next spell because of it.

### How2Test
- .level 59, visit class trainer, try to learn spells by spamming "Train" button - you will see.
