### PR TITLE
SQL: Make changes compatible with MySQL 5.7 (EOL)

### DIFF
--- a/sql/updates/mangos/z2824_01_mangos_model_unification.sql
+++ b/sql/updates/mangos/z2824_01_mangos_model_unification.sql
@@ -1,5 +1,5 @@
 ALTER TABLE db_version CHANGE COLUMN required_z2823_01_mangos_displayid_probability required_z2824_01_mangos_model_unification bit;
 
-ALTER TABLE `creature_model_info` RENAME COLUMN `modelid_other_team` TO `modelid_alternative`;
+ALTER TABLE `creature_model_info` CHANGE `modelid_other_team` `modelid_alternative` MEDIUMINT UNSIGNED NOT NULL DEFAULT 0;
 
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR makes the MySQL column rename command compatible with MySQL 5.7 (EOL) as well as old MariaDB versions.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/3707
