### PR TITLE
AHBot: Add support for dynamic or static filtering by RequiredLevel and ItemLevel

### DIFF
--- a/src/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -563,7 +563,7 @@ void AuctionHouseBot::CalculateItemLevelCap()
     }
     else
     {
-        m_maxItemLevel = m_maxRequiredLevel;
+        m_maxItemLevel = m_maxRequiredLevel + 5; // Typical item level is required level + 5
     }
 }
 

--- a/src/game/AuctionHouseBot/AuctionHouseBot.h
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.h
@@ -64,6 +64,8 @@ class AuctionHouseBot
         void ParseLootConfig(char const* fieldname, std::vector<int32>& lootConfig);
         void FillUintVectorFromQuery(char const* query, std::vector<uint32>& lootTemplates);
 	void ParseLevelConstraints();
+	void UpdateDynamicMaxLevel();
+        void CalculateItemLevelCap();
         void ParseItemValueConfig(char const* fieldname, std::vector<uint32>& itemValues);
         void AddLootToItemMap(LootStore* store, std::vector<int32>& lootConfig, std::vector<uint32>& lootTemplates, std::unordered_map<uint32, uint32>& itemMap);
         uint32 CalculateBuyoutPrice(ItemPrototype const* prototype);
@@ -88,9 +90,12 @@ class AuctionHouseBot
         std::vector<int32> m_skinningLootConfig;
         std::vector<int32> m_professionItemsConfig;
 
+	bool m_useDynamicMaxLevel;
+	bool m_ignoreGm;
+	uint32 m_lastLevelUpdateTime = 0;
+	uint32 m_levelRefreshInterval = 0;
 	uint32 m_maxRequiredLevel;
 	uint32 m_maxItemLevel;
-	bool m_useDynamicMaxLevel;
 
         std::vector<std::vector<uint32>> m_itemValue = std::vector<std::vector<uint32>>(MAX_ITEM_QUALITY, std::vector<uint32>(MAX_ITEM_CLASS));
         bool m_vendorValue;

--- a/src/game/AuctionHouseBot/AuctionHouseBot.h
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.h
@@ -63,6 +63,7 @@ class AuctionHouseBot
         uint32 GetMinMaxConfig(const char* config, uint32 minValue, uint32 maxValue, uint32 defaultValue);
         void ParseLootConfig(char const* fieldname, std::vector<int32>& lootConfig);
         void FillUintVectorFromQuery(char const* query, std::vector<uint32>& lootTemplates);
+	void ParseLevelConstraints();
         void ParseItemValueConfig(char const* fieldname, std::vector<uint32>& itemValues);
         void AddLootToItemMap(LootStore* store, std::vector<int32>& lootConfig, std::vector<uint32>& lootTemplates, std::unordered_map<uint32, uint32>& itemMap);
         uint32 CalculateBuyoutPrice(ItemPrototype const* prototype);
@@ -86,6 +87,10 @@ class AuctionHouseBot
         std::vector<int32> m_gameobjectLootConfig;
         std::vector<int32> m_skinningLootConfig;
         std::vector<int32> m_professionItemsConfig;
+
+	uint32 m_maxRequiredLevel;
+	uint32 m_maxItemLevel;
+	bool m_useDynamicMaxLevel;
 
         std::vector<std::vector<uint32>> m_itemValue = std::vector<std::vector<uint32>>(MAX_ITEM_QUALITY, std::vector<uint32>(MAX_ITEM_CLASS));
         bool m_vendorValue;

--- a/src/game/AuctionHouseBot/ahbot.conf.dist.in
+++ b/src/game/AuctionHouseBot/ahbot.conf.dist.in
@@ -70,23 +70,44 @@ AuctionHouseBot.Loot.Skinning   =    3,  5, 50, 50
 AuctionHouseBot.Items.Profession = 80, 90, 0, 50
 
 ###################################################################################################################
-# Max required level for items listed by AHBot
+# Enable dynamic max required level filtering
 #
-# Items that require a level higher than this value will not be listed at the AH
-# This setting is only used if Level.DynamicMaxRequired is disabled.
-# Value must be between 1 and 255. Default: 60
-###################################################################################################################
-AuctionHouseBot.Level.MaxRequired = 60
-
-###################################################################################################################
-# Enable dynamic max item level filtering
-#
-# If enabled, the AHBot will check the database for the highest-level character on the server
-# and use that value to restrict the required level of items it lists.
-# If disabled, it will use the static value in AuctionHouseBot.Level.MaxRequired.
+# If enabled, AHBot checks the database for the highest-level character currently online
+# and uses that level to restrict the required level of items it lists.
+# If disabled, the bot will use the static value below (AuctionHouseBot.Level.MaxRequired).
 # Value must be 0 (disabled) or 1 (enabled). Default: 0
 ###################################################################################################################
 AuctionHouseBot.Level.DynamicMaxRequired = 0
