### PR TITLE
Fix ready check

### DIFF
--- a/src/game/Groups/GroupHandler.cpp
+++ b/src/game/Groups/GroupHandler.cpp
@@ -589,8 +589,7 @@ void WorldSession::HandleRaidReadyCheckOpcode(WorldPacket& recv_data)
         /********************/
 
         // everything is fine, do it
-        WorldPacket data(MSG_RAID_READY_CHECK, 8);
-        data << ObjectGuid(GetPlayer()->GetObjectGuid());
+        WorldPacket data(MSG_RAID_READY_CHECK, 0);
         group->BroadcastPacket(data, true, -1);
 
         group->OfflineReadyCheck();
@@ -605,10 +604,13 @@ void WorldSession::HandleRaidReadyCheckOpcode(WorldPacket& recv_data)
             return;
 
         // everything is fine, do it
-        WorldPacket data(MSG_RAID_READY_CHECK_CONFIRM, 9);
-        data << GetPlayer()->GetObjectGuid();
-        data << uint8(state);
-        group->BroadcastReadyCheck(data);
+        if (Player* gleader = sObjectMgr.GetPlayer(group->GetLeaderGuid()))
+        {
+            WorldPacket data(MSG_RAID_READY_CHECK, 9);
+            data << GetPlayer()->GetObjectGuid();
+            data << uint8(state);
+            gleader->GetSession()->SendPacket(data);
+        }
     }
 }
 


### PR DESCRIPTION
## 🍰 Pullrequest
Fixes ready check handler

### Proof
Taken from vmangos

### Issues
Original code is from tbc, in 1.12 it should not have player guid who started it sent on request (Because client automatically shows leader name in request, Assistants cant do ready check as in tbc), and response from players should only be sent to raid leader, otherwise leader sees that he is not ready and other artifacts.

### How2Test
- Make a raid of 2+ ppl
- Try to do ready check
- Watch result
