### PR TITLE
Upgrade soon to be deprecated runners to newer versions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,15 +7,13 @@ env:
   BUILD_TYPE: Release
   REPO_DIR : ${{github.workspace}}
   BUILD_DIR: ${{github.workspace}}/bin/builddir
-  BOOST_VERSION: "1.83.0"
-  BOOST_PLATFORM_VERSION: "13"
 
 permissions:
   contents: read
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-14
     permissions:
       contents: read
 
@@ -27,29 +25,15 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          brew install mysql-client
+          brew install mysql-client@8.4
           brew install openssl
+          brew install boost
           echo "OPENSSL_ROOT_DIR=$(brew --prefix --installed openssl)" >> $GITHUB_ENV
-
-      - name: Install Boost
-        uses: MarkusJx/install-boost@v2.5.0
-        id: install-boost
-        with:
-          # REQUIRED: Specify the required boost version
-          # A list of supported versions can be found here:
-          # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
-          boost_version: ${{env.BOOST_VERSION}}
-          # OPTIONAL: Specify a platform version
-          platform_version: ${{env.BOOST_PLATFORM_VERSION}}
-          # OPTIONAL: Specify a toolset
-          toolset: clang
-          # NOTE: If a boost version matching all requirements cannot be found,
-          # this build step will fail
 
       - name: Configure
         env:
-          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
-        run: cmake -B ${{env.BUILD_DIR}} -S ${{env.REPO_DIR}} -DBoost_ARCHITECTURE=-x64
+          BOOST_ROOT: /opt/homebrew/opt/boost
+        run: cmake -B ${{env.BUILD_DIR}} -S ${{env.REPO_DIR}} -DBoost_ARCHITECTURE=-arm64
 
       - name: Build
         env:
@@ -60,7 +44,7 @@ jobs:
     permissions:
       contents: none
     name: Send Notification to Discord on Failure
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: # make sure the notification is sent AFTER the jobs you want included have completed
       - build
     if: failure()

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -85,7 +85,7 @@ jobs:
 
   notify:
     name: Send Notification to Discord on Failure
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: none
     needs: # make sure the notification is sent AFTER the jobs you want included have completed

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -1,6 +1,5 @@
 name: Windows Release Build
 
-#
 on:
   schedule:
     # every day at 6am
@@ -11,9 +10,6 @@ env:
   BUILD_TYPE: RelWithDebInfo
   REPO_DIR : ${{github.workspace}}
   BUILD_DIR: ${{github.workspace}}/bin/builddir
-  BOOST_TOOLSET: "msvc"
-  BOOST_VERSION: "1.83.0"
-  BOOST_PLATFORM_VERSION: "2022"
 
 jobs:
   build:
@@ -50,26 +46,9 @@ jobs:
         run: |
           echo "ARCHIVE_FILENAME=$env:CI_REPOSITORY_NAME-${{matrix.TYPE}}-$env:CI_SHA_SHORT.zip" >> $env:GITHUB_ENV
           cmake -E make_directory ${{ env.BUILD_DIR }}
-
-      # install dependencies
-      - name: Install Boost
-        uses: MarkusJx/install-boost@v2.5.0
-        id: install-boost
-        with:
-          # REQUIRED: Specify the required boost version
-          # A list of supported versions can be found here:
-          # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
-          boost_version: ${{env.BOOST_VERSION}}
-          # OPTIONAL: Specify a platform version
-          platform_version: ${{env.BOOST_PLATFORM_VERSION}}
-          # OPTIONAL: Specify a toolset
-          toolset: ${{env.BOOST_TOOLSET}}
-          # NOTE: If a boost version matching all requirements cannot be found,
-          # this build step will fail
+          choco install boost-msvc-14.3
 
       - name: Configure
-        env:
-          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
         run: cmake ${{matrix.OPTIONAL_DEFINES}} -B ${{env.BUILD_DIR}} -S ${{env.REPO_DIR}}
 
       - name: Build
@@ -136,7 +115,7 @@ jobs:
 
   notify-success:
     name: Send Notification to Discord on Success
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: none
     needs:
