### PR TITLE
Script Rework for Quest 7631 - Dreadsteed of Xoroth (Warlock Mount Quest)

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/dire_maul/dire_maul.h
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/dire_maul/dire_maul.h
@@ -89,7 +89,7 @@ enum
     NPC_DREAD_GUARD             = 14483,
     NPC_LORD_HELNURATH          = 14506,
 
-    SAY_UNSUMMON_DEMON          = -1429004,
+    SAY_UNSUMMON_DEMON          = -1429005,
 
     // North
     NPC_GUARD_MOLDAR            = 14326,

--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/dire_maul/instance_dire_maul.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/dire_maul/instance_dire_maul.cpp
@@ -53,7 +53,7 @@ void instance_dire_maul::Update(uint32 /*uiDiff*/)
             GameObject* bell = instance->GetGameObject(m_goEntryGuidStore[GO_BELL_OF_DETHMOORA]);
             GameObject* wheel = instance->GetGameObject(m_goEntryGuidStore[GO_WHEEL_OF_BLACK_MARCH]);
             GameObject* candle = instance->GetGameObject(m_goEntryGuidStore[GO_DOOMSDAY_CANDLE]);
-            if (bell && bell->GetGoState() != GO_STATE_ACTIVE && wheel && wheel->GetGoState() != GO_STATE_ACTIVE && candle && candle->GetGoState() != GO_STATE_ACTIVE)
+            if (bell && bell->GetLootState() != GO_ACTIVATED && wheel && wheel->GetLootState() != GO_ACTIVATED && candle && candle->GetLootState() != GO_ACTIVATED)
                 SetData(TYPE_DREADSTEED, FAIL);
         }
     }
@@ -619,9 +619,10 @@ void instance_dire_maul::ProcessDreadsteedRitualStart()
         go->SetRespawnTime(900);
         go->Refresh();
     }
+
     for (auto portal : m_lDreadsteedPortalsGUIDs)
         if (GameObject* go = instance->GetGameObject(portal))
-            DoRespawnGameObject(portal, 360);
+            DoRespawnGameObject(portal, 380);
 }
 
 InstanceData* GetInstanceData_instance_dire_maul(Map* pMap)


### PR DESCRIPTION
Quest was not functioning properly.
- 3 Summoned objects should no longer bug out the first time you activate the quest, instantly resetting
- Waves of demons spawning should be closer to how it should be (more random and consistent, not big waves all at once)
- 3 Objects now properly deactivate and need to be clicked by the warlock to reactivate
- Demons should no longer float through the air awkwardly
- Adjusted timers a little bit
- Changed Unsummon dialog to new, previously missing entry

The check to ensure the dreadsteed event is in progress, and if not to despawn the 3 quest GOs is probably not the best way to do that. After trying several other things I could not get them to stop spawning in by default, which causes problems.

I mostly watched this video as my reference:
youtube.com/watch?v=a5eAYFIJj68
