### PR TITLE
disable map optimizations for playerbots if sPlayerbotAIConfig.DisableBotOptimizations

### DIFF
--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -847,7 +847,14 @@ void Map::Update(const uint32& t_diff)
             plr->Update(t_diff);
 
 #ifdef ENABLE_PLAYERBOTS
-            plr->UpdateAI(t_diff, !shouldUpdateBot);
+            if (sPlayerbotAIConfig.disableBotOptimizations)
+            {
+                plr->UpdateAI(t_diff, false);
+            }
+            else
+            {
+                plr->UpdateAI(t_diff, !shouldUpdateBot);
+            }
 #endif
         }
     }
@@ -869,7 +876,7 @@ void Map::Update(const uint32& t_diff)
 
 #ifdef ENABLE_PLAYERBOTS
         // For non-players only load the grid
-        if (!player->isRealPlayer()) 
+        if (!sPlayerbotAIConfig.disableBotOptimizations && !player->isRealPlayer())
         {
             CellPair center = MaNGOS::ComputeCellPair(player->GetPositionX(), player->GetPositionY()).normalize();
             uint32 cell_id = (center.y_coord * TOTAL_NUMBER_OF_CELLS_PER_MAP) + center.x_coord;
@@ -926,7 +933,7 @@ void Map::Update(const uint32& t_diff)
 
 #ifdef ENABLE_PLAYERBOTS
             // Skip objects on locations away from real players if world is laggy
-            if (IsContinent() && avgDiff > 100)
+            if (!sPlayerbotAIConfig.disableBotOptimizations && IsContinent() && avgDiff > 100)
             {
                 const bool isInActiveZone = IsContinent() ? HasActiveZone(obj->GetZoneId()) : HasRealPlayers();
                 if (!isInActiveZone && !shouldUpdateObjects)
@@ -1090,7 +1097,7 @@ void Map::Remove(T* obj, bool remove)
             obj->SaveRespawnTime(); // requires map not being reset
 
     obj->ResetMap();
-        
+
     if (remove) // Note: In case resurrectable corpse and pet its removed from global lists in own destructor
         delete obj;
 }
@@ -1313,7 +1320,7 @@ void Map::UpdateObjectVisibility(WorldObject* obj, Cell cell, const CellPair& ce
         if (Player* player = GetPlayer(guid))
         {
 #ifdef ENABLE_PLAYERBOTS
-            if (player->isRealPlayer())
+            if (sPlayerbotAIConfig.disableBotOptimizations || player->isRealPlayer())
 #endif
             player->UpdateVisibilityOf(player->GetCamera().GetBody(), obj);
         }


### PR DESCRIPTION
## 🍰 Pullrequest
disable map optimizations for playerbots if sPlayerbotAIConfig.DisableBotOptimizations (default off - optimizations enabled) to allow full activity at all times

because no other way to disable this behavior from config, and it hinders bot activity

### How2Test
- build with Playerbots
- set AiPlayerbot.DisableBotOptimizations = 1 in aiplayerbot.conf
- launch the server
