### PR TITLE
Use #/bin/bash instead of #/bin/sh

### DIFF
--- a/contrib/extractor_scripts/ExtractResources.sh
+++ b/contrib/extractor_scripts/ExtractResources.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 # This file is part of the CMaNGOS Project. See AUTHORS file for Copyright information

--- a/contrib/extractor_scripts/ExtractResources.sh
+++ b/contrib/extractor_scripts/ExtractResources.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 # This file is part of the CMaNGOS Project. See AUTHORS file for Copyright information
@@ -144,8 +144,8 @@ then
   echo "How many CPU threads should be used for extracting mmaps? (leave empty to use all available threads)"
   read line
   echo
-  if [[ ! -z $line ]]; then
-    if [[ $line =~ ^[1-9+]$ ]]; then
+  if [ ! -z "$line" ]; then
+    if [ $(expr "$line" : "^[1-9][0-9]*$") -gt 0 ]; then
       NUM_THREAD=$line
     else
       echo "Only numbers are allowed!"
@@ -252,11 +252,6 @@ if [ "$USE_VMAPS" = "1" ]
 then
   echo "$(date): Start extraction of vmaps..." | tee -a $LOG_FILE
   $PREFIX/vmap_extractor $VMAP_RES $VMAP_OPT_RES | tee -a $DETAIL_LOG_FILE
-  exit_code="${PIPESTATUS[0]}"
-  if [[ "$exit_code" -ne "0" ]]; then
-    echo "$(date): Extraction of vmaps failed with errors. Aborting extraction. See the log file for more details."
-    exit "$exit_code"
-  fi
   echo "$(date): Extracting of vmaps finished" | tee -a $LOG_FILE
   if [ ! -d "$(pwd)/vmaps" ]
   then
@@ -264,11 +259,6 @@ then
   fi
   echo "$(date): Start assembling of vmaps..." | tee -a $LOG_FILE
   $PREFIX/vmap_assembler ${OUTPUT_PATH:-.}/Buildings ${OUTPUT_PATH:-.}/vmaps | tee -a $DETAIL_LOG_FILE
-  exit_code="${PIPESTATUS[0]}"
-  if [[ "$exit_code" -ne "0" ]]; then
-    echo "$(date): Assembling of vmaps failed with errors. Aborting extraction. See the log file for more details."
-    exit "$exit_code"
-  fi
   echo "$(date): Assembling of vmaps finished" | tee -a $LOG_FILE
 
   echo | tee -a $LOG_FILE


### PR DESCRIPTION
Use bash in shebang since double brackets used in this script are bash extensions and for example line 147 is causing the following error with sh "./ExtractResources.sh: 147: [[: not found"  (MoveMapGen.sh is also using  #/bin/bash)