### PR TITLE
SQL: Fix naming of modelId in Classic

### DIFF
--- a/sql/base/mangos.sql
+++ b/sql/base/mangos.sql
@@ -1074,7 +1074,7 @@ CREATE TABLE `creature_model_info` (
   `SpeedRun` FLOAT NOT NULL DEFAULT '1.14286' COMMENT 'Default running speed for any creature with model',
   `gender` tinyint(3) unsigned NOT NULL DEFAULT '2',
   `modelid_other_gender` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `modelid_other_team` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `modelid_alternative` mediumint(8) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`modelid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='Creature System (Model related info)';
 
@@ -1219,7 +1219,6 @@ CREATE TABLE `creature_template` (
   `SubName` char(100) DEFAULT NULL,
   `MinLevel` tinyint(3) unsigned NOT NULL DEFAULT '1',
   `MaxLevel` tinyint(3) unsigned NOT NULL DEFAULT '1',
-  `HeroicEntry` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `DisplayId1` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `DisplayId2` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `DisplayId3` mediumint(8) unsigned NOT NULL DEFAULT '0',

--- a/sql/updates/mangos/z2823_01_mangos_displayid_probability.sql
+++ b/sql/updates/mangos/z2823_01_mangos_displayid_probability.sql
@@ -9,6 +9,8 @@ ALTER TABLE `creature_template` ADD COLUMN `DisplayIdProbability2` SMALLINT UNSI
 ALTER TABLE `creature_template` ADD COLUMN `DisplayIdProbability3` SMALLINT UNSIGNED NOT NULL DEFAULT 0 AFTER `DisplayIdProbability2`;
 ALTER TABLE `creature_template` ADD COLUMN `DisplayIdProbability4` SMALLINT UNSIGNED NOT NULL DEFAULT 0 AFTER `DisplayIdProbability3`;
 
+ALTER TABLE `creature_model_info` RENAME COLUMN `modelid_other_team` TO `modelid_alternative`;
+
 SET sql_safe_updates=0;
 -- setting probabilities to exactly replicate previous behaviour
 UPDATE creature_template SET DisplayIdProbability1=100 WHERE DisplayId1!=0;

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -319,7 +319,7 @@ struct CreatureModelInfo
     float SpeedRun;
     uint8 gender;
     uint32 modelid_other_gender;                            // The oposite gender for this modelid (male/female)
-    uint32 modelid_other_team;                              // The oposite team. Generally for alliance totem
+    uint32 modelid_alternative;                              // The oposite team. Generally for alliance totem
 };
 
 struct CreatureConditionalSpawn

--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -1476,7 +1476,7 @@ void ObjectMgr::LoadEquipmentTemplates()
 uint32 ObjectMgr::GetCreatureModelOtherTeamModel(uint32 modelId) const
 {
     if (const CreatureModelInfo* modelInfo = GetCreatureModelInfo(modelId))
-        return modelInfo->modelid_other_team;
+        return modelInfo->modelid_alternative;
 
     return 0;
 }
@@ -1535,17 +1535,17 @@ void ObjectMgr::LoadCreatureModelInfo()
             }
         }
 
-        if (minfo->modelid_other_team)
+        if (minfo->modelid_alternative)
         {
-            if (minfo->modelid_other_team == minfo->modelid)
+            if (minfo->modelid_alternative == minfo->modelid)
             {
-                sLog.outErrorDb("Table `creature_model_info` has redundant modelid_other_team model (%u) defined for model id %u.", minfo->modelid_other_team, minfo->modelid);
-                const_cast<CreatureModelInfo*>(minfo)->modelid_other_team = 0;
+                sLog.outErrorDb("Table `creature_model_info` has redundant modelid_alternative model (%u) defined for model id %u.", minfo->modelid_alternative, minfo->modelid);
+                const_cast<CreatureModelInfo*>(minfo)->modelid_alternative = 0;
             }
-            else if (!sCreatureDisplayInfoStore.LookupEntry(minfo->modelid_other_team))
+            else if (!sCreatureDisplayInfoStore.LookupEntry(minfo->modelid_alternative))
             {
-                sLog.outErrorDb("Table `creature_model_info` has nonexistent modelid_other_team model (%u) defined for model id %u.", minfo->modelid_other_team, minfo->modelid);
-                const_cast<CreatureModelInfo*>(minfo)->modelid_other_team = 0;
+                sLog.outErrorDb("Table `creature_model_info` has nonexistent modelid_alternative model (%u) defined for model id %u.", minfo->modelid_alternative, minfo->modelid);
+                const_cast<CreatureModelInfo*>(minfo)->modelid_alternative = 0;
             }
         }
     }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR changes the naming of the `modelid_other_team` column to be in line with the other cores and updates the SQL update file accordingly

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/3707

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Check for oversights
