### PR TITLE
Ruins of Ahn'Quiraj memory leak fix

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/ruins_of_ahnqiraj/ruins_of_ahnqiraj.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/ruins_of_ahnqiraj/ruins_of_ahnqiraj.cpp
@@ -84,6 +84,17 @@ void instance_ruins_of_ahnqiraj::OnObjectCreate(GameObject* go)
         m_goEntryGuidCollection[go->GetEntry()].push_back(go->GetObjectGuid());
 }
 
+void instance_ruins_of_ahnqiraj::OnObjectDestroy(GameObject* go)
+{
+   if (go->GetEntry() == GO_OSSIRIAN_CRYSTAL)
+   {
+      auto it = m_goEntryGuidCollection.find(go->GetEntry());
+
+      if (it != m_goEntryGuidCollection.end())
+         m_goEntryGuidCollection.erase(it);
+   }
+}
+
 void instance_ruins_of_ahnqiraj::OnCreatureEnterCombat(Creature* pCreature)
 {
     switch (pCreature->GetEntry())

--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/ruins_of_ahnqiraj/ruins_of_ahnqiraj.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/ruins_of_ahnqiraj/ruins_of_ahnqiraj.cpp
@@ -88,10 +88,14 @@ void instance_ruins_of_ahnqiraj::OnObjectDestroy(GameObject* go)
 {
    if (go->GetEntry() == GO_OSSIRIAN_CRYSTAL)
    {
-      auto it = m_goEntryGuidCollection.find(go->GetEntry());
+      auto& crystal_vect = m_goEntryGuidCollection[go->GetEntry()];
 
-      if (it != m_goEntryGuidCollection.end())
-         m_goEntryGuidCollection.erase(it);
+      auto it = std::find(crystal_vect.begin(), crystal_vect.end(), go->GetObjectGuid());
+
+      if (it != crystal_vect.end())
+      {
+         crystal_vect.erase(it);
+      }
    }
 }
 

--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/ruins_of_ahnqiraj/ruins_of_ahnqiraj.h
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/ruins_of_ahnqiraj/ruins_of_ahnqiraj.h
@@ -109,6 +109,7 @@ class instance_ruins_of_ahnqiraj : public ScriptedInstance
 
         void OnCreatureCreate(Creature* pCreature) override;
         void OnObjectCreate(GameObject* go) override;
+        void OnObjectDestroy(GameObject* go) override;
         void OnPlayerEnter(Player* pPlayer) override;
 
         void OnCreatureEnterCombat(Creature* pCreature) override;

--- a/src/game/Entities/GameObject.cpp
+++ b/src/game/Entities/GameObject.cpp
@@ -643,6 +643,11 @@ void GameObject::Update(const uint32 diff)
             // Remove wild summoned after use
             if (!HasStaticDBSpawnData() && (!GetSpellId() || GetGOInfo()->GetDespawnPossibility() || GetGOInfo()->IsDespawnAtAction() || m_forcedDespawn))
             {
+                if (InstanceData* iData = GetMap()->GetInstanceData())
+                {
+                    iData->OnObjectDestroy(this);
+                }
+
                 if (Unit* owner = GetOwner())
                     owner->RemoveGameObject(this, false);
                 Delete();

--- a/src/game/Maps/InstanceData.h
+++ b/src/game/Maps/InstanceData.h
@@ -89,6 +89,9 @@ class InstanceData
         // Called when a gameobject is created
         virtual void OnObjectCreate(GameObject*) {}
 
+        // Called when a gameobject is destroyed
+        virtual void OnObjectDestroy(GameObject*) {}
+
         // Called when a gameobject is spawned into map
         virtual void OnObjectSpawn(GameObject*) {}
 


### PR DESCRIPTION
## 🍰 Pullrequest
With each Ossirian attempt the instance map is filled with new spawned crystals, that never get removed from there (only if we instance is unloaded i guess)

### Proof
ticket on discord

### Issues
- fixes #Ruins of Ahnquiraj memory leak

### How2Test
- Start the instance presumably with bots, go to ossirian, have couple tries on him and just attach with VS and watch the m_goEntryGuidCollection of instance_ruins_of_ahnqiraj

### Todo / Checklist
- [X] None
