### PR TITLE
Fix Razorfen Downs Escort Quest

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/razorfen_downs/razorfen_downs.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/razorfen_downs/razorfen_downs.cpp
@@ -186,11 +186,11 @@ struct npc_belnistraszAI : public npc_escortAI
                         m_uiRitualTimer = 1000;
                         break;
                     case 1:
-                        DoSummonSpawner(irand(1, 3));
+                        DoSummonSpawner(irand(0, 2));
                         m_uiRitualTimer = 39000;
                         break;
                     case 2:
-                        DoSummonSpawner(irand(1, 3));
+                        DoSummonSpawner(irand(0, 2));
                         m_uiRitualTimer = 20000;
                         break;
                     case 3:
@@ -198,16 +198,16 @@ struct npc_belnistraszAI : public npc_escortAI
                         m_uiRitualTimer = 20000;
                         break;
                     case 4:
-                        DoSummonSpawner(irand(1, 3));
+                        DoSummonSpawner(irand(0, 2));
                         m_uiRitualTimer = 40000;
                         break;
                     case 5:
-                        DoSummonSpawner(irand(1, 3));
+                        DoSummonSpawner(irand(0, 2));
                         DoScriptText(SAY_BELNISTRASZ_2_MIN, m_creature, m_creature);
                         m_uiRitualTimer = 40000;
                         break;
                     case 6:
-                        DoSummonSpawner(irand(1, 3));
+                        DoSummonSpawner(irand(0, 2));
                         m_uiRitualTimer = 20000;
                         break;
                     case 7:
@@ -215,7 +215,7 @@ struct npc_belnistraszAI : public npc_escortAI
                         m_uiRitualTimer = 40000;
                         break;
                     case 8:
-                        DoSummonSpawner(irand(1, 3));
+                        DoSummonSpawner(irand(0, 2));
                         m_uiRitualTimer = 20000;
                         break;
                     case 9:


### PR DESCRIPTION
## 🍰 Pullrequest
Fix the random selection of spawn position for the escort quest in Razorfen Downs, the random generates a value between 1 and 3, but the array has indexes from 0 to 2.

### Proof
- Crashdump: https://pastebin.com/Texv5JNB

### Issues
- Access an out of bounds coordinate due to bad random number generated.

### How2Test
- Go to Razorfen Downs and look for the NPC belnistrasz (Entry: 8516) and start the escort quest (Entry: 3525). Because of the randomness of it you have 1/3 chance of reproducing the issue and access an out of bounds value of the array.

### Todo / Checklist
- [x] None
