### PR TITLE
Prevent using dangling pointer to HonorStanding.

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -6448,10 +6448,10 @@ void Player::UpdateHonor()
     SetHonorLastWeekStandingPos(sObjectMgr.GetHonorStandingPositionByGUID(GetGUIDLow(), GetTeam()));
 
     // RANK POINTS
-    HonorStanding standing = sObjectMgr.GetHonorStandingByGUID(GetGUIDLow(), GetTeam());
+    std::optional<HonorStanding> standing = sObjectMgr.GetHonorStandingByGUID(GetGUIDLow(), GetTeam());
     float rankP = GetStoredHonor();
     if (standing)
-        rankP += standing.rpEarning;
+        rankP += standing.value().rpEarning;
 
     SetRankPoints(rankP);
 

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -6451,7 +6451,7 @@ void Player::UpdateHonor()
     std::optional<HonorStanding> standing = sObjectMgr.GetHonorStandingByGUID(GetGUIDLow(), GetTeam());
     float rankP = GetStoredHonor();
     if (standing)
-        rankP += standing.value().rpEarning;
+        rankP += standing->rpEarning;
 
     SetRankPoints(rankP);
 

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -6448,10 +6448,10 @@ void Player::UpdateHonor()
     SetHonorLastWeekStandingPos(sObjectMgr.GetHonorStandingPositionByGUID(GetGUIDLow(), GetTeam()));
 
     // RANK POINTS
-    HonorStanding* standing = sObjectMgr.GetHonorStandingByGUID(GetGUIDLow(), GetTeam());
+    HonorStanding standing = sObjectMgr.GetHonorStandingByGUID(GetGUIDLow(), GetTeam());
     float rankP = GetStoredHonor();
     if (standing)
-        rankP += standing->rpEarning;
+        rankP += standing.rpEarning;
 
     SetRankPoints(rankP);
 

--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -3681,19 +3681,19 @@ HonorStandingList ObjectMgr::GetStandingListBySide(uint32 side)
     }
 }
 
-HonorStanding* ObjectMgr::GetHonorStandingByGUID(uint32 guid, uint32 side)
+HonorStanding ObjectMgr::GetHonorStandingByGUID(uint32 guid, uint32 side)
 {
     HonorStandingList standingList = sObjectMgr.GetStandingListBySide(side);
 
     for (HonorStandingList::iterator itr = standingList.begin(); itr != standingList.end() ; ++itr)
         if (itr->guid == guid)
-            return itr->GetInfo();
+            return *itr;
 
-    return 0;
+    return HonorStanding();
 }
 
 
-HonorStanding* ObjectMgr::GetHonorStandingByPosition(uint32 position, uint32 side)
+HonorStanding ObjectMgr::GetHonorStandingByPosition(uint32 position, uint32 side)
 {
     HonorStandingList standingList = sObjectMgr.GetStandingListBySide(side);
     uint32 pos = 1;
@@ -3701,11 +3701,11 @@ HonorStanding* ObjectMgr::GetHonorStandingByPosition(uint32 position, uint32 sid
     for (HonorStandingList::iterator itr = standingList.begin(); itr != standingList.end() ; ++itr)
     {
         if (pos == position)
-            return itr->GetInfo();
+            return *itr;
         pos++;
     }
 
-    return 0;
+    return HonorStanding();
 }
 
 uint32 ObjectMgr::GetHonorStandingPositionByGUID(uint32 guid, uint32 side)

--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -3681,7 +3681,7 @@ HonorStandingList ObjectMgr::GetStandingListBySide(uint32 side)
     }
 }
 
-HonorStanding ObjectMgr::GetHonorStandingByGUID(uint32 guid, uint32 side)
+std::optional<HonorStanding> ObjectMgr::GetHonorStandingByGUID(uint32 guid, uint32 side)
 {
     HonorStandingList standingList = sObjectMgr.GetStandingListBySide(side);
 
@@ -3689,11 +3689,11 @@ HonorStanding ObjectMgr::GetHonorStandingByGUID(uint32 guid, uint32 side)
         if (itr->guid == guid)
             return *itr;
 
-    return HonorStanding();
+    return {};
 }
 
 
-HonorStanding ObjectMgr::GetHonorStandingByPosition(uint32 position, uint32 side)
+std::optional<HonorStanding> ObjectMgr::GetHonorStandingByPosition(uint32 position, uint32 side)
 {
     HonorStandingList standingList = sObjectMgr.GetStandingListBySide(side);
     uint32 pos = 1;
@@ -3705,7 +3705,7 @@ HonorStanding ObjectMgr::GetHonorStandingByPosition(uint32 position, uint32 side
         pos++;
     }
 
-    return HonorStanding();
+    return {};
 }
 
 uint32 ObjectMgr::GetHonorStandingPositionByGUID(uint32 guid, uint32 side)

--- a/src/game/Globals/ObjectMgr.h
+++ b/src/game/Globals/ObjectMgr.h
@@ -38,6 +38,7 @@
 #include <climits>
 #include <memory>
 #include <tuple>
+#include <optional>
 
 class Group;
 class Item;
@@ -421,11 +422,6 @@ class HonorStanding
         {
             return honorPoints > rhs.honorPoints;
         }
