### PR TITLE
OutdoorPVP SI/EP

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -6785,7 +6785,11 @@ void Player::UpdateZone(uint32 newZone, uint32 newArea, bool force)
         sOutdoorPvPMgr.HandlePlayerEnterZone(this, newZone);
         sWorldState.HandlePlayerEnterZone(this, newZone);
 
-        SendInitWorldStates(newZone);                       // only if really enters to new zone, not just area change, works strange...
+//        SendInitWorldStates(newZone);                       // only if really enters to new zone, not just area change, works strange...
+	if ((newZone == 139 || newZone == 1377) && !sWorld.getConfig(CONFIG_BOOL_OUTDOORPVP_EP_ENABLED))
+	{}
+	else
+		SendInitWorldStates(newZone);                       // never send when entering EP/SI end outdoorpvp is disabled	    
 
         if (sWorld.getConfig(CONFIG_BOOL_WEATHER))
         {


### PR DESCRIPTION
entering silithus/eastern plaguelands when outdoorpvp is not enabled will show no longer the AlwaysUpFrame* on top of the screen

## 🍰 Pullrequest
Avoid the AlwaysUpFrame* showing up when the OutdoorPVP is set to not enable in mangosd.conf

### Proof

### Issues
doing the teleport to SI/EP without this update may often cause the AlwaysUpFrames show up even when outdoorpvp is not enable


### How2Test
- without patch: set both the OutdoorPvp.*Enabled = 0, teleport to SI or EP and see the AlwaysUpFrames on top of the screen
- with patch: set both the OutdoorPvp.*Enabled = 0, teleport to SI or EP and see the AlwaysUpFrames are not showed


### Todo / Checklist
- [X] None
