### PR TITLE
Allow lockpicking items in the trade window

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -5455,7 +5455,10 @@ SpellCastResult Spell::CheckCast(bool strict)
                 else if (Item* item = m_targets.getItemTarget())
                 {
                     // not own (trade?)
-                    if (item->GetOwner() != m_caster)
+                    Player* itemOwner = item->GetOwner();
+                    Player* itemTrader = itemOwner->GetTrader();
+
+                    if (itemOwner != m_caster && itemTrader != m_caster)
                         return SPELL_FAILED_ITEM_GONE;
 
                     lockId = item->GetProto()->LockID;


### PR DESCRIPTION
## 🍰 Pullrequest
Players should be able to lockpick other players items that are placed in the trade window

### Proof
- vmangos: https://github.com/vmangos/core/blob/f53de3d5b43d1654f02e7ee2c8e3f6b5e1f5c907/src/game/Spells/Spell.cpp#L6642
- wowiki: [Patch 1.2.2](https://wowpedia.fandom.com/wiki/Patch_1.2.2) (2005-02-15): Rogues now correctly gain Lockpicking skill from items picked in the trade window. https://wowpedia.fandom.com/wiki/Pick_Lock

### How2Test
- Log in with two clients
- Learn lockpicking skill with one of them (.learn 1809)
- Get the thieve tools (.additem 5060)
- Get a locked box with the other character (.additem 6712)
- Trade the locked box (place it in the will not trade slot)
- Cast the lockpick spell and press trade