### PR TITLE
Delete QueryResult* for _LoadForgottenSkills

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -13924,6 +13924,8 @@ void Player::_LoadForgottenSkills(QueryResult* result)
 
             m_forgottenSkills.insert(std::make_pair(skill, value));
         } while (result->NextRow());
+	    
+        delete result;
     }
 }
 


### PR DESCRIPTION
## 🍰 Pullrequest
Tiny memory leak for forgotten skills on player login.

### Proof
Forgotten skills uses a QueryResult* as parameter here: https://github.com/cmangos/mangos-classic/blob/8a1666aa8880d61980cc600d40fd7ff4f6b6b30d/src/game/Entities/Player.cpp#L13898

However this QueryResult* is never deleted leading to a minor memory leak. 
