### PR TITLE
Playerbots: Fix grid loading issue

### DIFF
--- a/src/game/Entities/Camera.cpp
+++ b/src/game/Entities/Camera.cpp
@@ -146,11 +146,6 @@ template void Camera::UpdateVisibilityOf(DynamicObject*, UpdateData&, WorldObjec
 
 void Camera::UpdateVisibilityForOwner(bool addToWorld)
 {
-#ifdef ENABLE_PLAYERBOTS
-    if (!m_owner.isRealPlayer())
-        return;
-#endif
-
     MaNGOS::VisibleNotifier notifier(*this);
     Cell::VisitAllObjects(m_source, notifier, addToWorld ? MAX_VISIBILITY_DISTANCE : m_source->GetVisibilityData().GetVisibilityDistance(), false);
     notifier.Notify();


### PR DESCRIPTION
## 🍰 Pullrequest
This PR activates the **UpdateVisibilityForOwner** handling for playerbots. Deactivation led to the playerbot grid not loading in special cases (presumably resurrection).

### Issues
https://discord.com/channels/362206349339262976/1223715932468412446