### PR TITLE
Core/PacketIO: Update SMSG_QUESTGIVER_REQUEST_ITEMS

### DIFF
--- a/src/game/Entities/GossipDef.cpp
+++ b/src/game/Entities/GossipDef.cpp
@@ -559,16 +559,15 @@ void PlayerMenu::SendQuestGiverRequestItems(Quest const* pQuest, ObjectGuid npcG
             data << uint32(0);
     }
 
-    data << uint32(0x02);
+    data << uint32(0x02);                                   // flags1
 
     if (!Completable)                                       // Completable = flags1 && flags2 && flags3 && flags4
-        data << uint32(0x00);                               // flags1
+        data << uint32(0x00);                               // flags2
     else
-        data << uint32(0x03);
+        data << uint32(0x03);                               // flags2
 
-    data << uint32(0x04);                                   // flags2
-    data << uint32(0x08);                                   // flags3
-    data << uint32(0x10);                                   // flags4
+    data << uint32(0x04);                                   // flags3
+    data << uint32(0x08);                                   // flags4
 
     GetMenuSession()->SendPacket(data);
     DEBUG_LOG("WORLD: Sent SMSG_QUESTGIVER_REQUEST_ITEMS NPCGuid = %s, questid = %u", npcGUID.GetString().c_str(), pQuest->GetQuestId());


### PR DESCRIPTION
## 🍰 Pullrequest
Updates the packet structure for SMSG_QUESTGIVER_REQUEST_ITEMS.

After the loop, all three clients (1.12.2, 2.4.3, and 3.3.5) read only these four flags/booleans and combine them with && into a boolean value (probably 'Completable' according to the original comment - // Completable = flags1 && flags2 && flags3 && flags4). The four flags are neither stored nor any further processed (1.12.2, 2.4.3, and 3.3.5). Verified using IDA.

Picked from: https://github.com/vmangos/core

Co-authored-by: brotalnia <brotalnia@gmail.com>

https://github.com/vmangos/core/commit/b9b006db08fcdc055057ff68a3f9fe295ead3ba5
