### PR TITLE
G3D: Add support for RISC-V CPU's

### DIFF
--- a/dep/g3dlite/System.cpp
+++ b/dep/g3dlite/System.cpp
@@ -1710,6 +1710,15 @@ void System::cpuid(CPUIDFunction func, uint32& eax, uint32& ebx, uint32& ecx, ui
     edx = 0;
 }
 
+#elif defined(G3D_LINUX) && ( defined(__riscv) || defined(__riscv32) || defined(__riscv__) || defined(_riscv))
+// non-x86 CPU; no CPUID, at least in userspace
+void System::cpuid(CPUIDFunction func, uint32& eax, uint32& ebx, uint32& ecx, uint32& edx) {
+    eax = 0;
+    ebx = 0;
+    ecx = 0;
+    edx = 0;
+}
+
 #else
 
 // See http://sam.zoy.org/blog/2007-04-13-shlib-with-non-pic-code-have-inline-assembly-and-pic-mix-well


### PR DESCRIPTION
## 🍰 Pullrequest
This change allows for compilation under RISC-V instruction set CPU's. Tested functionality of server, could enter game, playerbots compiles, all extractors work.

### Proof
- None

### Issues
- When compiling on a RISC-V CPU would error out in build due to undefined processor definition causing to to fall back to x86 code.

### How2Test
- Attempt to build on RISC-V
- Error
- Apply change, error gone and compile successful

### Todo / Checklist
- [X] None
