### PR TITLE
Battleground: Fix players unable to join running battleground or too …

### DIFF
--- a/src/game/BattleGround/BattleGroundQueue.cpp
+++ b/src/game/BattleGround/BattleGroundQueue.cpp
@@ -786,7 +786,7 @@ void BattleGroundQueueItem::Update(BattleGroundQueue& queue, BattleGroundTypeId 
     // battleground with free slot for player should be always in the beggining of the queue
     // maybe it would be better to create bgfreeslotqueue for each bracket_id
     BgFreeSlotQueueType::iterator next;
-    auto queueItems = queue.GetFreeSlotQueueItem(bgTypeId);
+    auto& queueItems = queue.GetFreeSlotQueueItem(bgTypeId);
     for (BgFreeSlotQueueType::iterator itr = queueItems.begin(); itr != queueItems.end(); itr = next)
     {
         BattleGroundInQueueInfo& queueInfo = *itr;
@@ -861,8 +861,6 @@ void BattleGroundQueueItem::Update(BattleGroundQueue& queue, BattleGroundTypeId 
         bgInfo.instanceId = sMapMgr.GenerateInstanceId();
         bgInfo.m_clientInstanceId = queue.CreateClientVisibleInstanceId(bgTypeId, bracketId);
 
-        queue.AddBgToFreeSlots(bgInfo);
-
         // invite those selection pools
         for (uint8 i = 0; i < PVP_TEAM_COUNT; ++i)
             for (GroupsQueueType::const_iterator citr = m_selectionPools[TEAM_INDEX_ALLIANCE + i].selectedGroups.begin(); citr != m_selectionPools[TEAM_INDEX_ALLIANCE + i].selectedGroups.end(); ++citr)
@@ -871,6 +869,8 @@ void BattleGroundQueueItem::Update(BattleGroundQueue& queue, BattleGroundTypeId 
         // clear structures
         m_selectionPools[TEAM_INDEX_ALLIANCE].Init();
         m_selectionPools[TEAM_INDEX_HORDE].Init();
+
+        queue.AddBgToFreeSlots(bgInfo);
 
         sWorld.GetMessager().AddMessage([instanceId = bgInfo.instanceId, clientInstanceId = bgInfo.m_clientInstanceId, bgTypeId, bracketId, allianceCount = bgInfo.GetInvitedCount(ALLIANCE), hordeCount = bgInfo.GetInvitedCount(HORDE)](World* world)
         {
@@ -901,12 +901,12 @@ void BattleGroundQueueItem::Update(BattleGroundQueue& queue, BattleGroundTypeId 
         bgInfo.instanceId = sMapMgr.GenerateInstanceId();
         bgInfo.m_clientInstanceId = queue.CreateClientVisibleInstanceId(bgTypeId, bracketId);
 
-        queue.AddBgToFreeSlots(bgInfo);
-
         // invite those selection pools
         for (uint8 i = 0; i < PVP_TEAM_COUNT; ++i)
             for (GroupsQueueType::const_iterator citr = m_selectionPools[TEAM_INDEX_ALLIANCE + i].selectedGroups.begin(); citr != m_selectionPools[TEAM_INDEX_ALLIANCE + i].selectedGroups.end(); ++citr)
                 InviteGroupToBg((*citr), bgInfo, (*citr)->groupTeam);
+
+        queue.AddBgToFreeSlots(bgInfo);
 
         sWorld.GetMessager().AddMessage([instanceId = bgInfo.instanceId, clientInstanceId = bgInfo.m_clientInstanceId, bgTypeId, bracketId, allianceCount = bgInfo.GetInvitedCount(ALLIANCE), hordeCount = bgInfo.GetInvitedCount(HORDE)](World* world)
         {


### PR DESCRIPTION
…many players being able to join

## 🍰 Pullrequest
This pull request fixes two issues with battleground queues. 
1. Players are able to join a battleground that is in progress but that is full.
2. Players are unable to join a battleground that is in progress but where there is room to join.

### Proof
When a battleground is created for a premade group (and for non-premades simulary) the BattleGroundInQueueInfo is saved to the BattleGroundQueue here: https://github.com/cmangos/mangos-classic/blob/f0fab6b47cc892c185b8370208d7ee729fdaeae8/src/game/BattleGround/BattleGroundQueue.cpp#L864

Notice that his is an emplace_back which copies the BattleGroundInQueueInfo so it can later be used to check the room for new invites. However only after the copy it fills the invited counts here: https://github.com/cmangos/mangos-classic/blob/f0fab6b47cc892c185b8370208d7ee729fdaeae8/src/game/BattleGround/BattleGroundQueue.cpp#L869
Since the original bgInfo goes out of scope after this method the information is lost.

This leaves the invited players at 0/0 globally in the BattleGroundInQueueInfo while the battleground has the correct values. If a player removes the battleground it will actually make these values negative which makes it a huge number and this block any invites.

The second issue was actually a bit nastier. This is actually a copy: https://github.com/cmangos/mangos-classic/blob/f0fab6b47cc892c185b8370208d7ee729fdaeae8/src/game/BattleGround/BattleGroundQueue.cpp#L789
The auto hides it a bit but if you create a custom destructor for BattleGroundInQueueInfo you see the queueInfo created from it go out of scope at the end of this code.

The result is that even with above fix new players joining a bg in progress are not saved to the global BattleGroundInQueueInfo resulting in the ability to join a filled battleground.

### Issues
- None found.

### How2Test
- I used 21 clients to properly fill a wsg + 1. While 10 clients (5/5) are enough to test the initial issue of players being unable to join a bg in progress after 1 player leaves. The second issue of joining a completely filled wsg need (probably) at least 16 clients (5 horde/11 alliance) or active debugging to check the values of BattleGroundInQueueInfo.
-The expected results are that a battleground that is not completely filled should be joinable after one of the players leaves it and that a completely filled battleground should not be joinable.