### PR TITLE
Don't generate pet number twice on tame.

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -3368,7 +3368,7 @@ void Spell::EffectTameCreature(SpellEffectIndex /*eff_idx*/)
     if (plr->IsPvP())
         pet->SetPvP(true);
 
-    pet->GetCharmInfo()->SetPetNumber(sObjectMgr.GeneratePetNumber(), (m_caster->GetTypeId() == TYPEID_PLAYER));
+    pet->GetCharmInfo()->SetPetNumber(pet->GetObjectGuid().GetEntry(), (m_caster->GetTypeId() == TYPEID_PLAYER));
 
     uint32 level = creatureTarget->GetLevel();
     pet->SetCanModifyStats(true);


### PR DESCRIPTION
It's already generated and set as the entry of the ObjectGuid in CreateBaseAtCreature

vmangos had same issue https://github.com/vmangos/core/commit/b1e49ba3e6043a21416480b03bd3ff74f60e441f