### PR TITLE
Incorrect instance reset crash fix.

### DIFF
--- a/src/game/World/World.cpp
+++ b/src/game/World/World.cpp
@@ -916,11 +916,11 @@ void World::SetInitialWorldSettings()
     sSpellMgr.LoadSkillRaceClassInfoMap();
 
     ///- Clean up and pack instances
-    sLog.outString("Cleaning up instances...");
-    sMapPersistentStateMgr.CleanupInstances();              // must be called before `creature_respawn`/`gameobject_respawn` tables
-
     sLog.outString("Packing instances...");
     sMapPersistentStateMgr.PackInstances();
+
+    sLog.outString("Cleaning up instances...");
+    sMapPersistentStateMgr.CleanupInstances();              // must be called before `creature_respawn`/`gameobject_respawn` tables
 
     sLog.outString("Packing groups...");
     sObjectMgr.PackGroupIds();                              // must be after CleanupInstances


### PR DESCRIPTION
## 🍰 Pullrequest
See https://github.com/cmangos/mangos-tbc/pull/698
This PR fixes crashes when resetting an instance ID that previously belonged to a dungeon but was re-used as a battleground. 

### Proof
On server start in https://github.com/cmangos/mangos-tbc/blob/910d594493c2bd715efdba876cb3fd5f490a7cd3/src/game/World/World.cpp#L978 instance ID's are first cleaned up before they are 'packed' which means they are lowered to remove any gaps. The problem however is that besides cleaning up this method also starts a reset countdown timer for instances that are slated to reset but have not done so yet. This timer is started for the original ID's and not modified along with the database content during the packing.

The end result is that an instance id 10 which is slated to expire after server start can be lowered to 5 while a new battleground will re-use the 10 which causes a assert. More detail is given in the fixed issue.

While moving the packing in front of the cleaning results in a slightly less efficient packing as some instances will be removed leaving some holes, it is simpler and less error prone than modifying the reset timers during the packing.

### Issues
- fixes [https://github.com/cmangos/issues/issues/3769]

### How2Test
Start a few instances during a server and make some expire (by breaking up the groups) such that gaps are created in the instance ID's after server shutdown.
Now before the remaining instances are slated to reset start the server and notice that the original instance ID's are modified in the database to a lower number. Now start battlegrounds such that the original ID's are re-used. Keep the battleground active until the original dungeon was slated to reset and watch the server crash (or not crash with this fix).
