### PR TITLE
Playerbot: Prevent double login while player is teleporting

### DIFF
--- a/src/game/Entities/CharacterHandler.cpp
+++ b/src/game/Entities/CharacterHandler.cpp
@@ -124,7 +124,7 @@ void PlayerbotHolder::HandlePlayerBotLoginCallback(QueryResult* dummy, SqlQueryH
     botSession->SetNoAnticheat();
 
     // has bot already been added?
-    if (sObjectMgr.GetPlayer(lqh->GetGuid()))
+    if (sObjectMgr.GetPlayer(lqh->GetGuid(), false))
         return;
 
     uint32 guid = lqh->GetGuid().GetRawValue();


### PR DESCRIPTION
## 🍰 Pullrequest
This is a minor fix that stops players (and bots) from actually logging into a character that is already online. This would result in player duplication where two players with the same guid exist in the server.

### Proof
During a teleport players are marked as inWorld=false. Before this fix only players where inWorld=true were being detected as already logged in.

### How2Test
With latest botcode this can no longer be reproduced since the check to see if a login request should be sent has also been adjusted to include teleporting players.
