### PR TITLE
More robust extractor scripts

### DIFF
--- a/contrib/extractor_scripts/ExtractResources.sh
+++ b/contrib/extractor_scripts/ExtractResources.sh
@@ -31,35 +31,28 @@ AD_RES=""
 VMAP_RES=""
 NUM_THREAD=""
 
-if [ "$1" != "a" ] && [ "x$1" != "x" ]
-then
+if [ "$1" != "a" ] && [ "x$1" != "x" ]; then
   CLIENT_PATH="$1"
   OUTPUT_PATH="$2"
-elif [ "x$2" != "x" ]
-then
+elif [ "x$2" != "x" ]; then
   CLIENT_PATH="$2"
   OUTPUT_PATH="$3"
 fi
 
-if [ "x${CLIENT_PATH}" != "x" ]
-then
-  if [ ! -d "${CLIENT_PATH}/Data" ]
-  then
+if [ "x${CLIENT_PATH}" != "x" ]; then
+  if [ ! -d "${CLIENT_PATH}/Data" ]; then
     echo "Data folder not found in provided client path [${CLIENT_PATH}]. Plese provide a correct client path."
     exit 1
   fi
 else
-  if [ ! -d "$(pwd)/Data" ]
-  then
+  if [ ! -d "$(pwd)/Data" ]; then
     echo "Data folder not found. Make sure you have copied the script to the client folder and the 'Data' folder has the correct case."
     exit 1
   fi
 fi
 
-if [ "x${OUTPUT_PATH}" != "x" ]
-then
-  if [ ! -d "${OUTPUT_PATH}" ]
-  then
+if [ "x${OUTPUT_PATH}" != "x" ]; then
+  if [ ! -d "${OUTPUT_PATH}" ]; then
     echo "Provided OUTPUT_PATH=${OUTPUT_PATH} does not exist, please create it before"
     exit 1
   fi
@@ -67,8 +60,7 @@ then
   DETAIL_LOG_FILE="${OUTPUT_PATH:-.}/${DETAIL_LOG_FILE}"
 fi
 
-if [ "$1" = "a" ]
-then
+if [ "$1" = "a" ]; then
   ## extract all
   USE_AD="1"
   USE_VMAPS="1"
@@ -80,8 +72,7 @@ else
   echo "Welcome to helper script to extract required dataz for MaNGOS!"
   echo "Should all dataz (dbc, maps, vmaps and mmaps) be extracted? (y/n)"
   read line
-  if [ "$line" = "y" ]
-  then
+  if [ "$line" = "y" ]; then
     ## extract all
     USE_AD="1"
     USE_VMAPS="1"
@@ -101,36 +92,31 @@ else
     echo "Should mmaps be extracted? (y/n)"
     echo "WARNING! This may take several hours with small number of CPU threads!"
     read line
-    if [ "$line" = "y" ]
-    then
-      USE_MMAPS="1";
+    if [ "$line" = "y" ]; then
+      USE_MMAPS="1"
     else
       echo
       echo "Only reextract offmesh tiles for mmaps? (y/n)"
       read line
-      if [ "$line" = "y" ]
-      then
-        USE_MMAPS_OFFMESH="1";
+      if [ "$line" = "y" ]; then
+        USE_MMAPS_OFFMESH="1"
       fi
     fi
   fi
 fi
 
 ## Special case: Only reextract offmesh tiles
-if [ "$USE_MMAPS_OFFMESH" = "1" ]
-then
+if [ "$USE_MMAPS_OFFMESH" = "1" ]; then
   echo "Only extracting offmesh tiles"
   "$PREFIX"/MoveMapGen.sh offmesh "$OUTPUT_PATH" "$LOG_FILE" "$DETAIL_LOG_FILE"
   exit 0
 fi
 
 ## MMap Extraction specific
-if [ "$1" = "a" ]
-then
+if [ "$1" = "a" ]; then
   NUM_THREAD="all"
   USE_MMAPS_DELAY=""
