### PR TITLE
Playerbots: Add methods to retrieve battleground event objects

### DIFF
--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -1486,6 +1486,53 @@ void BattleGround::OnObjectDBLoad(Creature* creature)
         ChangeBgCreatureSpawnState(creature->GetDbGuid(), RESPAWN_ONE_DAY);
 }
 
+#ifdef ENABLE_PLAYERBOTS
+/**
+  Retrieves a creature from the event map based on the specified event pair and creature entry.
+
+  @param    event1
+  @param    event2
+  @param    entry    The creature entry ID to search for.
+  @return            A pointer to the Creature object if found, otherwise nullptr.
+*/
+Creature* BattleGround::GetCreature(uint8 event1, uint8 event2, uint32 entry)
+{
+    auto itr = m_eventObjects[MAKE_PAIR32(event1, event2)].creatures.begin();
+    auto end = m_eventObjects[MAKE_PAIR32(event1, event2)].creatures.end();
+    for (; itr != end; ++itr)
+    {
+        Creature* obj = GetBgMap()->GetCreature(*itr);
+        if (obj && obj->GetEntry() == entry)
+        {
+            return obj;
+        }
+    }
+    return nullptr;
+}
+
+/**
+  Retrieves a game object from the event map based on the specified event pair and game object entry.
+
+  @param    event1
+  @param    event2
+  @param    entry    The game object entry ID to search for.
+  @return            A pointer to the GameObject object if found, otherwise nullptr.
+*/
+GameObject* BattleGround::GetGameObject(uint8 event1, uint8 event2, uint32 entry)
+{
+    auto itr = m_eventObjects[MAKE_PAIR32(event1, event2)].gameobjects.begin();
+    auto end = m_eventObjects[MAKE_PAIR32(event1, event2)].gameobjects.end();
+    for (; itr != end; ++itr)
+    {
+        GameObject* obj = GetBgMap()->GetGameObject(*itr);
+        if (obj && obj->GetEntry() == entry)
+        {
+            return obj;
+        }
+    }
+    return nullptr;
+}
+
 /**
   Function returns a creature guid from event map
 
@@ -1517,6 +1564,7 @@ uint32 BattleGround::GetSingleGameObjectGuid(uint8 event1, uint8 event2)
 
     return ObjectGuid();
 }
+#endif
 
 /**
   Method that handles gameobject load from DB event map

--- a/src/game/BattleGround/BattleGround.h
+++ b/src/game/BattleGround/BattleGround.h
@@ -505,11 +505,19 @@ class BattleGround
             return m_activeEvents[event1] == event2;
         }
 
+#ifdef ENABLE_PLAYERBOTS
+        // Get a creature from the event map based on the specified event pair and creature entry
+        Creature* GetCreature(uint8 /*event1*/, uint8 /*event2*/, uint32 /*entry*/);
+
+        // Get a game object from the event map based on the specified event pair and game object entry
+        GameObject* GetGameObject(uint8 /*event1*/, uint8 /*event2*/, uint32 /*entry*/);
+
         // Get creature guid from event
         uint32 GetSingleCreatureGuid(uint8 /*event1*/, uint8 /*event2*/);
 
         // Get gameobject guid from event
         uint32 GetSingleGameObjectGuid(uint8 /*event1*/, uint8 /*event2*/);
+#endif
 
         // Handle door events
         void OpenDoorEvent(uint8 /*event1*/, uint8 event2 = 0);


### PR DESCRIPTION
## 🍰 Pullrequest
Added methods to `BattleGround` to retrieve event objects by entry ID, essential for [cmangos-playerbots#134](https://github.com/cmangos/playerbots/pull/134). Also encapsulated related playerbot methods with `#ifdef ENABLE_PLAYERBOTS`, which was previously missing.

### Issues
- https://github.com/cmangos/playerbots/pull/134