@@ -179,7 +158,7 @@ jobs:
 
   notify:
     name: Send Notification to Discord on Failure
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: none
     needs: # make sure the notification is sent AFTER the jobs you want included have completed

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,3 @@
-
 name: Windows Build
 
 on: [push]
@@ -8,9 +7,6 @@ env:
   BUILD_TYPE: Release
   REPO_DIR : ${{github.workspace}}
   BUILD_DIR: ${{github.workspace}}/bin/builddir
-  BOOST_TOOLSET: "msvc"
-  BOOST_VERSION: "1.83.0"
-  BOOST_PLATFORM_VERSION: "2022"
 
 jobs:
   build:
@@ -29,26 +25,9 @@ jobs:
           echo "GITHUB_SHORT_REV=$(git rev-parse --short HEAD)" >> $env:GITHUB_ENV
           echo "ARCHIVE_FILENAME=${{ github.event.repository.name }}-$(git rev-parse --short HEAD).zip" >> $env:GITHUB_ENV
           cmake -E make_directory ${{ env.BUILD_DIR }}
+          choco install boost-msvc-14.3
 
-      # install dependencies
-      - name: Install Boost
-        uses: MarkusJx/install-boost@v2.5.0
-        id: install-boost
-        with:
-          # REQUIRED: Specify the required boost version
-          # A list of supported versions can be found here:
-          # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
-          boost_version: ${{env.BOOST_VERSION}}
-          # OPTIONAL: Specify a platform version
-          platform_version: ${{env.BOOST_PLATFORM_VERSION}}
-          # OPTIONAL: Specify a toolset
-          toolset: ${{env.BOOST_TOOLSET}}
-          # NOTE: If a boost version matching all requirements cannot be found,
-          # this build step will fail
-          
       - name: Configure
-        env:
-          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
         run: cmake -B ${{env.BUILD_DIR}} -S ${{env.REPO_DIR}}
 
       - name: Build
@@ -69,7 +48,7 @@ jobs:
 
   notify:
     name: Send Notification to Discord on Failure
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: none
     needs: # make sure the notification is sent AFTER the jobs you want included have completed

--- a/cmake/macros/FindMySQL.cmake
+++ b/cmake/macros/FindMySQL.cmake
@@ -23,6 +23,8 @@ if( UNIX )
     /usr/local/bin/
     /usr/bin/
     /usr/local/opt/mysql/bin/
+    /opt/homebrew/opt/mysql-client/bin
+    /opt/homebrew/opt/mysql-client@8.4/bin
     /opt/mysql/mysql/bin/
   )
 
@@ -77,6 +79,10 @@ find_path(MYSQL_INCLUDE_DIR
     /usr/local/opt/mysql/include
     /usr/local/opt/mysql-client/include
     /usr/local/opt/mysql-client/include/mysql
+    /opt/homebrew/opt/mysql-client
+    /opt/homebrew/opt/mysql-client/include
+    /opt/homebrew/opt/mysql-client@8.4
+    /opt/homebrew/opt/mysql-client@8.4/include
     /opt/mysql/mysql/include
     /opt/mysql/mysql/include/mysql
     "C:/Program Files/MySQL/include"
@@ -107,6 +113,10 @@ foreach(LIB ${MYSQL_ADD_LIBRARIES})
       /usr/local/mysql/lib/mysql
       /usr/local/opt/mysql/lib
       /usr/local/opt/mysql-client/lib
+      /opt/homebrew/opt/mysql-client
+      /opt/homebrew/opt/mysql-client/lib
+      /opt/homebrew/opt/mysql-client@8.4
+      /opt/homebrew/opt/mysql-client@8.4/lib
       /opt/mysql/mysql/lib
       /opt/mysql/mysql/lib/mysql
     DOC "Specify the location of the mysql library here."


### PR DESCRIPTION
## 🍰 Pullrequest
Ubuntu 20.04 runners will soon be shut down by GH. Some of the Discord notifiers were still using this version. Also since there is only 1 remaining x64 Apple runner, upgraded the Apple CI test to be compatible with Apple Silicon.

### Proof
(https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/)

### Issues
- None

### How2Test
- None

### Todo / Checklist
- [X] None
