### PR TITLE
Prevent unneeded item_instance update when loading from db.

### DIFF
--- a/src/game/Entities/Item.cpp
+++ b/src/game/Entities/Item.cpp
@@ -444,16 +444,6 @@ bool Item::LoadFromDB(uint32 guidLow, Field* fields, ObjectGuid ownerGuid)
 
     SetUInt32Value(ITEM_FIELD_FLAGS, fields[6].GetUInt32());
 
-    // update max durability (and durability) if need
-    if (proto->MaxDurability != GetUInt32Value(ITEM_FIELD_MAXDURABILITY))
-    {
-        SetUInt32Value(ITEM_FIELD_MAXDURABILITY, proto->MaxDurability);
-        if (GetUInt32Value(ITEM_FIELD_DURABILITY) > proto->MaxDurability)
-            SetUInt32Value(ITEM_FIELD_DURABILITY, proto->MaxDurability);
-
-        need_save = true;
-    }
-
     // Remove bind flag for items vs NO_BIND set
     if (IsSoulBound() && proto->Bonding == NO_BIND)
     {


### PR DESCRIPTION
## 🍰 Pullrequest
This pull request attempts to prevent undeeded database calls while players are logging in. 

### Proof
During loading of item_instance from db Item::LoadFromDB a check is done to fix max durability and durability here:
https://github.com/cmangos/mangos-classic/blob/5c64aab6a404d5e1ea36bb20a77866848bdefdcf/src/game/Entities/Item.cpp#L448

However the durability is correctly filled here:
https://github.com/cmangos/mangos-classic/blob/5c64aab6a404d5e1ea36bb20a77866848bdefdcf/src/game/Entities/Item.cpp#L467
and fixed to be lower than maxDurability here:
https://github.com/cmangos/mangos-classic/blob/5c64aab6a404d5e1ea36bb20a77866848bdefdcf/src/game/Entities/Item.cpp#L473

Because GetUInt32Value(ITEM_FIELD_MAXDURABILITY) is empty at the moment of the first check need_save will always be true and an update will always be done on item_instance here:
https://github.com/cmangos/mangos-classic/blob/5c64aab6a404d5e1ea36bb20a77866848bdefdcf/src/game/Entities/Item.cpp#L498

Removing the check will prevent these unneeded updates.

### Issues
When the database is running on slower HDD this issue would delay async sql calls significantly. Especially since item_instance is a larger table.

### How2Test
Using breakpoints or sql audit triggering it's possible to check item_instance is updated less.
