### PR TITLE
Pathfinder memory leak fix and actually use saved polyRefs.

### DIFF
--- a/src/game/MotionGenerators/PathFinder.cpp
+++ b/src/game/MotionGenerators/PathFinder.cpp
@@ -133,7 +133,7 @@ bool PathFinder::calculate(Vector3 const& start, Vector3 const& dest, bool force
     return true;
 }
 
-dtPolyRef PathFinder::getPathPolyByPosition(const dtPolyRef* polyPath, uint32 polyPathSize, const float* point, float* distance) const
+dtPolyRef PathFinder::getPathPolyByPosition(const dtPolyRef* polyPath, uint32 polyPathSize, const float* point, float* distance, const float maxDist) const
 {
     if (!polyPath || !polyPathSize)
         return INVALID_POLYREF;
@@ -161,7 +161,7 @@ dtPolyRef PathFinder::getPathPolyByPosition(const dtPolyRef* polyPath, uint32 po
     if (distance)
         *distance = dtMathSqrtf(minDist3d);
 
-    return (minDist3d < 3.0f) ? nearestPoly : INVALID_POLYREF;
+    return (minDist3d <= maxDist) ? nearestPoly : INVALID_POLYREF;
 }
 
 dtPolyRef PathFinder::getPolyByLocation(const float* point, float* distance)
@@ -173,6 +173,14 @@ dtPolyRef PathFinder::getPolyByLocation(const float* point, float* distance)
     if (polyRef != INVALID_POLYREF)
         return polyRef;
 
+    //We have more stored points. Search those too
+    if (m_pathPolyRefs.size() > std::max(m_polyLength, m_pointPathLimit)) 
+    {
+        dtPolyRef polyRef = getPathPolyByPosition(&m_pathPolyRefs[m_pointPathLimit], m_pathPolyRefs.size() - m_pointPathLimit, point, distance, 7.0f);
+        if (polyRef != INVALID_POLYREF)
+            return polyRef;
+    }
+
     // we don't have it in our old path
     // try to get it by findNearestPoly()
     // first try with NearPolySearchBound
@@ -180,8 +188,10 @@ dtPolyRef PathFinder::getPolyByLocation(const float* point, float* distance)
     dtStatus dtResult = m_navMeshQuery->findNearestPoly(point, NearPolySearchBound, &m_filter, &polyRef, closestPoint);
     if (dtStatusSucceed(dtResult) && polyRef != INVALID_POLYREF)
     {
-        *distance = dtVdist(closestPoint, point);
-        m_pathPolyRefs.push_back(polyRef);
+        float newDistance = dtVdist(closestPoint, point);
+        if (!*distance || newDistance < *distance) //Only store found point if it's actually closer than the one found from the path.
+            m_pathPolyRefs.push_back(polyRef);
+        *distance = newDistance;
         return polyRef;
     }
 
@@ -193,8 +203,10 @@ dtPolyRef PathFinder::getPolyByLocation(const float* point, float* distance)
     dtResult = m_navMeshQuery->findNearestPoly(point, FarPolySearchBound, &m_filter, &polyRef, closestPoint);
     if (dtStatusSucceed(dtResult) && polyRef != INVALID_POLYREF)
     {
-        *distance = dtVdist(closestPoint, point);
-        m_pathPolyRefs.push_back(polyRef);
+        float newDistance = dtVdist(closestPoint, point);
+        if (!*distance || newDistance < *distance) //Only store found point if it's actually closer than the one found from the path.
+            m_pathPolyRefs.push_back(polyRef);
+        *distance = newDistance;
         return polyRef;
     }
 

--- a/src/game/MotionGenerators/PathFinder.h
+++ b/src/game/MotionGenerators/PathFinder.h
@@ -134,7 +134,7 @@ class PathFinder
         float dist3DSqr(const Vector3& p1, const Vector3& p2) const;
         bool inRangeYZX(const float* v1, const float* v2, float r, float h) const;
 
-        dtPolyRef getPathPolyByPosition(const dtPolyRef* polyPath, uint32 polyPathSize, const float* point, float* distance = nullptr) const;
+        dtPolyRef getPathPolyByPosition(const dtPolyRef* polyPath, uint32 polyPathSize, const float* point, float* distance = nullptr, const float maxDist = 3.0f) const;
         dtPolyRef getPolyByLocation(const float* point, float* distance);
         bool HaveTile(const Vector3& p) const;
 


### PR DESCRIPTION
## 🍰 Pullrequest

This pull request fixes the pathfinders ability to actually use previously saved polyRefs and stops the same from being saved over and over.


An issue was found by looking for memory leaks. For a server that was running for multiple hours Pathfinder.m_pathPolyRefs https://github.com/cmangos/mangos-classic/blob/1debc9cd703d5372ceb5fcb4f279cd8d2b907895/src/game/MotionGenerators/PathFinder.h#L102
was filled with many duplicate records. Futher inspection showed these duplicate records are not used.

This issue is introduced in (https://github.com/cmangos/mangos-classic/commit/9c0a31b496977ad55d11dc7753579a17ae29f93c) and probably the result of an imcomplete change.

This PR fixes the issue where saved polyRefs are not properly found for later use. This also attempts to prevent the same polyRef from being saved over and over again.

### Proof
When looking for polys the pathfinder will first look at polys saved in the current path: https://github.com/cmangos/mangos-classic/blob/1debc9cd703d5372ceb5fcb4f279cd8d2b907895/src/game/MotionGenerators/PathFinder.cpp#L172
However if no suitable poly is found two broader searches are executed to find a result: 
https://github.com/cmangos/mangos-classic/blob/1debc9cd703d5372ceb5fcb4f279cd8d2b907895/src/game/MotionGenerators/PathFinder.cpp#L180
Any found poly is then saved in Pathfinder.m_pathPolyRefs with a pushback in: https://github.com/cmangos/mangos-classic/blob/1debc9cd703d5372ceb5fcb4f279cd8d2b907895/src/game/MotionGenerators/PathFinder.cpp#L184

Pathfinder.m_pathPolyRefs however used to be an array but is now a vector that is initalized with a default size of MAX_POINT_PATH_LENGTH in: https://github.com/cmangos/mangos-classic/blob/1debc9cd703d5372ceb5fcb4f279cd8d2b907895/src/game/MotionGenerators/PathFinder.cpp#L38
This means that new polyRefs pushed_back into Pathfinder.m_pathPolyRefs will be at the end at location MAX_POINT_PATH_LENGTH+(number of saved polyPaths).
However when looping over this vector it loops from 0 to m_polyLength in: https://github.com/cmangos/mangos-classic/blob/1debc9cd703d5372ceb5fcb4f279cd8d2b907895/src/game/MotionGenerators/PathFinder.cpp#L144
Since m_polyLength is the length of the path the extra Polys at the end of the vector are never found.

The result is in: https://github.com/cmangos/mangos-classic/blob/1debc9cd703d5372ceb5fcb4f279cd8d2b907895/src/game/MotionGenerators/PathFinder.cpp#L167
-The path is checked for a suitable poly.
-If none is found a broader search is done using the navmesh query.
-Any result is saved at the end of the vector containing the path.
-The next search will still not find this previously saved poly in the path part of the vector.
-Again a search is done with navmesh query.
-The result is saved again in the vector.
-Ect.


### Issues
This fixes a memory leak for units that do pathfinding over a longer time.
This 'should' give some performance increase because it prevents some extra navmesh queries.

### How2Test
While the server is running for a little while, put a breakpoint at: https://github.com/cmangos/mangos-classic/blob/1debc9cd703d5372ceb5fcb4f279cd8d2b907895/src/game/MotionGenerators/PathFinder.cpp#L167
Notice that this->m_pathPolyRefs does not contain many duplicate records at the end of the vector and the size isn't too many times MAX_POINT_PATH_LENGTH.

### Todo / Checklist
An alternative to this PR is to simply remove the push_backs until futher notice or refactor the pathfinding code to initialize m_pathPolyRefs without a size and dynamically size the vector when needed instead. Ideally I'd like to discuss proper implementation of https://github.com/cmangos/mangos-classic/commit/9c0a31b496977ad55d11dc7753579a17ae29f93c with the autor or anyone who has a decent graps of the pathfinder code.
