### PR TITLE
Auth: Port VMaNGOS implementation of TOTP for 1.12

### DIFF
--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -566,10 +566,10 @@ bool AuthSocket::_HandleLogonProof()
 
     bool pinResult = true;
 
-    if (m_promptPin && lp.securityFlags & SECURITY_FLAG_PIN)
+    if (m_promptPin && (lp.securityFlags & SECURITY_FLAG_PIN))
         pinResult = false;
 
-    if (m_promptPin && lp.securityFlags & SECURITY_FLAG_PIN)
+    if (m_promptPin && (lp.securityFlags & SECURITY_FLAG_PIN))
     {
         auto pin = generateToken(_token.c_str());
 

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -551,7 +551,7 @@ bool AuthSocket::_HandleLogonProof()
     ///- Check if SRP6 results match (password is correct), else send an error
     if (!srp.Proof(lp.M1, 20))
     {
-        if (lp.securityFlags & SECURITY_FLAG_AUTHENTICATOR || !_token.empty())
+        if (_build > 6141 && (lp.securityFlags & SECURITY_FLAG_AUTHENTICATOR || !_token.empty()))
         {
             uint8 pinCount;
             if (!Read((char*)&pinCount, sizeof(uint8)))

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -531,7 +531,7 @@ bool AuthSocket::_HandleLogonProof()
 
     PINData pinData;
 
-    if (lp.securityFlags == SECURITY_FLAG_PIN)
+    if (lp.securityFlags & SECURITY_FLAG_PIN)
     {
         if (!Read((char*)&pinData, sizeof(pinData)))
             return false;
@@ -566,10 +566,10 @@ bool AuthSocket::_HandleLogonProof()
 
     bool pinResult = true;
 
-    if (m_promptPin && lp.securityFlags == SECURITY_FLAG_PIN)
+    if (m_promptPin && lp.securityFlags & SECURITY_FLAG_PIN)
         pinResult = false;
 
-    if (m_promptPin && lp.securityFlags == SECURITY_FLAG_PIN)
+    if (m_promptPin && lp.securityFlags & SECURITY_FLAG_PIN)
     {
         auto pin = generateToken(_token.c_str());
 

--- a/src/realmd/AuthSocket.h
+++ b/src/realmd/AuthSocket.h
@@ -37,6 +37,12 @@
 
 #define HMAC_RES_SIZE 20
 
+struct PINData
+{
+    uint8 salt[16];
+    uint8 hash[20];
+};
+
 class AuthSocket : public MaNGOS::Socket
 {
     public:
@@ -48,6 +54,7 @@ class AuthSocket : public MaNGOS::Socket
 
         void SendProof(Sha1Hash sha);
         void LoadRealmlist(ByteBuffer& pkt, uint32 acctid, uint8 accountSecurityLevel = 0);
+        bool VerifyPinData(uint32 pin, const PINData& clientData);
         int32 generateToken(char const* b32key);
 
         uint8 getEligibleRealmCount(uint8 accountSecurityLevel);
@@ -89,6 +96,10 @@ class AuthSocket : public MaNGOS::Socket
         std::string _safelocale;
         uint16 _build;
         AccountTypes _accountSecurityLevel;
+
+        BigNumber m_serverSecuritySalt;
+        uint32 m_gridSeed = 0;
+        bool m_promptPin = false;
 
         boost::asio::deadline_timer m_timeoutTimer;
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR prevents realmd from requiring a valid token response from the client if the client is older than 1.12.3, as it was only implemented in 2.4.3. Checking specifically for 1.12.3 and not for 2.4.3 because a TBC server *may* possibly allow other builds than just 2.4.3 and it shouldn't be possible to use these to circumvent a token that would otherwise be enforced with 2.4.3