### PR TITLE
Realm/Core: Implement realm category mapping using realm zone and major version

### DIFF
--- a/src/game/World/World.h
+++ b/src/game/World/World.h
@@ -365,41 +365,6 @@ enum RealmType
                          // replaced by REALM_PVP in realm list
 };
 
-// [-ZERO] Need drop not existed cases
-enum RealmZone
-{
-    REALM_ZONE_UNKNOWN       = 0,                           // any language
-    REALM_ZONE_DEVELOPMENT   = 1,                           // any language
-    REALM_ZONE_UNITED_STATES = 2,                           // extended-Latin
-    REALM_ZONE_OCEANIC       = 3,                           // extended-Latin
-    REALM_ZONE_LATIN_AMERICA = 4,                           // extended-Latin
-    REALM_ZONE_TOURNAMENT_5  = 5,                           // basic-Latin at create, any at login
-    REALM_ZONE_KOREA         = 6,                           // East-Asian
-    REALM_ZONE_TOURNAMENT_7  = 7,                           // basic-Latin at create, any at login
-    REALM_ZONE_ENGLISH       = 8,                           // extended-Latin
-    REALM_ZONE_GERMAN        = 9,                           // extended-Latin
-    REALM_ZONE_FRENCH        = 10,                          // extended-Latin
-    REALM_ZONE_SPANISH       = 11,                          // extended-Latin
-    REALM_ZONE_RUSSIAN       = 12,                          // Cyrillic
-    REALM_ZONE_TOURNAMENT_13 = 13,                          // basic-Latin at create, any at login
-    REALM_ZONE_TAIWAN        = 14,                          // East-Asian
-    REALM_ZONE_TOURNAMENT_15 = 15,                          // basic-Latin at create, any at login
-    REALM_ZONE_CHINA         = 16,                          // East-Asian
-    REALM_ZONE_CN1           = 17,                          // basic-Latin at create, any at login
-    REALM_ZONE_CN2           = 18,                          // basic-Latin at create, any at login
-    REALM_ZONE_CN3           = 19,                          // basic-Latin at create, any at login
-    REALM_ZONE_CN4           = 20,                          // basic-Latin at create, any at login
-    REALM_ZONE_CN5           = 21,                          // basic-Latin at create, any at login
-    REALM_ZONE_CN6           = 22,                          // basic-Latin at create, any at login
-    REALM_ZONE_CN7           = 23,                          // basic-Latin at create, any at login
-    REALM_ZONE_CN8           = 24,                          // basic-Latin at create, any at login
-    REALM_ZONE_TOURNAMENT_25 = 25,                          // basic-Latin at create, any at login
-    REALM_ZONE_TEST_SERVER   = 26,                          // any language
-    REALM_ZONE_TOURNAMENT_27 = 27,                          // basic-Latin at create, any at login
-    REALM_ZONE_QA_SERVER     = 28,                          // any language
-    REALM_ZONE_CN9           = 29                           // basic-Latin at create, any at login
-};
-
 /// Storage class for commands issued for delayed execution
 struct CliCommandHolder
 {

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -880,13 +880,15 @@ void AuthSocket::LoadRealmlist(ByteBuffer& pkt, uint32 acctid, uint8 securityLev
                 if (!ok_build || (i.second.allowedSecurityLevel > _accountSecurityLevel))
                     realmflags = RealmFlags(realmflags | REALM_FLAG_OFFLINE);
 
+                uint8 categoryId = GetRealmCategoryIdByBuildAndZone(_build, RealmZone(i.second.timezone));
+
                 pkt << uint32(i.second.icon);              // realm type
                 pkt << uint8(realmflags);                   // realmflags
                 pkt << name;                                // name
                 pkt << i.second.address;                   // address
                 pkt << float(i.second.populationLevel);
                 pkt << uint8(AmountOfCharacters);
-                pkt << uint8(i.second.timezone);           // realm category
+                pkt << uint8(categoryId);                   // realm category
                 pkt << uint8(0x00);                         // unk, may be realm number/id?
             }
 
@@ -940,6 +942,8 @@ void AuthSocket::LoadRealmlist(ByteBuffer& pkt, uint32 acctid, uint8 securityLev
                 if (!buildInfo)
                     realmFlags = RealmFlags(realmFlags & ~REALM_FLAG_SPECIFYBUILD);
 
+                uint8 categoryId = GetRealmCategoryIdByBuildAndZone(_build, RealmZone(i.second.timezone));
+
                 pkt << uint8(i.second.icon);               // realm type (this is second column in Cfg_Configs.dbc)
                 pkt << uint8(lock);                         // flags, if 0x01, then realm locked
                 pkt << uint8(realmFlags);                   // see enum RealmFlags
@@ -947,7 +951,7 @@ void AuthSocket::LoadRealmlist(ByteBuffer& pkt, uint32 acctid, uint8 securityLev
                 pkt << i.second.address;                   // address
                 pkt << float(i.second.populationLevel);
                 pkt << uint8(AmountOfCharacters);
-                pkt << uint8(i.second.timezone);           // realm category (Cfg_Categories.dbc)
+                pkt << uint8(categoryId);                   // realm category (Cfg_Categories.dbc)
                 pkt << uint8(0x2C);                         // unk, may be realm number/id?
 
                 if (realmFlags & REALM_FLAG_SPECIFYBUILD)

--- a/src/realmd/RealmList.cpp
+++ b/src/realmd/RealmList.cpp
@@ -82,6 +82,25 @@ RealmBuildInfo const* FindBuildInfo(uint16 _build)
     return nullptr;
 }
 
+static const uint8 RealmCategoryIdsByRealmZoneByMajorVersion[4][MAX_REALM_ZONES] =
+{
+    { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1 }, // 0 - Alpha
+    { 0, 1, 1, 5, 1, 1, 1, 1, 1, 2,  3,  5,  1,  1,  1,  1,  1,  1,  1,  2,  1,  1,  1,  3,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1 }, // 1 - Classic
+    { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,  0,  0,  0,  0,  0,  0,  0 }, // 2 - TBC
+    { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 }  // 3 - WotLK
+};
+
+uint8 GetRealmCategoryIdByBuildAndZone(uint16 _build, RealmZone _realmZone)
+{
+    if (_realmZone >= MAX_REALM_ZONES)
+    {
+        _realmZone = REALM_ZONE_DEVELOPMENT;
+    }
+
+    RealmBuildInfo const* buildInfo = FindBuildInfo(_build);
+    return buildInfo ? RealmCategoryIdsByRealmZoneByMajorVersion[buildInfo->major_version][_realmZone] : _realmZone;
+}
+
 RealmList::RealmList() : m_UpdateInterval(0), m_NextUpdateTime(time(nullptr))
 {
 }

--- a/src/realmd/RealmList.h
+++ b/src/realmd/RealmList.h
@@ -38,6 +38,7 @@ struct RealmBuildInfo
 };
 
 RealmBuildInfo const* FindBuildInfo(uint16 _build);
+uint8 GetRealmCategoryIdByBuildAndZone(uint16 _build, RealmZone _realmZone);
 
 typedef std::set<uint32> RealmBuilds;
 

--- a/src/shared/Common.h
+++ b/src/shared/Common.h
@@ -142,6 +142,52 @@ enum RealmFlags
     REALM_FLAG_FULL         = 0x80
 };
 
