### PR TITLE
fix multithread access segmentation fault

### DIFF
--- a/src/game/Maps/SpawnGroup.cpp
+++ b/src/game/Maps/SpawnGroup.cpp
@@ -487,7 +487,9 @@ void CreatureGroup::MoveHome()
 void CreatureGroup::Despawn(uint32 timeMSToDespawn, bool onlyAlive, uint32 forcedDespawnTime)
 {
     time_t when = time(nullptr) + forcedDespawnTime;
-    for (auto objItr : m_objects)
+    auto objects = m_objects;
+    
+    for (auto objItr : objects)
     {
         uint32 dbGuid = objItr.first;
         if (Creature* creature = m_map.GetCreature(dbGuid))


### PR DESCRIPTION
## 🍰 Pullrequest
fix segmentation fault caused by multithread access m_objects in CreatureGroup::Despawn

### Proof
![Screenshot from 2023-05-23 16-45-05](https://github.com/cmangos/mangos-classic/assets/5158513/53838a93-6e8d-47ca-8070-84145d56737a)

### Issues
I found my mangosd crashes every day at 12:00 a.m. After added some log I found these lines of code called simultaneously.
```
void SpawnGroup::RemoveObject(WorldObject* wo)
{
    m_objects.erase(wo->GetDbGuid());
    // ...
}

void CreatureGroup::Despawn(uint32 timeMSToDespawn, bool onlyAlive, uint32 forcedDespawnTime)
{
    //...
    for (auto objItr : m_objects)   // segmentation fault here
    {
    }
}
```

### How2Test
- None

### Todo / Checklist
- [X] None
