### PR TITLE
Pet: Fix pet not losing happiness when dismissed

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -1871,7 +1871,7 @@ void Spell::EffectPowerDrain(SpellEffectIndex eff_idx)
         return;
     if (!unitTarget->IsAlive())
         return;
-    if (unitTarget->GetPowerType() != powerType)
+    if (unitTarget->GetPowerType() != powerType && powerType != POWER_HAPPINESS)
         return;
     if (damage < 0)
         return;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR fixes the pet not losing happiness when it's being dismissed

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Tame pet
- Feed pet to 100k Happiness points (check with `.debug listupdatefields` )
- Keep dismissing and calling the pet on repeat
- With fix pet will become unhappy after ~40 seconds
- without fix pet will become unhappy after 5 minutes (normal happiness countdown)