+
+###################################################################################################################
+# Ignore GM accounts when determining dynamic max required level
+#
+# Only applies if AuctionHouseBot.Level.DynamicMaxRequired is enabled.
+# If enabled, characters belonging to GM accounts (gmlevel > 0) will be excluded from the level check.
+# If no valid non-GM characters are online, the bot will fallback to the highest-level online GM character.
+# If no characters are online at all, the static value below will be used.
+# Value must be 0 (disabled) or 1 (enabled). Default: 0
+###################################################################################################################
+AuctionHouseBot.Level.IgnoreGmAccounts = 0
+
+###################################################################################################################
+# Interval in minutes to refresh the dynamic max required level
+#
+# Only applies if AuctionHouseBot.Level.DynamicMaxRequired is enabled.
+# AHBot will refresh the required level only after this amount of time has passed.
+# Value must be 1 or higher. Default: 10
+###################################################################################################################
+AuctionHouseBot.Level.DynamicRefreshInterval = 10
+
+###################################################################################################################
+# Max required level for items listed by AHBot
+#
+# This static value is used when:
+# - AuctionHouseBot.Level.DynamicMaxRequired is disabled, OR
+# - No characters are online to determine a dynamic value
+# Value must be between 1 and 255. Default: 60
+###################################################################################################################
+AuctionHouseBot.Level.MaxRequired = 60
 
 ###################################################################################################################
 # Item value

--- a/src/game/AuctionHouseBot/ahbot.conf.dist.in
+++ b/src/game/AuctionHouseBot/ahbot.conf.dist.in
@@ -70,6 +70,25 @@ AuctionHouseBot.Loot.Skinning   =    3,  5, 50, 50
 AuctionHouseBot.Items.Profession = 80, 90, 0, 50
 
 ###################################################################################################################
+# Max required level for items listed by AHBot
+#
+# Items that require a level higher than this value will not be listed at the AH
+# This setting is only used if Level.DynamicMaxRequired is disabled.
+# Value must be between 1 and 255. Default: 60
+###################################################################################################################
+AuctionHouseBot.Level.MaxRequired = 60
+
+###################################################################################################################
+# Enable dynamic max item level filtering
+#
+# If enabled, the AHBot will check the database for the highest-level character on the server
+# and use that value to restrict the required level of items it lists.
+# If disabled, it will use the static value in AuctionHouseBot.Level.MaxRequired.
+# Value must be 0 (disabled) or 1 (enabled). Default: 0
+###################################################################################################################
+AuctionHouseBot.Level.DynamicMaxRequired = 0
+
+###################################################################################################################
 # Item value
 #
 # This determines the item value, as a percentage of item sell value (what a vendor would charge for the item).


### PR DESCRIPTION
### Summary

This feature adds support for filtering items listed by AuctionHouseBot using either a **static** or **dynamic** RequiredLevel cap.

- **Static filtering** uses a fixed value from the config
- **Dynamic filtering** adjusts based on the highest-level online character(s), with optional exclusion of GM accounts

This controls both the maximum RequiredLevel and ItemLevel allowed in auction listings, helping tailor AHBot behavior to the server’s progression.

---

### Behavior

- If `AuctionHouseBot.Level.DynamicMaxRequired = 1`, RequiredLevel is capped using the result of:
  `SELECT MAX(level) FROM characters WHERE online = 1`
- If disabled (`= 0`), the static config value `AuctionHouseBot.Level.MaxRequired` is used instead
- If `AuctionHouseBot.Level.IgnoreGmAccounts = 1`, GM accounts are excluded from dynamic level calculation
- `AuctionHouseBot.Level.DynamicRefreshInterval` sets how often AHBot re-evaluates online character levels (in minutes)

ItemLevel is capped to match RequiredLevel in either case, **except** when RequiredLevel reaches **60 or higher** — at which point the ItemLevel cap is lifted entirely (`255`), allowing full item availability.

---

### Edge Case

Note: The presence of a level 60 character (e.g., an admin or test account) will lift the ItemLevel cap in dynamic mode, potentially exposing high-end gear earlier than intended on fresh realms.

---

### Configuration

**New/Updated Keys in `ahbot.conf`:**
```
AuctionHouseBot.Level.DynamicMaxRequired = 1       ; Enable dynamic level filtering
AuctionHouseBot.Level.MaxRequired = 10             ; Fallback static RequiredLevel cap
AuctionHouseBot.Level.IgnoreGmAccounts = 1         ; Exclude GM accounts from level check
AuctionHouseBot.Level.DynamicRefreshInterval = 20  ; Time (in minutes) between level recalculations
```
