### PR TITLE
adjust ExtractResources.sh to be posix-compliant

### DIFF
--- a/contrib/extractor_scripts/ExtractResources.sh
+++ b/contrib/extractor_scripts/ExtractResources.sh
@@ -144,8 +144,8 @@ then
   echo "How many CPU threads should be used for extracting mmaps? (leave empty to use all available threads)"
   read line
   echo
-  if [[ ! -z $line ]]; then
-    if [[ $line =~ ^[1-9+]$ ]]; then
+  if [ ! -z "$line" ]; then
+    if [ $(expr "$line" : "^[1-9][0-9]*$") -gt 0 ]; then
       NUM_THREAD=$line
     else
       echo "Only numbers are allowed!"
@@ -252,11 +252,6 @@ if [ "$USE_VMAPS" = "1" ]
 then
   echo "$(date): Start extraction of vmaps..." | tee -a $LOG_FILE
   $PREFIX/vmap_extractor $VMAP_RES $VMAP_OPT_RES | tee -a $DETAIL_LOG_FILE
-  exit_code="${PIPESTATUS[0]}"
-  if [[ "$exit_code" -ne "0" ]]; then
-    echo "$(date): Extraction of vmaps failed with errors. Aborting extraction. See the log file for more details."
-    exit "$exit_code"
-  fi
   echo "$(date): Extracting of vmaps finished" | tee -a $LOG_FILE
   if [ ! -d "$(pwd)/vmaps" ]
   then
@@ -264,11 +259,6 @@ then
   fi
   echo "$(date): Start assembling of vmaps..." | tee -a $LOG_FILE
   $PREFIX/vmap_assembler ${OUTPUT_PATH:-.}/Buildings ${OUTPUT_PATH:-.}/vmaps | tee -a $DETAIL_LOG_FILE
-  exit_code="${PIPESTATUS[0]}"
-  if [[ "$exit_code" -ne "0" ]]; then
-    echo "$(date): Assembling of vmaps failed with errors. Aborting extraction. See the log file for more details."
-    exit "$exit_code"
-  fi
   echo "$(date): Assembling of vmaps finished" | tee -a $LOG_FILE
 
   echo | tee -a $LOG_FILE


### PR DESCRIPTION
The ExtractResources.sh script fails when used with sh since bash specific parts are used. (I closed my previous pull request to just use bash instead of sh since an sh compatible version would be preferred https://github.com/cmangos/mangos-classic/pull/491)

In this pull request the regex for checking the "number of threads for mmap" input is adjusted. Moreover, the previous version (`^[1-9+]$`) was also rejecting 10 cores:
>  ➜ bash ExtractResources.sh
> 
> Welcome to helper script to extract required dataz for MaNGOS!
> Should all dataz (dbc, maps, vmaps and mmaps) be extracted? (y/n)
> y
> How many CPU threads should be used for extracting mmaps? (leave empty to use all available threads)
> 10
> Only numbers are allowed!

However, the parts using ${PIPESTATUS[0]} have been removed since other pipes are also not checked and sh compatible workarounds would definitely worsen the readability.

For me the script works like this with sh but I am not a shellscript guru. So please take a close look at it.