-elif [ "$USE_MMAPS" = "1" ]
-then
+elif [ "$USE_MMAPS" = "1" ]; then
   ## Obtain number of processes
   echo "How many CPU threads should be used for extracting mmaps? (leave empty to use all available threads)"
   read line
@@ -162,8 +148,7 @@ then
 fi
 
 ## Check if user want to do high resolution extraction of maps
-if [ "$1" = "a" ]
-then
+if [ "$1" = "a" ]; then
   AD_RES=""
 elif [ "$USE_AD" = "1" ]; then
   echo
@@ -177,8 +162,7 @@ elif [ "$USE_AD" = "1" ]; then
 fi
 
 ## Check if user want to do high resolution extraction of vmaps
-if [ "$1" = "a" ]
-then
+if [ "$1" = "a" ]; then
   VMAP_RES=""
 elif [ "$USE_VMAPS" = "1" ]; then
   echo
@@ -196,17 +180,16 @@ echo
 echo "Current Settings:"
 echo "Extract DBCs/maps: $USE_AD, Extract vmaps: $USE_VMAPS, Extract mmaps: $USE_MMAPS, Processes for mmaps: $NUM_THREAD"
 if [ "$USE_AD" = "1" ] && [ "$AD_RES" = "-f 0" ]; then
-  echo "maps extraction will be high-resolution";
+  echo "maps extraction will be high-resolution"
 fi
 if [ "$USE_VMAPS" = "1" ] && [ "$VMAP_RES" = "-l" ]; then
-  echo "vmaps extraction will be high-resolution";
+  echo "vmaps extraction will be high-resolution"
 fi
 if [ "$USE_MMAPS_DELAY" != "" ]; then
   echo "MMap Extraction will be started delayed by $USE_MMAPS_DELAY"
 fi
 echo
-if [ "$1" != "a" ]
-then
+if [ "$1" != "a" ]; then
   echo "Press (Enter) to continue, or interrupt with (CTRL+C)"
   read line
 fi
@@ -214,20 +197,17 @@ fi
 echo "$(date): Start extracting dataz for MaNGOS" | tee "$LOG_FILE"
 
 ## Handle log messages
-if [ "$USE_AD" = "1" ];
-then
+if [ "$USE_AD" = "1" ]; then
   echo "DBC and map files will be extracted" | tee -a "$LOG_FILE"
 else
   echo "DBC and map files won't be extracted!" | tee -a "$LOG_FILE"
 fi
-if [ "$USE_VMAPS" = "1" ]
-then
+if [ "$USE_VMAPS" = "1" ]; then
   echo "Vmaps will be extracted" | tee -a "$LOG_FILE"
 else
   echo "Vmaps won't be extracted!" | tee -a "$LOG_FILE"
 fi
-if [ "$USE_MMAPS" = "1" ]
-then
+if [ "$USE_MMAPS" = "1" ]; then
   echo "Mmaps will be extracted using $NUM_THREAD CPU threads" | tee -a "$LOG_FILE"
 else
   echo "Mmaps files won't be extracted!" | tee -a "$LOG_FILE"
@@ -238,50 +218,50 @@ echo "$(date): Start extracting MaNGOS data: DBCs/maps $USE_AD, vmaps $USE_VMAPS
 echo | tee -a "$DETAIL_LOG_FILE"
 
 ## Extract dbcs and maps
