### PR TITLE
Implement IsInitialized for auctionhousebot

### DIFF
--- a/src/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -30,7 +30,7 @@
 
 INSTANTIATE_SINGLETON_1(AuctionHouseBot);
 
-AuctionHouseBot::AuctionHouseBot() : m_configFileName(_AUCTIONHOUSEBOT_CONFIG), m_houseAction(-1)
+AuctionHouseBot::AuctionHouseBot() : m_configFileName(_AUCTIONHOUSEBOT_CONFIG), m_houseAction(-1), m_isInitialized(false)
 {
 }
 
@@ -148,6 +148,8 @@ void AuctionHouseBot::Initialize()
             }
             while (queryResult->NextRow());
         }
+
+        m_isInitialized = true;        
     }
 }
 

--- a/src/game/AuctionHouseBot/AuctionHouseBot.h
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.h
@@ -58,7 +58,7 @@ class AuctionHouseBot
         void PrepareStatusInfos(AuctionHouseBotStatusInfo& statusInfo) const;
         void SetItemData(uint32 item, AuctionHouseBotItemData& itemData, bool reset = false);
         AuctionHouseBotItemData GetItemData(uint32 item);
-
+        bool IsInitialized() const { return m_isInitialized; };
     private:
         uint32 GetMinMaxConfig(const char* config, uint32 minValue, uint32 maxValue, uint32 defaultValue);
         void ParseLootConfig(char const* fieldname, std::vector<int32>& lootConfig);
@@ -110,6 +110,8 @@ class AuctionHouseBot
         std::unordered_set<uint32> m_vendorItems;
 
         std::unordered_map<uint32, AuctionHouseBotItemData> m_itemData;
+
+        bool m_isInitialized;        
 };
 
 #define sAuctionHouseBot MaNGOS::Singleton<AuctionHouseBot>::Instance()


### PR DESCRIPTION
## 🍰 Pullrequest
IsInitialized() implementation for AuctionhouseBot to allow external modules (such as playerbot) to detect if GetItemData() can be used safely. 

### Proof
When AuctionHouseBot.Chance.Sell and  AuctionHouseBot.Chance.Buy are both set to 0 in the config GetItemData() will return uninitialized values. This causes issues in for example playerbot code.

### How2Test
Disable Auctionhousebot in the config with playerbots enabled.

### Todo / Checklist
- [X] Use IsInitialized in botcode.