### PR TITLE
Makes BRD arena spectator stairs walkable

### DIFF
--- a/contrib/extractor_scripts/config.json
+++ b/contrib/extractor_scripts/config.json
@@ -9,8 +9,8 @@
 	},
 	"230": {
 		"3230": {
-			"walkableHeight": 6.9,
-			"walkableClimb": 6.4,
+			"walkableHeight": 7,
+			"walkableClimb": 6,
 			"_Info": "Makes BRD arena spectator stairs walkable"
 		}
 	},

--- a/contrib/extractor_scripts/config.json
+++ b/contrib/extractor_scripts/config.json
@@ -7,6 +7,13 @@
 			"_Info": "walkableClimb <= 8 else .go c 1000403 goes over the edge"
 		}
 	},
+	"230": {
+		"3230": {
+			"walkableHeight": 6.9,
+			"walkableClimb": 6.4,
+			"_Info": "Makes BRD arena spectator stairs walkable"
+		}
+	},
 	"530": {
 		"2029": {
 			"detailSampleDist": 1,


### PR DESCRIPTION
## 🍰 Pullrequest
Stairs on top of BRD arena don't have any path out of it and prevent mobs from reaching player in melee.

### Proof
![image](https://github.com/user-attachments/assets/04d23d1b-9a3d-4234-9194-3ae8d7abb318)

This fix the pathing on the tile