-if [ "$USE_AD" = "1" ]
-then
- echo "$(date): Start extraction of DBCs and map files..." | tee -a "$LOG_FILE"
- # Prepare ad arguments
- set -- $AD_RES
- if [ "x$CLIENT_PATH" != "x" ]
- then
-  set -- "$@" "-i" "$CLIENT_PATH"
- fi
- if [ "x$OUTPUT_PATH" != "x" ] && [ -d "$OUTPUT_PATH" ]
- then
-  set -- "$@" "-o" "$OUTPUT_PATH"
- fi
- file=$(mktemp)
- { "$PREFIX"/ad "$@"; echo $? > "$file"; } | tee -a "$DETAIL_LOG_FILE"
- exit_code=$(cat "$file")
- rm "$file"
- if [ "$exit_code" -ne "0" ]; then
-  echo "$(date): Extraction of DBCs and map files failed with errors. Aborting extraction. See the log file for more details."
-  exit "$exit_code"
- fi
- echo "$(date): Extracting of DBCs and map files finished" | tee -a "$LOG_FILE"
- echo | tee -a "$LOG_FILE"
- echo | tee -a "$DETAIL_LOG_FILE"
+if [ "$USE_AD" = "1" ]; then
+  echo "$(date): Start extraction of DBCs and map files..." | tee -a "$LOG_FILE"
+  # Prepare ad arguments
+  set -- $AD_RES
+  if [ "x$CLIENT_PATH" != "x" ]; then
+    set -- "$@" "-i" "$CLIENT_PATH"
+  fi
+  if [ "x$OUTPUT_PATH" != "x" ] && [ -d "$OUTPUT_PATH" ]; then
+    set -- "$@" "-o" "$OUTPUT_PATH"
+  fi
+  file=$(mktemp)
+  {
+    "$PREFIX"/ad "$@"
+    echo $? >"$file"
+  } | tee -a "$DETAIL_LOG_FILE"
+  exit_code=$(cat "$file")
+  rm "$file"
+  if [ "$exit_code" -ne "0" ]; then
+    echo "$(date): Extraction of DBCs and map files failed with errors. Aborting extraction. See the log file for more details."
+    exit "$exit_code"
+  fi
+  echo "$(date): Extracting of DBCs and map files finished" | tee -a "$LOG_FILE"
+  echo | tee -a "$LOG_FILE"
+  echo | tee -a "$DETAIL_LOG_FILE"
 fi
 
 ## Extract vmaps
-if [ "$USE_VMAPS" = "1" ]
-then
+if [ "$USE_VMAPS" = "1" ]; then
   # We need to save the exit code for vmap_extractor and vmap_assembler so it doesn't get swallowed by tee. For this we create a temporary file.
   file=$(mktemp)
   echo "$(date): Start extraction of vmaps..." | tee -a "$LOG_FILE"
   # Prepare vmap_extractor arguments
   set -- $VMAP_RES
-  if [ "x$CLIENT_PATH" != "x" ]
-  then
-   set -- "$@" "-d" "$CLIENT_PATH/Data"
+  if [ "x$CLIENT_PATH" != "x" ]; then
+    set -- "$@" "-d" "$CLIENT_PATH/Data"
   fi
-  if [ "x$OUTPUT_PATH" != "x" ] && [ -d "$OUTPUT_PATH" ]
-  then
-   set -- "$@" "-o" "$OUTPUT_PATH"
+  if [ "x$OUTPUT_PATH" != "x" ] && [ -d "$OUTPUT_PATH" ]; then
+    set -- "$@" "-o" "$OUTPUT_PATH"
   fi
   # We group command and echo to file so we can save the exit code ($?) before execution of tee overwrites it.
-  { "$PREFIX"/vmap_extractor "$@"; echo $? > "$file"; } | tee -a "$DETAIL_LOG_FILE"
+  {
+    "$PREFIX"/vmap_extractor "$@"
+    echo $? >"$file"
+  } | tee -a "$DETAIL_LOG_FILE"
   exit_code=$(cat "$file")
   if [ "$exit_code" -ne "0" ]; then
     echo "$(date): Extraction of vmaps failed with errors. Aborting extraction. See the log file for more details."
@@ -289,20 +269,21 @@ then
     exit "$exit_code"
   fi
   echo "$(date): Extracting of vmaps finished" | tee -a "$LOG_FILE"
