### PR TITLE
Stormwind: Fix Windsor not despawning after The Great Masquerade

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/stormwind_city.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/stormwind_city.cpp
@@ -889,6 +889,7 @@ struct npc_reginald_windsorAI : public npc_escortAI, private DialogueHelper
                 m_creature->ClearAllReactives();
                 m_creature->SetImmobilizedState(true, true);
                 m_creature->SetStandState(UNIT_STAND_STATE_DEAD);
+                m_creature->SetUInt32Value(UNIT_FIELD_MOUNTDISPLAYID, 0);
                 break;
             case SAY_PRESTOR_KEEP_14:
                 if (Creature* onyxia = m_scriptedMap->GetSingleCreatureFromStorage(NPC_PRESTOR))
@@ -941,6 +942,7 @@ struct npc_reginald_windsorAI : public npc_escortAI, private DialogueHelper
                     onyxia->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP | UNIT_NPC_FLAG_QUESTGIVER);
                 // Allow creature to despawn
                 SetEscortPaused(false);
+                m_creature->Suicide();
                 break;
         }
     }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR ensures that Reginald Windsor despawns at the end of The Great Masquerade (and also doesn't have his horse model when fake-dead)

### Proof
<!-- Link resources as proof -->
- [None](https://youtu.be/myj4g07wb88?si=sJi1SaErCsVidIx0&t=217)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/3482 fully

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- 😱😱😱😱😱