### PR TITLE
Battleground: Check for m_bg being not null

### DIFF
--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -890,7 +890,12 @@ bool Creature::Create(uint32 dbGuid, uint32 guidlow, CreatureCreatePos& cPos, Cr
 
     // Notify the pvp script
     if (GetMap()->IsBattleGround())
-        static_cast<BattleGroundMap*>(GetMap())->GetBG()->HandleCreatureCreate(this);
+    {
+        if (BattleGround* bg = static_cast<BattleGroundMap*>(GetMap())->GetBG())
+        {
+            bg->HandleCreatureCreate(this);
+        }
+    }
     else if (OutdoorPvP* outdoorPvP = sOutdoorPvPMgr.GetScript(GetZoneId()))
         outdoorPvP->HandleCreatureCreate(this);
 


### PR DESCRIPTION
This is probably not the right fix and needs more investigation.

RelWithDebInfo Stacktrace:

```
mangosd.exe!Creature::Create(unsigned int dbGuid, unsigned int guidlow, CreatureCreatePos & cPos, const CreatureInfo * cinfo, const CreatureData * data, const GameEventCreatureData * eventData) Zeile 893
	unter C:\Repositories\cmangos-classic\src\game\Entities\Creature.cpp (893)
mangosd.exe!Creature::LoadFromDB(unsigned int dbGuid, Map * map, unsigned int newGuid, unsigned int forcedEntry, GenericTransport * transport) Zeile 1634
	unter C:\Repositories\cmangos-classic\src\game\Entities\Creature.cpp (1634)
mangosd.exe!LoadHelper<Creature>(const std::set<unsigned int,std::less<unsigned int>,std::allocator<unsigned int>> & guid_set, CoordPair<1024> & cell, GridRefManager<Creature> & __formal, unsigned int & count, Map * map, Grid<Player,TypeList<Player,TypeList<Creature,TypeList<Corpse,TypeList<Camera,TypeNull>>>>,TypeList<GameObject,TypeList<Creature,TypeList<DynamicObject,TypeList<Corpse,TypeNull>>>>> & grid) Zeile 138
	unter C:\Repositories\cmangos-classic\src\game\Grids\ObjectGridLoader.cpp (138)
mangosd.exe!ObjectGridLoader::Visit(GridRefManager<Creature> & m) Zeile 218
	unter C:\Repositories\cmangos-classic\src\game\Grids\ObjectGridLoader.cpp (218)
[Inlineframe] mangosd.exe!TypeContainerVisitor<ObjectGridLoader,TypeMapContainer<TypeList<GameObject,TypeList<Creature,TypeList<DynamicObject,TypeList<Corpse,TypeNull>>>>>>::Visit(TypeMapContainer<TypeList<GameObject,TypeList<Creature,TypeList<DynamicObject,TypeList<Corpse,TypeNull>>>>> &) Zeile 80
	unter C:\Repositories\cmangos-classic\src\framework\GameSystem\TypeContainerVisitor.h (80)
[Inlineframe] mangosd.exe!Grid<Player,TypeList<Player,TypeList<Creature,TypeList<Corpse,TypeList<Camera,TypeNull>>>>,TypeList<GameObject,TypeList<Creature,TypeList<DynamicObject,TypeList<Corpse,TypeNull>>>>>::Visit(TypeContainerVisitor<ObjectGridLoader,TypeMapContainer<TypeList<GameObject,TypeList<Creature,TypeList<DynamicObject,TypeList<Corpse,TypeNull>>>>>> &) Zeile 80
	unter C:\Repositories\cmangos-classic\src\framework\GameSystem\Grid.h (80)
mangosd.exe!ObjectGridLoader::Load(Grid<Player,TypeList<Player,TypeList<Creature,TypeList<Corpse,TypeList<Camera,TypeNull>>>>,TypeList<GameObject,TypeList<Creature,TypeList<DynamicObject,TypeList<Corpse,TypeNull>>>>> & grid) Zeile 243
	unter C:\Repositories\cmangos-classic\src\game\Grids\ObjectGridLoader.cpp (243)
[Inlineframe] mangosd.exe!GridLoader<Player,TypeList<Player,TypeList<Creature,TypeList<Corpse,TypeList<Camera,TypeNull>>>>,TypeList<GameObject,TypeList<Creature,TypeList<DynamicObject,TypeList<Corpse,TypeNull>>>>>::Load(Grid<Player,TypeList<Player,TypeList<Creature,TypeList<Corpse,TypeList<Camera,TypeNull>>>>,TypeList<GameObject,TypeList<Creature,TypeList<DynamicObject,TypeList<Corpse,TypeNull>>>>> &) Zeile 52
	unter C:\Repositories\cmangos-classic\src\framework\GameSystem\GridLoader.h (52)
mangosd.exe!ObjectGridLoader::LoadN() Zeile 257
	unter C:\Repositories\cmangos-classic\src\game\Grids\ObjectGridLoader.cpp (257)
mangosd.exe!Map::EnsureGridLoaded(const Cell & cell) Zeile 384
	unter C:\Repositories\cmangos-classic\src\game\Maps\Map.cpp (384)
mangosd.exe!Map::EnsureGridLoadedAtEnter(const Cell & cell, Player * player) Zeile 343
	unter C:\Repositories\cmangos-classic\src\game\Maps\Map.cpp (343)
mangosd.exe!Map::CreatureCellRelocation(Creature * c, const Cell & new_cell) Zeile 1214
	unter C:\Repositories\cmangos-classic\src\game\Maps\Map.cpp (1214)
mangosd.exe!Map::CreatureRespawnRelocation(Creature * c) Zeile 1240
	unter C:\Repositories\cmangos-classic\src\game\Maps\Map.cpp (1240)
mangosd.exe!ObjectGridRespawnMover::Visit(GridRefManager<Creature> & m) Zeile 54
	unter C:\Repositories\cmangos-classic\src\game\Grids\ObjectGridLoader.cpp (54)
mangosd.exe!ObjectGridUnloader::MoveToRespawnN() Zeile 274
	unter C:\Repositories\cmangos-classic\src\game\Grids\ObjectGridLoader.cpp (274)
mangosd.exe!Map::UnloadGrid(const unsigned int & x, const unsigned int & y, bool pForce) Zeile 1274
	unter C:\Repositories\cmangos-classic\src\game\Maps\Map.cpp (1274)
mangosd.exe!Map::UnloadAll(bool pForce) Zeile 1304
	unter C:\Repositories\cmangos-classic\src\game\Maps\Map.cpp (1304)
mangosd.exe!MapManager::Update(unsigned int diff) Zeile 219
	unter C:\Repositories\cmangos-classic\src\game\Maps\MapManager.cpp (219)
mangosd.exe!World::Update(unsigned int diff) Zeile 1610
	unter C:\Repositories\cmangos-classic\src\game\World\World.cpp (1610)
mangosd.exe!WorldRunnable::run() Zeile 57
	unter C:\Repositories\cmangos-classic\src\mangosd\WorldRunnable.cpp (57)
[Inlineframe] mangosd.exe!std::invoke(void(*)(void *) &&) Zeile 1705
	unter C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.42.34433\include\type_traits (1705)
mangosd.exe!std::thread::_Invoke<std::tuple<void (__cdecl*)(void *),void *>,0,1>(void * _RawVals) Zeile 61
	unter C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.42.34433\include\thread (61)
ucrtbase.dll!00007ff9a5511bb2()
kernel32.dll!00007ff9a64a7374()
ntdll.dll!00007ff9a779cc91()
```

More info about the related creature from the debugger (if helpful):
```
dbGuid 3001785
guidLow 3001785
id 11840
mapid 30
posX -1568.06006
posY -446.270996
posZ 67.8460007
orientation 3.46805000
```