-  if [ ! -d "${OUTPUT_PATH:-.}/vmaps" ]
-  then
+  if [ ! -d "${OUTPUT_PATH:-.}/vmaps" ]; then
     mkdir "${OUTPUT_PATH:-.}/vmaps"
   fi
   echo "$(date): Start assembling of vmaps..." | tee -a "$LOG_FILE"
   # We group command and echo to file so we can save the exit code ($?) before execution of tee overwrites it.
-  { "$PREFIX"/vmap_assembler "${OUTPUT_PATH:-.}/Buildings" "${OUTPUT_PATH:-.}/vmaps"; echo $? > "$file"; } | tee -a "$DETAIL_LOG_FILE"
+  {
+    "$PREFIX"/vmap_assembler "${OUTPUT_PATH:-.}/Buildings" "${OUTPUT_PATH:-.}/vmaps"
+    echo $? >"$file"
+  } | tee -a "$DETAIL_LOG_FILE"
   exit_code=$(cat "$file")
+  rm "$file"
   if [ "$exit_code" -ne "0" ]; then
     echo "$(date): Assembling of vmaps failed with errors. Aborting extraction. See the log file for more details."
-    rm "$file"
     exit "$exit_code"
   fi
-  rm "$file"
   echo "$(date): Assembling of vmaps finished" | tee -a "$LOG_FILE"
 
   echo | tee -a "$LOG_FILE"
@@ -310,8 +291,7 @@ then
 fi
 
 ## Extract mmaps
-if [ "$USE_MMAPS" = "1" ]
-then
+if [ "$USE_MMAPS" = "1" ]; then
   if [ "$USE_MMAPS_DELAY" != "" ]; then
     echo "Extracting of MMaps is set to be started delayed by $USE_MMAPS_DELAY"
     echo "Current time: $(date)"

--- a/contrib/extractor_scripts/ExtractResources.sh
+++ b/contrib/extractor_scripts/ExtractResources.sh
@@ -251,7 +251,14 @@ then
  then
   set -- "$@" "-o" "$OUTPUT_PATH"
  fi
- "$PREFIX"/ad "$@" | tee -a "$DETAIL_LOG_FILE"
+ file=$(mktemp)
+ { "$PREFIX"/ad "$@"; echo $? > "$file"; } | tee -a "$DETAIL_LOG_FILE"
+ exit_code=$(cat "$file")
+ rm "$file"
+ if [ "$exit_code" -ne "0" ]; then
+  echo "$(date): Extraction of DBCs and map files failed with errors. Aborting extraction. See the log file for more details."
+  exit "$exit_code"
+ fi
  echo "$(date): Extracting of DBCs and map files finished" | tee -a "$LOG_FILE"
  echo | tee -a "$LOG_FILE"
  echo | tee -a "$DETAIL_LOG_FILE"

--- a/contrib/extractor_scripts/MoveMapGen.sh
+++ b/contrib/extractor_scripts/MoveMapGen.sh
@@ -29,93 +29,83 @@ LOG_FILE="MoveMapGen.log"
 ## Detailed log file
 DETAIL_LOG_FILE="MoveMapGen_detailed.log"
 
