### PR TITLE
Core/PacketIO: Update RaidGroupError enum

### DIFF
--- a/src/game/Entities/Player.h
+++ b/src/game/Entities/Player.h
@@ -307,11 +307,9 @@ typedef std::list<Item*> ItemDurationList;
 
 enum RaidGroupError
 {
-    ERR_RAID_GROUP_NONE                 = 0,
-    ERR_RAID_GROUP_LOWLEVEL             = 1,
-    ERR_RAID_GROUP_ONLY                 = 2,
-    ERR_RAID_GROUP_FULL                 = 3,
-    ERR_RAID_GROUP_REQUIREMENTS_UNMATCH = 4
+    ERR_RAID_GROUP_NONE         = 0,
+    ERR_RAID_GROUP_REQUIRED     = 1,
+    ERR_RAID_GROUP_FULL         = 2,
 };
 
 enum DrunkenState


### PR DESCRIPTION
## 🍰 Pullrequest
Updates raid group error definitions for SMSG_RAID_GROUP_ONLY (1.12. and 2.4.3 only). Verified using IDA.