### PR TITLE
Fix mangos.sql import error

### DIFF
--- a/sql/base/mangos.sql
+++ b/sql/base/mangos.sql
@@ -323,9 +323,9 @@ CREATE TABLE `battleground_template` (
 LOCK TABLES `battleground_template` WRITE;
 /*!40000 ALTER TABLE `battleground_template` DISABLE KEYS */;
 INSERT INTO `battleground_template` VALUES
-(1,20,40,51,60,611,610,100),
-(2,5,10,10,60,769,770,75),
-(3,8,15,20,60,890,889,75);
+(1,20,40,51,60,611,610,100,0),
+(2,5,10,10,60,769,770,75,0),
+(3,8,15,20,60,890,889,75,0);
 /*!40000 ALTER TABLE `battleground_template` ENABLE KEYS */;
 UNLOCK TABLES;
 


### PR DESCRIPTION
Fix error below on mangos.sql import
ERROR 1136 (21S01) at line 325: Column count doesn't match value count at row 1

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