-badParam()
-{
- echo "ERROR! Bad arguments!"
- echo "You can (re)extract mmaps with this helper script,"
- echo "or recreate only the tiles from the offmash file"
- echo
- echo "Call with 'maps' to create mmaps"
- echo "Call with 'offmesh' to reextract the tiles from offmash file"
- echo
+badParam() {
+  echo "ERROR! Bad arguments!"
+  echo "You can (re)extract mmaps with this helper script,"
+  echo "or recreate only the tiles from the offmash file"
+  echo
+  echo "Call with 'maps' to create mmaps"
+  echo "Call with 'offmesh' to reextract the tiles from offmash file"
+  echo
 }
 
-if [ "$#" = "5" ]
-then
+if [ "$#" = "5" ]; then
   OUTPUT_PATH="$2"
   LOG_FILE="$3"
   DETAIL_LOG_FILE="$4"
-  if [ "$5" != "all" ]
-  then
+  if [ "$5" != "all" ]; then
     PARAMS="${PARAMS} --threads $5"
   fi
-elif [ "$#" = "4" ]
-then
+elif [ "$#" = "4" ]; then
   OUTPUT_PATH="$2"
   LOG_FILE="$3"
   DETAIL_LOG_FILE="$4"
-elif [ "$#" = "3" ]
-then
+elif [ "$#" = "3" ]; then
   OUTPUT_PATH="$2"
   LOG_FILE="$3"
 fi
 
 # Offmesh file provided?
 OFFMESH=""
-if [ "$OFFMESH_FILE" != "" ]
-then
- if [ ! -f "$OFFMESH_FILE" ]
- then
-   echo "ERROR! Offmesh file $OFFMESH_FILE could not be found."
-   echo "Provide valid file or none. You need to edit the script"
-   exit 1
- else
-   OFFMESH="--offMeshInput $OFFMESH_FILE"
- fi
+if [ "$OFFMESH_FILE" != "" ]; then
+  if [ ! -f "$OFFMESH_FILE" ]; then
+    echo "ERROR! Offmesh file $OFFMESH_FILE could not be found."
+    echo "Provide valid file or none. You need to edit the script"
+    exit 1
+  else
+    OFFMESH="--offMeshInput $OFFMESH_FILE"
+  fi
 fi
 
-createHeader()
-{
- echo "$(date): Start creating MoveMaps" | tee -a "$LOG_FILE"
- echo "Used params: $PARAMS $OFFMESH" | tee -a "$LOG_FILE"
- echo "Detailed log can be found in $DETAIL_LOG_FILE" | tee -a "$LOG_FILE"
- echo "Start creating MoveMaps" | tee -a "$DETAIL_LOG_FILE"
- echo
- echo "Be PATIENT - This may take a long time with small number of threads and might also have gaps between visible changes on the console."
- echo "WAIT until you are informed that 'creating MoveMaps' is 'finished'!"
+createHeader() {
+  echo "$(date): Start creating MoveMaps" | tee -a "$LOG_FILE"
+  echo "Used params: $PARAMS $OFFMESH" | tee -a "$LOG_FILE"
+  echo "Detailed log can be found in $DETAIL_LOG_FILE" | tee -a "$LOG_FILE"
+  echo "Start creating MoveMaps" | tee -a "$DETAIL_LOG_FILE"
+  echo
+  echo "Be PATIENT - This may take a long time with small number of threads and might also have gaps between visible changes on the console."
+  echo "WAIT until you are informed that 'creating MoveMaps' is 'finished'!"
 }
 
 # Create mmaps directory if not exist
-if [ ! -d mmaps ]
-then
- mkdir "${OUTPUT_PATH:-.}/mmaps"
+if [ ! -d mmaps ]; then
+  mkdir "${OUTPUT_PATH:-.}/mmaps"
 fi
 
 # Param control
 case "$1" in
 
- "maps" )
-    createHeader
-    "$PREFIX"/MoveMapGen $PARAMS $OFFMESH --workdir "${OUTPUT_PATH:-.}/" --buildGameObjects | tee -a "$DETAIL_LOG_FILE"
-   ;;
- "offmesh" )
-   echo "$(date): Recreate offmeshes from file $OFFMESH_FILE" | tee -a "$LOG_FILE"
-   echo "Recreate offmeshes from file $OFFMESH_FILE" | tee -a "$DETAIL_LOG_FILE"
-   while read map tile line
-   do
-     "$PREFIX"/MoveMapGen $PARAMS $OFFMESH --workdir "${OUTPUT_PATH:-.}/" "$map" --tile "$tile" | tee -a "$DETAIL_LOG_FILE"
-     echo "$(date): Recreated $map $tile from $OFFMESH_FILE" | tee -a "$LOG_FILE"
-   done < $OFFMESH_FILE &
-   ;;
- * )
-   badParam
-   exit 1
-   ;;
+"maps")
+  createHeader
+  "$PREFIX"/MoveMapGen $PARAMS $OFFMESH --workdir "${OUTPUT_PATH:-.}/" --buildGameObjects | tee -a "$DETAIL_LOG_FILE"
+  ;;
+"offmesh")
+  echo "$(date): Recreate offmeshes from file $OFFMESH_FILE" | tee -a "$LOG_FILE"
+  echo "Recreate offmeshes from file $OFFMESH_FILE" | tee -a "$DETAIL_LOG_FILE"
+  while read map tile line; do
+    "$PREFIX"/MoveMapGen $PARAMS $OFFMESH --workdir "${OUTPUT_PATH:-.}/" "$map" --tile "$tile" | tee -a "$DETAIL_LOG_FILE"
+    echo "$(date): Recreated $map $tile from $OFFMESH_FILE" | tee -a "$LOG_FILE"
+  done <$OFFMESH_FILE &
+  ;;
+*)
+  badParam
+  exit 1
+  ;;
 esac
 
 wait
 
