### PR TITLE
Granting honor on PvP-Kill blizzlike

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -6650,7 +6650,7 @@ bool Player::RewardHonor(Unit* uVictim, uint32 groupsize)
         if (GetTeam() == pVictim->GetTeam())
             return false;
 
-        if (GetLevel() < (pVictim->GetLevel() + 5))
+        if (!MaNGOS::XP::IsTrivialLevelDifference(GetLevel(), pVictim->GetLevel()))
         {
             AddHonorCP(MaNGOS::Honor::HonorableKillPoints(this, pVictim, groupsize), HONORABLE, pVictim);
             return true;


### PR DESCRIPTION
Added "IsTrivialLevelDifference" to grant honor when the victim has green, yellow or red name.

According to blizzards wow website in 2005 (waybackmachine) honor is granted when the name is green, yellow or red.

"Honorable Kill: killing a player character within your XP range, i.e. a character whose name is colored (green to red), not grey. [...]"

source: https://web.archive.org/web/20050619021442/http://www.worldofwarcraft.com/pvp/honorguide.html

## 🍰 Pullrequest
the old calculation would only grant honor on pvp-kill if the player was max. 5 level below the killer's level, even if the name is still green.

### Proof
"Honorable Kill: killing a player character within your XP range, i.e. a character whose name is colored (green to red), not grey."
https://web.archive.org/web/20050619021442/http://www.worldofwarcraft.com/pvp/honorguide.html

### Issues
non-blizzlike honor granting

### How2Test
add code, compile, run
kill gray, green, yellow, red enemies

### Todo / Checklist
- [x] None
