### PR TITLE
fix searing goege quest npc not walking

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/searing_gorge.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/searing_gorge.cpp
@@ -48,7 +48,7 @@ enum
     
     RELAY_SCRIPT_FINISHED           = 8284,
 
-    PATH_ID                         = 8284,        // Sniffed Waypoints for Escort Event
+    PATH_ID                         = 0,        // Sniffed Waypoints for Escort Event
     QUEST_ID_SUNTARA_STONES         = 3367,
 };
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Proof

1. create a gm level 3 account
2. create a alliance character
3. run gm command:  .level 50
4. run gm command: .go -7003 -1747 234
5. talk to that npc and accept the quest

the npc should move but does not
![Screenshot 2023-06-25 181259](https://github.com/cmangos/mangos-classic/assets/5158513/a43717ba-4594-44fc-a4d0-836da2417529)

run sql ```SELECT * FROM `script_waypoint` WHERE `Entry` = 8284;``` shows PathId is 0,
after change the PATH_ID the npc moves as expected.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