-echo  | tee -a "$LOG_FILE"
-echo  | tee -a "$DETAIL_LOG_FILE"
+echo | tee -a "$LOG_FILE"
+echo | tee -a "$DETAIL_LOG_FILE"
 echo "$(date): Finished creating MoveMaps" | tee -a "$LOG_FILE"
-echo "$(date): Finished creating MoveMaps" >> "$DETAIL_LOG_FILE"
+echo "$(date): Finished creating MoveMaps" >>"$DETAIL_LOG_FILE"

--- a/contrib/extractor_scripts/MoveMapGen.sh
+++ b/contrib/extractor_scripts/MoveMapGen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # This file is part of the CMaNGOS Project. See AUTHORS file for Copyright information
 #
@@ -62,7 +62,6 @@ fi
 
 # Offmesh file provided?
 OFFMESH=""
-MMG_RES="--workdir ${OUTPUT_PATH:-.}/"
 if [ "$OFFMESH_FILE" != "" ]
 then
  if [ ! -f "$OFFMESH_FILE" ]
@@ -97,14 +96,14 @@ case "$1" in
 
  "maps" )
     createHeader
-    "$PREFIX"/MoveMapGen $PARAMS $OFFMESH $MMG_RES --buildGameObjects | tee -a "$DETAIL_LOG_FILE"
+    "$PREFIX"/MoveMapGen $PARAMS $OFFMESH --workdir "${OUTPUT_PATH:-.}/" --buildGameObjects | tee -a "$DETAIL_LOG_FILE"
    ;;
  "offmesh" )
    echo "$(date): Recreate offmeshes from file $OFFMESH_FILE" | tee -a "$LOG_FILE"
    echo "Recreate offmeshes from file $OFFMESH_FILE" | tee -a "$DETAIL_LOG_FILE"
    while read map tile line
    do
-     "$PREFIX"/MoveMapGen $PARAMS $OFFMESH $MMG_RES "$map" --tile "$tile" | tee -a "$DETAIL_LOG_FILE"
+     "$PREFIX"/MoveMapGen $PARAMS $OFFMESH --workdir "${OUTPUT_PATH:-.}/" "$map" --tile "$tile" | tee -a "$DETAIL_LOG_FILE"
      echo "$(date): Recreated $map $tile from $OFFMESH_FILE" | tee -a "$LOG_FILE"
    done < $OFFMESH_FILE &
    ;;


### PR DESCRIPTION
## 🍰 Pullrequest
Changed how the arguments passed to the executables (ad, vmap_extractor, etc) are prepared, so the script can accept client and output paths containing white-spaces.
Added a check to halt execution if `ad` had an error, as to not proceed to `MoveMapGen.sh` if map files were not properly extracted.
Formatted both scripts using `shfmt -i 2` to keep indentation consistent and making the scripts easier to read.

All changes were tested in dash and bash. 

### Todo 
- [ ] (Optionally) Check exit code of MoveMapGen to know if it was executed properly.