-	
-        operator bool() const
-        {
-            return honorPoints || honorKills || guid || rpEarning;
-        }	
 };
 
 typedef std::list<HonorStanding> HonorStandingList;
@@ -772,8 +768,8 @@ class ObjectMgr
             return itr != mFishingBaseForArea.end() ? itr->second : 0;
         }
 
-        static HonorStanding GetHonorStandingByGUID(uint32 guid, uint32 side);
-        static HonorStanding GetHonorStandingByPosition(uint32 position, uint32 side);
+        static std::optional<HonorStanding> GetHonorStandingByGUID(uint32 guid, uint32 side);
+        static std::optional<HonorStanding> GetHonorStandingByPosition(uint32 position, uint32 side);
         HonorStandingList GetStandingListBySide(uint32 side);
         uint32 GetHonorStandingPositionByGUID(uint32 guid, uint32 side);
         void UpdateHonorStandingByGuid(uint32 guid, HonorStanding standing, uint32 side) ;

--- a/src/game/Globals/ObjectMgr.h
+++ b/src/game/Globals/ObjectMgr.h
@@ -421,6 +421,11 @@ class HonorStanding
         {
             return honorPoints > rhs.honorPoints;
         }
+	
+        operator bool() const
+        {
+            return honorPoints || honorKills || guid || rpEarning;
+        }	
 };
 
 typedef std::list<HonorStanding> HonorStandingList;
@@ -767,8 +772,8 @@ class ObjectMgr
             return itr != mFishingBaseForArea.end() ? itr->second : 0;
         }
 
-        static HonorStanding* GetHonorStandingByGUID(uint32 guid, uint32 side);
-        static HonorStanding* GetHonorStandingByPosition(uint32 position, uint32 side);
+        static HonorStanding GetHonorStandingByGUID(uint32 guid, uint32 side);
+        static HonorStanding GetHonorStandingByPosition(uint32 position, uint32 side);
         HonorStandingList GetStandingListBySide(uint32 side);
         uint32 GetHonorStandingPositionByGUID(uint32 guid, uint32 side);
         void UpdateHonorStandingByGuid(uint32 guid, HonorStanding standing, uint32 side) ;

--- a/src/game/Tools/Formulas.h
+++ b/src/game/Tools/Formulas.h
@@ -142,7 +142,7 @@ namespace MaNGOS
 
             // the X values for each breakpoint are found from the CP scores
             // of the players around that point in the WS scores
-            HonorStanding* tempSt;
+            HonorStanding tempSt;
             float honor;
 
             // initialize CP array
@@ -154,10 +154,10 @@ namespace MaNGOS
                 tempSt = sObjectMgr.GetHonorStandingByPosition(sc.BRK[i], team);
                 if (tempSt)
                 {
-                    honor += tempSt->honorPoints;
+                    honor += tempSt.honorPoints;
                     tempSt = sObjectMgr.GetHonorStandingByPosition(sc.BRK[i] + 1, team);
                     if (tempSt)
-                        honor += tempSt->honorPoints;
+                        honor += tempSt.honorPoints;
                 }
 
                 sc.FX[i] = honor ? honor / 2 : 0;

--- a/src/game/Tools/Formulas.h
+++ b/src/game/Tools/Formulas.h
@@ -154,10 +154,10 @@ namespace MaNGOS
                 std::optional<HonorStanding> tempSt = sObjectMgr.GetHonorStandingByPosition(sc.BRK[i], team);
                 if (tempSt)
                 {
-                    honor += tempSt.value().honorPoints;
+                    honor += tempSt->honorPoints;
                     tempSt = sObjectMgr.GetHonorStandingByPosition(sc.BRK[i] + 1, team);
                     if (tempSt)
-                        honor += tempSt.value().honorPoints;
+                        honor += tempSt->honorPoints;
                 }
 
                 sc.FX[i] = honor ? honor / 2 : 0;

--- a/src/game/Tools/Formulas.h
+++ b/src/game/Tools/Formulas.h
@@ -151,13 +151,13 @@ namespace MaNGOS
             for (uint8 i = 1; i <= 13; i++)
             {
                 honor = 0.0f;
-                tempSt = sObjectMgr.GetHonorStandingByPosition(sc.BRK[i], team);
+                std::optional<HonorStanding> tempSt = sObjectMgr.GetHonorStandingByPosition(sc.BRK[i], team);
                 if (tempSt)
                 {
-                    honor += tempSt.honorPoints;
+                    honor += tempSt.value().honorPoints;
                     tempSt = sObjectMgr.GetHonorStandingByPosition(sc.BRK[i] + 1, team);
                     if (tempSt)
-                        honor += tempSt.honorPoints;
+                        honor += tempSt.value().honorPoints;
                 }
 
                 sc.FX[i] = honor ? honor / 2 : 0;


### PR DESCRIPTION
## 🍰 Pullrequest
GetHonorStandingByGUID and GetHonorStandingByPosition return pointers to HonorStanding which are dereferenced inside the methods. This pull-request makes these methods return a copy of the object instead.

### Proof
<!-- Link resources as proof -->
Here (https://github.com/cmangos/mangos-classic/blob/b2ac38debda59413b680575b26e57df2b9b77638/src/game/Globals/ObjectMgr.cpp#L3690) GetInfo() returns a pointer to itself which is a HonorStanding contained in the list defined inside the method.