### PR TITLE
Added virtual destructor to Worker so MapUpdateWorker can be deleted …

### DIFF
--- a/src/game/Maps/MapWorkers.h
+++ b/src/game/Maps/MapWorkers.h
@@ -31,7 +31,7 @@ class Worker
     public:
         Worker(MapUpdater& updater) : m_updater(updater) {}
         virtual void execute() {};
-
+        virtual ~Worker() = default;
     protected:
         MapUpdater& GetWorker() { return m_updater; }
 


### PR DESCRIPTION
…properly as Worker* in MapUpdater::OnceWorkerThread()

## 🍰 Pullrequest
MapUpdateWorker is deleted as Worker* however Worker lacks a virtual destructor. This leads to undefined behavior and might cause memory leaks.

### Proof
<!-- Link resources as proof -->
As MapUpdateWorker is created here and stored as Worker*:
https://github.com/cmangos/mangos-classic/blob/b2ac38debda59413b680575b26e57df2b9b77638/src/game/Maps/MapManager.cpp#L199

The Worker* is later deleted in:
https://github.com/cmangos/mangos-classic/blob/b2ac38debda59413b680575b26e57df2b9b77638/src/game/Maps/MapUpdater.cpp#L82

From the C++98 ISO/IEC documentation:
In the first alternative (delete object), if the static type of the operand is different from its dynamic type, the static type shall be a base class of the operand’s dynamic type and the static type shall have a virtual destructor or the behavior is undefined.
