### PR TITLE
Spell/GameObject: Fix crashes due to GO cast time casting

### DIFF
--- a/src/game/Entities/GameObject.cpp
+++ b/src/game/Entities/GameObject.cpp
@@ -581,8 +581,16 @@ void GameObject::Update(const uint32 diff)
                 linkedTrap->Delete();
             }
 
+            bool preventDespawn = false;
             switch (GetGoType())
             {
+                case GAMEOBJECT_TYPE_TRAP:
+                    if (m_events.GetEvents().size() > 0)
+                    {
+                        preventDespawn = true;
+                        break;
+                    }
+                    break;
                 case GAMEOBJECT_TYPE_GOOBER:
                     // if gameobject should cast spell, then this, but some GOs (type = 10) should be destroyed
                     if (uint32 spellId = GetGOInfo()->goober.spellId)
@@ -630,6 +638,9 @@ void GameObject::Update(const uint32 diff)
                 default:
                     break;
             }
+
+            if (preventDespawn) // mainly serves to prevent casting traps from despawning
+                break;
 
             // Remove wild summoned after use
             if (!HasStaticDBSpawnData() && (!GetSpellId() || GetGOInfo()->GetDespawnPossibility() || GetGOInfo()->IsDespawnAtAction() || m_forcedDespawn))

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -7153,7 +7153,7 @@ bool SpellEvent::Execute(uint64 e_time, uint32 p_time)
                     if (n_offset)
                     {
                         // re-add us to the queue
-                        m_Spell->GetCaster()->m_events.AddEvent(this, m_Spell->GetDelayStart() + n_offset, false);
+                        m_Spell->GetTrueCaster()->m_events.AddEvent(this, m_Spell->GetDelayStart() + n_offset, false);
                         return false;                       // event not complete
                     }
                     // event complete
@@ -7165,7 +7165,7 @@ bool SpellEvent::Execute(uint64 e_time, uint32 p_time)
                 // delaying had just started, record the moment
                 m_Spell->SetDelayStart(e_time);
                 // re-plan the event for the delay moment
-                m_Spell->GetCaster()->m_events.AddEvent(this, e_time + m_Spell->GetDelayMoment(), false);
+                m_Spell->GetTrueCaster()->m_events.AddEvent(this, e_time + m_Spell->GetDelayMoment(), false);
                 return false;                               // event not complete
             }
         } break;
@@ -7178,7 +7178,7 @@ bool SpellEvent::Execute(uint64 e_time, uint32 p_time)
     }
 
     // spell processing not complete, plan event on the next update interval
-    m_Spell->GetCaster()->m_events.AddEvent(this, e_time + 1, false);
+    m_Spell->GetTrueCaster()->m_events.AddEvent(this, e_time + 1, false);
     return false;                                           // event not complete
 }
 


### PR DESCRIPTION
## 🍰 Pullrequest
Backport of wotlk-db97b5a

### Proof
https://github.com/cmangos/mangos-wotlk/commit/db97b5a8a2db1639e9f491f02c0e677314f1050a

### Issues
Fixes Issue 3267 on classic

### How2Test
Hatch eggs in the Blackrock Spire Rookery.

### Todo / Checklist
[X] None
