### PR TITLE
Spell: Move Black Qiraji mount to SpellScript

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -106,6 +106,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (26591,'spell_teleport_image'),
 (26608,'spell_viscidus_despawn_adds'),
 (26619,'spell_periodic_scarab_trigger'),
+(26656,'spell_summon_black_qiraji_battle_tank'),
 (26686,'spell_aq_whirlwind'),
 (26767,'spell_cthun_tentacles_summon'),
 (26769,'spell_cthun_periodic_eye_trigger'),

--- a/src/game/AI/ScriptDevAI/scripts/world/item_scripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/world/item_scripts.cpp
@@ -223,6 +223,26 @@ struct GoblinBomb : public SpellScript
     }
 };
 
+struct SummonBlackQirajiBattleTank : public SpellScript
+{
+    void OnEffectExecute(Spell* spell, SpellEffectIndex /*effIdx*/) const override
+    {
+        Unit* unitTarget = spell->GetUnitTarget();
+        if (!unitTarget)
+            return;
+
+        // Prevent stacking of mounts
+        unitTarget->RemoveSpellsCausingAura(SPELL_AURA_MOUNTED);
+
+        // Two separate mounts depending on area id (allows use both in and out of specific instance)
+        switch (unitTarget->GetAreaId())
+        {
+            [[unlikely]] case 3428: unitTarget->CastSpell(nullptr, 25863, TRIGGERED_NONE); break;
+            default: unitTarget->CastSpell(nullptr, 26655, TRIGGERED_NONE);
+        }
+    }
+};
+
 void AddSC_item_scripts()
 {
     Script* pNewScript = new Script;
@@ -238,4 +258,5 @@ void AddSC_item_scripts()
     RegisterSpellScript<OrbOfDeception>("spell_orb_of_deception");
     RegisterSpellScript<SummonGoblinBomb>("spell_summon_goblin_bomb");
     RegisterSpellScript<GoblinBomb>("spell_goblin_bomb");
+    RegisterSpellScript<SummonBlackQirajiBattleTank>("spell_summon_black_qiraji_battle_tank");
 }

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -4170,25 +4170,6 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
                         unitTarget->CastSpell(nullptr, 26529, TRIGGERED_NONE);
                     return;
                 }
-                case 26656:                                 // Summon Black Qiraji Battle Tank
-                {
-                    if (!unitTarget)
-                        return;
-
-                    if (unitTarget->HasAura(25863) || unitTarget->HasAura(26655))
-                        return; // protection against visual glitch
-
-                    // Prevent stacking of mounts
-                    unitTarget->RemoveSpellsCausingAura(SPELL_AURA_MOUNTED);
-
-                    // Two separate mounts depending on area id (allows use both in and out of specific instance)
-                    if (unitTarget->GetAreaId() == 3428)
-                        unitTarget->CastSpell(unitTarget, 25863, TRIGGERED_NONE);
-                    else
-                        unitTarget->CastSpell(unitTarget, 26655, TRIGGERED_NONE);
-
-                    return;
-                }
                 case 26663:                                 // Valentine - Orgrimmar Grunt
                 case 26923:                                 // Valentine - Thunderbluff Watcher
                 case 26924:                                 // Valentine - Undercity Guardian


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR moves summoning the Black Qiraji Battle Tank into SpellScript and changes a minor visual difference

### Proof
<!-- Link resources as proof -->
- https://www.youtube.com/watch?v=vxfy2r5O5is

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- .additem 21176
- Learn Riding Skill (at least 150)
- Use Black Qiraji Resonating Crystal
- Use it again while mounted up (mount should make same sound as being summoned again)

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Check if Black Qiraji Battle Tank should replace other mounts if cast from mounted state.
- [ ] Possibly remove [[unlikely]] tag if CI build fails and go back to `if / else`
