### PR TITLE
Playerbot: Compile fix for new quest weakptr

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -19253,7 +19253,7 @@ void Player::learnClassLevelSpells(bool includeHighLevelQuestRewards)
     ObjectMgr::QuestMap const& qTemplates = sObjectMgr.GetQuestTemplates();
     for (const auto& qTemplate : qTemplates)
     {
-        Quest const* quest = qTemplate.second;
+        Quest const* quest = qTemplate.second.get();
         if (!quest)
             continue;
 


### PR DESCRIPTION
## 🍰 Pullrequest
This is a small PR to allow compilation with the enable_playerbots flag active with the new weakptr system for quests.
The same solution is used here as in the rest of the bot-codebase at the moment.

See also https://github.com/cmangos/mangos-tbc/pull/708