### PR TITLE
Missing bot-specific pathfinder modifications to allow for travel node generation.

### DIFF
--- a/src/game/MotionGenerators/PathFinder.h
+++ b/src/game/MotionGenerators/PathFinder.h
@@ -129,6 +129,9 @@ class PathFinder
 
         const dtNavMeshQuery*   m_defaultNavMeshQuery;     // the nav mesh query used to find the path
         uint32                  m_defaultMapId;
+#ifdef ENABLE_PLAYERBOTS
+        uint32                  m_defaultInstanceId;
+#endif
 
         bool                    m_ignoreNormalization;
 


### PR DESCRIPTION
## 🍰 Pullrequest
See also https://github.com/cmangos/mangos-tbc/pull/701

This PR (re-)implements some adjustments to the existing pathfinder logic to allow for pathfinding without a source unit. This is required for generating travelnodes used in long-range bot pathfinding.
This PR also includes a fix in using the proper instanceId when using get/set area which allows navmesh manipulation by bots in instances.

These changes should have been implemented during the original bot-code merge but where forgotten or have been broken since then.

Note without these changes bots will continue to work fine however we will be unable to re-generate the nodemap to keep up with future map-changes or fix existing minor issues (such as missing zeppelin paths in tbc).

### Proof
An example can be found in the current pathfinder:  https://github.com/cmangos/mangos-tbc/blob/1605ff06b177df6cdb4b4d72b7038ea273ca70d5/src/game/MotionGenerators/PathFinder.cpp#L127

This simply stops any calculation without a m_sourceUnit. This functionality is however essential to generate paths during server start. 

Here you can see the original bot implementation lacks that check: https://github.com/celguar/mangos-tbc/blob/63b2e8f43fb1a10e4a7b55de2f0697fbd46e8979/src/game/MotionGenerators/PathFinder.cpp#L119

If you look at the changes made they are limited to bypassing/implementing some m_sourceUnit checks and only effect builds that include playerbots. Also some extra instanceId handling specifically for get/setArea. Normal pathfinding should not be affected.

### Issues
-Unreported: Bots in tbc no longer use zeppelins to travel between continents.
-Unreported: Bots manipulating the navmesh to avoid mobs crash the server when in an instance.

### How2Test
Testing travelnode generation can be tested by clearing the ai_playerbot_travelnode table. Doing this without this fix will result in 800 travelnodes remaining mostly in instances. With this fix 2500+ nodes will remain including proper paths in the overworld.