+// Used in mangosd/realmd
+enum RealmZone : uint8
+{
+    REALM_ZONE_UNKNOWN       = 0,                           // any language
+    REALM_ZONE_DEVELOPMENT   = 1,                           // any language
+    REALM_ZONE_UNITED_STATES = 2,                           // extended-Latin
+    REALM_ZONE_OCEANIC       = 3,                           // extended-Latin
+    REALM_ZONE_LATIN_AMERICA = 4,                           // extended-Latin
+    REALM_ZONE_TOURNAMENT_5  = 5,                           // basic-Latin at create, any at login
+    REALM_ZONE_KOREA         = 6,                           // East-Asian
+    REALM_ZONE_TOURNAMENT_7  = 7,                           // basic-Latin at create, any at login
+    REALM_ZONE_ENGLISH       = 8,                           // extended-Latin
+    REALM_ZONE_GERMAN        = 9,                           // extended-Latin
+    REALM_ZONE_FRENCH        = 10,                          // extended-Latin
+    REALM_ZONE_SPANISH       = 11,                          // extended-Latin
+    REALM_ZONE_RUSSIAN       = 12,                          // Cyrillic
+    REALM_ZONE_TOURNAMENT_13 = 13,                          // basic-Latin at create, any at login
+    REALM_ZONE_TAIWAN        = 14,                          // East-Asian
+    REALM_ZONE_TOURNAMENT_15 = 15,                          // basic-Latin at create, any at login
+    REALM_ZONE_CHINA         = 16,                          // East-Asian
+    REALM_ZONE_CN1           = 17,                          // basic-Latin at create, any at login
+    REALM_ZONE_CN2           = 18,                          // basic-Latin at create, any at login
+    REALM_ZONE_CN3           = 19,                          // basic-Latin at create, any at login
+    REALM_ZONE_CN4           = 20,                          // basic-Latin at create, any at login
+    REALM_ZONE_CN5           = 21,                          // basic-Latin at create, any at login
+    REALM_ZONE_CN6           = 22,                          // basic-Latin at create, any at login
+    REALM_ZONE_CN7           = 23,                          // basic-Latin at create, any at login
+    REALM_ZONE_CN8           = 24,                          // basic-Latin at create, any at login
+    REALM_ZONE_TOURNAMENT_25 = 25,                          // basic-Latin at create, any at login
+    REALM_ZONE_TEST_SERVER   = 26,                          // any language
+    REALM_ZONE_TOURNAMENT_27 = 27,                          // basic-Latin at create, any at login
+    REALM_ZONE_QA_SERVER     = 28,                          // any language
+    REALM_ZONE_CN9           = 29,                          // basic-Latin at create, any at login
+    REALM_ZONE_TEST_SERVER_2 = 30,                          // any language
+    // in 3.x
+    REALM_ZONE_CN10          = 31,                          // basic-Latin at create, any at login
+    REALM_ZONE_CTC           = 32,
+    REALM_ZONE_CNC           = 33,
+    REALM_ZONE_CN1_4         = 34,                          // basic-Latin at create, any at login
+    REALM_ZONE_CN2_6_9       = 35,                          // basic-Latin at create, any at login
+    REALM_ZONE_CN3_7         = 36,                          // basic-Latin at create, any at login
+    REALM_ZONE_CN5_8         = 37                           // basic-Latin at create, any at login
+};
+
+#define MAX_REALM_ZONES 38
+
 // operator new[] based version of strdup() function! Release memory by using operator delete[] !
 inline char* mangos_strdup(const char* source)
 {


### PR DESCRIPTION
## 🍰 Pullrequest
The current configuration option for realm categories via the "RealmZone" option in cmangos-classic is causing issues. In version 1.12, only a maximum of four realm categories (1, 2, 3, 5) per locale/region exist. If a different value, such as 12 (RealmZone: Russian, Cyrillic), is used to set the cyrillic character set, the realm will not appear on the clients realm list. This limitation prevents consistent assignment of a valid realm category alongside the desired character set.

~~This PR implements a configuration option for realm categories (defined in Cfg_Categories.dbc) that is independent of the character set setting of "RealmZone".~~

Unlike TBC and WotLK, the categories are not uniquely numbered in 1.12; instead, some entries use the same ID for multiple entries. In cmangos-tbc and cmangos-wotlk, the realm category corresponds to the 'RealmZone' setting, which also configures the available character set. In Vanilla, character set configuration cannot be done directly via the realm category due to collisions in numbering (for example, enUS and ruRU use different character sets but have the same region and category IDs in 1.12).

- ~~The new setting "RealmCategory" configures the realm category based on the client locale in use~~
- ~~The setting "RealmZone" now only configures the server side character set~~

**//UPDATE:**
To ensure that the realm daemon remains compatible with other versions, the appropriate realm category is now mapped based on the realm zone setting and the major client version.

### Issues
- fixes [#3669](https://github.com/cmangos/issues/issues/3669)
- relates [vmangos#2495](https://github.com/vmangos/core/issues/2495)

### How2Test
1. Add two realms to your realmlist table and use different category values.
2. Start your client, login and open the realm selection dialog
3. The two realm categories should be displayed on the bottom

### Todo / Checklist
- [X] None

### Cfg_Categories.dbc (enUS)
```
CategoryId,RegionId,Name,None,None,None,None,None,None,None,flags,
1,1,"United States",,,,,,,,0x3F007E,
1,2,"Korea",,,,,,,,0x3F007E,
1,3,"English",,,,,,,,0x3F007E,
2,3,"German",,,,,,,,0x3F007E,
3,3,"French",,,,,,,,0x3F007E,
1,4,"Taiwan",,,,,,,,0x3F007E,
1,5,"China",,,,,,,,0x3F007E,
1,99,"Test Server",,,,,,,,0x3F007E,
5,1,"Oceanic",,,,,,,,0x3F007E,
1,101,"QA Server",,,,,,,,0x3F007E,
5,3,"Spanish",,,,,,,,0x3F007E,
5,99,"Oceanic",,,,,,,,0x3F007E,
2,5,"CN3",,,,,,,,0x3F007E,
3,5,"CN7",,,,,,,,0x3F007E,
```

### Cfg_Categories.dbc (ruRU)
```
CategoryId,RegionId,Name,None,None,None,None,None,None,None,flags,
1,1,"Русский",,,,,,,,0x3F007E,
1,2,"Корея",,,,,,,,0x3F007E,
1,3,"Английский",,,,,,,,0x3F007E,
2,3,"Немецкий",,,,,,,,0x3F007E,
3,3,"Французский",,,,,,,,0x3F007E,
1,4,"Тайвань",,,,,,,,0x3F007E,
1,5,"Китай",,,,,,,,0x3F007E,
1,99,"Тестовый сервер",,,,,,,,0x3F007E,
5,1,"Океания",,,,,,,,0x3F007E,
1,101,"Сервер контроля качества",,,,,,,,0x3F007E,
5,3,"Испанский",,,,,,,,0x3F007E,
5,99,"Океания",,,,,,,,0x3F007E,
2,5,"КТ3",,,,,,,,0x3F007E,
3,5,"КТ7",,,,,,,,0x3F007E,
```
