### PR TITLE
Magmadar panic should have a higher cooldown

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/molten_core/boss_magmadar.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/molten_core/boss_magmadar.cpp
@@ -102,7 +102,7 @@ struct boss_magmadarAI : public CombatAI
             case MAGMADAR_PANIC:
             {
                 if (DoCastSpellIfCan(nullptr, SPELL_PANIC) == CAST_OK)
-                    ResetCombatAction(action, urand(16000, 21000));
+                    ResetCombatAction(action, urand(30000, 35000));
                 break;
             }
             case MAGMADAR_LAVABOMB:


### PR DESCRIPTION
## 🍰 Pullrequest
I have noticed Magmadar boss in Molten Core (Entry:  11982) uses the Panic ability (Spell: 19408) too often. Upon further research I've noticed the cooldowns are not blizzlike as they should be between 30-36 seconds between casts.

### Proof
- Wowhead comment in 2006: https://www.wowhead.com/classic/npc=11982/magmadar#comments:id=85
- Vmangos: https://github.com/vmangos/core/blob/a8ca7e1d4e35f0b5ac3e3a1f840eb42c57999470/src/scripts/eastern_kingdoms/burning_steppes/molten_core/boss_magmadar.cpp#L96
- Video: https://youtu.be/RXdhDeVfH9k?si=TVV45O4vaVAsjBhv&t=338 Fear casted at 5:53 and then at 6:27

### How2Test
Go to magmadar in molten core or summon him with .npc add 11982 and count the amount of seconds between each fear.
