### PR TITLE
Topic/update skill remove second roll

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -4797,23 +4797,16 @@ void Player::LeaveLFGChannel()
     }
 }
 
-void Player::UpdateDefense(Unit* attacker, uint32 procEx)
+void Player::UpdateDefense(uint32 procEx)
 {
-    sLog.outString("UpdateDefense called. Running the checks.");
     uint32 defense_skill_gain = sWorld.getConfig(CONFIG_UINT32_SKILL_GAIN_DEFENSE);
 
     if (defense_skill_gain == 0)
         return;
 
-    if (!attacker)
-    {
-        sLog.outString("if (!attacker) -> true. Exiting before checking for avoidance or updating skill.");
-        return; // I fear this may be the opposite of intent, testing will reveal
-    }
-
+    // Filter out dodge/parry/block/miss so defense can only advance on actual hits.
     if (procEx & (PROC_EX_DODGE | PROC_EX_PARRY | PROC_EX_BLOCK | PROC_EX_MISS))
     {
-        sLog.outString("Avoided attack with dodge/parry/block/miss. Exiting before updating skill.");
         return;
     }
 
@@ -5250,7 +5243,7 @@ void Player::UpdateWeaponSkill(WeaponAttackType attType)
     UpdateAllCritPercentages();
 }
 
-void Player::UpdateCombatSkills(Unit* target, uint32 procEx, WeaponAttackType attType, bool defence)
+void Player::UpdateCombatSkills(uint32 procEx, WeaponAttackType attType, bool defence)
 {
     const uint16 skillId = (defence ? SKILL_DEFENSE : GetWeaponSkillIdForAttack(attType));
     const uint16 skill = GetSkillValuePure(skillId);
@@ -5271,7 +5264,7 @@ void Player::UpdateCombatSkills(Unit* target, uint32 procEx, WeaponAttackType at
     if (roll_chance_f(chance))
     {
         if (defence)
-            UpdateDefense(target, procEx);
+            UpdateDefense(procEx);
         else
             UpdateWeaponSkill(attType);
     }

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -73,6 +73,7 @@
 #include "playerbot/PlayerbotAIConfig.h"
 #endif
 
+#include <algorithm>
 #include <cmath>
 
 #define ZONE_UPDATE_INTERVAL (1*IN_MILLISECONDS)
@@ -4804,12 +4805,6 @@ void Player::UpdateDefense(uint32 procEx)
     if (defense_skill_gain == 0)
         return;
 
-    // Filter out dodge/parry/block/miss so defense can only advance on actual hits.
-    if (procEx & (PROC_EX_DODGE | PROC_EX_PARRY | PROC_EX_BLOCK | PROC_EX_MISS))
-    {
-        return;
-    }
-
     UpdateSkill(SKILL_DEFENSE, defense_skill_gain);
     UpdateDefenseBonusesMod();
 }
@@ -5247,21 +5242,52 @@ void Player::UpdateCombatSkills(uint32 procEx, WeaponAttackType attType, bool de
 {
     const uint16 skillId = (defence ? SKILL_DEFENSE : GetWeaponSkillIdForAttack(attType));
     const uint16 skill = GetSkillValuePure(skillId);
-    const uint16 cap = GetSkillMaxPure(skillId);
-    const int32 room = int32(cap - skill);
+    const uint16 skillMax = GetSkillMaxPure(skillId);
+    const int32 room = int32(skillMax - skill);
+    const int32 level = GetLevel();
+    const uint32 levelMax = sWorld.getConfig(CONFIG_UINT32_MAX_PLAYER_LEVEL);
 
-    // Max skill reached: nothing to gain
-    if (room <= 0)
+    // Skill already capped or invalid state: nothing to gain
+    if (skillMax == 0 || level == 0 || skill >= skillMax)
         return;
 
-    // The farther player is from the cap, the easier it gets to level up the skill
-    float chance = ((float(std::max(1, (room / 5))) / (cap / 5.f)) * 100);
+    // skillGapLogGrowth controls the slope of the logarithmic catch-up portion
+    const double skillGapLogGrowth = 0.22 * (1.0 + (12.0 / level));
+    // levelCapScale normalizes the curve across realm caps and anchors the seam at room = 7
+    const double levelCapScale = levelMax / 60.0;
 
-    // Weapon skills: increase chance by intellect
+    double baseChance = 0.0;
+
+    // Piecewise curve: logarithmic growth for catch-up, quadratic decay near the cap
+    if (room >= 7)
+        baseChance = (7.0 / skillMax) * levelCapScale
+                   + skillGapLogGrowth * std::log((room + 5.0) / 12.0);
+    else
+        baseChance = (room * room) / (7.0 * skillMax) * levelCapScale;
+
+    baseChance = std::clamp(baseChance, 0.0, 1.0);
+
+    // Weapon skills gain a small bonus from intellect
+    double intellectBonus = 0.0;
     if (!defence)
-        chance += ((chance * 0.02f) * GetStat(STAT_INTELLECT));
+    {
+        const double maxIntellectBonus = 0.10;
+        const double intellect = GetStat(STAT_INTELLECT);
+        const double intellectMax = (levelMax == 60) ? 750 :
+                                    (levelMax == 70) ? 1500 :
+                                    (levelMax == 80) ? 3000 : 750; // default fallback
 
-    if (roll_chance_f(chance))
+        intellectBonus = maxIntellectBonus *
+                         (intellect / intellectMax) *
+                         (static_cast<double>(levelMax) / static_cast<double>(level));
+
+        intellectBonus = std::clamp(intellectBonus, 0.0, maxIntellectBonus);
+    }
+
+    // Final skill-up probability
+    const float finalChance = std::clamp(baseChance + intellectBonus, 0.0, 1.0) * 100.0f;
+
+    if (roll_chance_f(finalChance))
     {
         if (defence)
             UpdateDefense(procEx);

--- a/src/game/Entities/Player.h
+++ b/src/game/Entities/Player.h
@@ -1576,7 +1576,7 @@ class Player : public Unit
         void SendPetBar();
         void StartCinematic();
         void StopCinematic();
-        bool UpdateSkill(uint16 id, uint16 diff);
+        void UpdateSkill(uint16 id, uint16 diff);
         bool UpdateSkillPro(uint16 id, int32 Chance, uint16 diff);
 
         bool UpdateCraftSkill(uint32 spellid);
@@ -1680,9 +1680,9 @@ class Player : public Unit
         uint32 GetLFGAreaId() const { return m_LFGAreaId; }
         bool IsInLFG() const { return m_LFGAreaId > 0; }
 
-        void UpdateDefense();
+        void UpdateDefense(Unit* attacker, uint32 procEx);
         void UpdateWeaponSkill(WeaponAttackType attType);
-        void UpdateCombatSkills(Unit* pVictim, WeaponAttackType attType, bool defence);
+        void UpdateCombatSkills(Unit* target, uint32 procEx, WeaponAttackType attType, bool defence);
         uint16 GetWeaponSkillIdForAttack(WeaponAttackType attType) const;
 
         SkillRaceClassInfoEntry const* GetSkillInfo(uint16 id, std::function<bool (SkillRaceClassInfoEntry const&)> filterfunc = nullptr) const;

--- a/src/game/Entities/Player.h
+++ b/src/game/Entities/Player.h
@@ -1680,9 +1680,9 @@ class Player : public Unit
         uint32 GetLFGAreaId() const { return m_LFGAreaId; }
         bool IsInLFG() const { return m_LFGAreaId > 0; }
 
-        void UpdateDefense(Unit* attacker, uint32 procEx);
+        void UpdateDefense(uint32 procEx);
         void UpdateWeaponSkill(WeaponAttackType attType);
-        void UpdateCombatSkills(Unit* target, uint32 procEx, WeaponAttackType attType, bool defence);
+        void UpdateCombatSkills(uint32 procEx, WeaponAttackType attType, bool defence);
         uint16 GetWeaponSkillIdForAttack(WeaponAttackType attType) const;
 
         SkillRaceClassInfoEntry const* GetSkillInfo(uint16 id, std::function<bool (SkillRaceClassInfoEntry const&)> filterfunc = nullptr) const;

--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -286,7 +286,7 @@ void Unit::ProcSkillsAndReactives(bool isVictim, Unit* target, uint32 procFlags,
             if (procEx & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT | PROC_EX_MISS | PROC_EX_DODGE | PROC_EX_PARRY | PROC_EX_BLOCK))
             {
                 if (target->GetTypeId() != TYPEID_PLAYER && target->GetCreatureType() != CREATURE_TYPE_CRITTER)
-                    ((Player*)this)->UpdateCombatSkills(target, procEx, attType, isVictim);
+                    ((Player*)this)->UpdateCombatSkills(procEx, attType, isVictim);
             }
         }
         // If exist crit/parry/dodge/block need update aura state (for victim and attacker)

--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -286,11 +286,8 @@ void Unit::ProcSkillsAndReactives(bool isVictim, Unit* target, uint32 procFlags,
             if (procEx & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT | PROC_EX_MISS | PROC_EX_DODGE | PROC_EX_PARRY | PROC_EX_BLOCK))
             {
                 if (target->GetTypeId() != TYPEID_PLAYER && target->GetCreatureType() != CREATURE_TYPE_CRITTER)
-                    ((Player*)this)->UpdateCombatSkills(target, attType, isVictim);
+                    ((Player*)this)->UpdateCombatSkills(target, procEx, attType, isVictim);
             }
-            // Update defence if player is victim and parry/dodge/block
-            if (isVictim && procEx & (PROC_EX_DODGE | PROC_EX_PARRY | PROC_EX_BLOCK))
-                ((Player*)this)->UpdateDefense();
         }
         // If exist crit/parry/dodge/block need update aura state (for victim and attacker)
         if (procEx & (PROC_EX_CRITICAL_HIT | PROC_EX_PARRY | PROC_EX_DODGE | PROC_EX_BLOCK))


### PR DESCRIPTION
## Summary

This PR refactors combat skill progression so that weapon and defense skills are governed by a single roll path, and retunes the skill-up formula so progression behaves more consistently during normal play across level 60, 70, and 80 environments.

Skill state mutation is now deterministic, with probability handled in one place.

## Problem statement
While leveling multiple characters, weapon skill progression consistently lagged behind the expected cap by several levels and often felt “stuck” unless the character leveled again.

Investigation identified two issues in the existing core logic:

1. **Double RNG gating for skill-ups**  
   `Player::UpdateCombatSkills()` performs a roll, and on success calls `UpdateWeaponSkill()` or `UpdateDefense()`. Both paths ultimately call `Player::UpdateSkill()`, which also performed its own roll, resulting in an unintended second RNG gate.

2. **Extra defense bypass call path**  
   Defense skill could also be advanced via a separate call in `Unit::ProcSkillsAndReactives()` on dodge/parry/block outcomes, effectively giving an additional roll after `UpdateCombatSkills()` is called.

## Expected behavior
- Skill-up probability should be evaluated once per eligible combat event.
- `UpdateSkill()` should only apply state changes (clamp and write the new value), not decide probabilistically whether an update occurs.
- Skills that fall behind should catch up during ordinary play without trivializing the final few points near cap.
- Behavior should remain consistent across Vanilla, TBC, and WotLK max-level environments.

## What this PR changes
- Removes the RNG check from `Player::UpdateSkill()` and makes it a deterministic state update.
- Removes the defense skill-up bypass path from `Unit::ProcSkillsAndReactives()`.
- Passes `procEx` through the defense skill path so combat outcomes can be evaluated explicitly.
- Reworks the skill-up chance calculation in `Player::UpdateCombatSkills()` using a piecewise curve:
  - **logarithmic growth** when the skill is meaningfully behind cap
  - **quadratic decay** near the cap to preserve the grind of the final few points
- Keeps the final chance clamped and applies a bounded intellect bonus for weapon skills using representative maximum stat values for Vanilla, TBC, and WotLK environments.

### Rationale
- **Separation of concerns:** `UpdateCombatSkills()` owns probability and eligibility; `UpdateSkill()` owns state mutation.
- **Single responsibility:** Removing RNG from `UpdateSkill()` prevents hidden double-gating and ensures probability is evaluated exactly once per eligible combat event.
- **Improved curve shape:** The previous linear formula provided a workable baseline but was not flexible enough to model both catch-up behavior and the expected slowdown near the cap. The logarithmic section improves catch-up without dragging out the approach to cap, while the quadratic tail preserves the slower progression expected for the final few skill points.
- **Cross-expansion scaling:** Additional level-based scaling terms ensure the curve behaves consistently at level 60, 70, and 80 caps. Without this normalization, later expansions naturally become harsher near cap simply because `skillMax` is larger.

## How to reproduce on upstream (before this PR)
- Use any character and fight normal PvE mobs.
- Observe weapon skill progression during normal leveling.
- Skills frequently lag the cap by several levels and often remain behind it until the character levels again.

## Testing performed
- Added temporary logging to validate call paths and confirm removal of the second RNG gate.
- Leveled multiple weapon skills to cap in-game.
- Tested multiple low-level characters during early progression.
- Built a Monte Carlo simulator to validate the revised formula across several scenarios.

### Simulator scenarios

| Category | Scenario | Level Cap | Intellect Model | Purpose |
|----------|----------|-----------|-----------------|---------|
| Defense | Defense skill progression | 60 | N/A | Validate defense curve across full Vanilla skill range |
| Defense | Defense skill progression | 70 | N/A | Validate scaling in TBC environment |
| Defense | Defense skill progression | 80 | N/A | Validate scaling in WotLK environment |
| Weapon | Warrior weapon skill | 60 | Low intellect (~25) | Baseline melee weapon progression |
| Weapon | Warrior weapon skill | 70 | Low intellect (~28) | Cross-expansion melee scaling |
| Weapon | Warrior weapon skill | 80 | Low intellect (~32) | WotLK scaling validation |
| Weapon | Mage weapon skill | 60 | High intellect (~400) | High-intellect weapon progression |
| Weapon | Mage weapon skill | 70 | High intellect (~800) | High-intellect scaling validation |
| Weapon | Mage weapon skill | 80 | High intellect (~1600) | WotLK high-intellect scaling |
| Level Path | Mage wand leveling path | 1 → 60 | Progressive intellect growth with gear | Simulates real leveling progression |
| Level Path | Warrior weapon leveling path | 1 → 60 | Stepped intellect growth | Baseline melee leveling progression |

### Result
- Modeled probabilities and empirical simulation results track closely.
- The logarithmic and quadratic regions join smoothly at the seam.
- Skill progression remains consistent across expansion-level caps.
- CSV results of Monte Carlo simulations: [monte_carlo_tests_csv.zip](https://github.com/user-attachments/files/26013577/monte_carlo_tests_csv.zip)
- Text summary of CSV files: [monte_carlo_tests_summary.zip](https://github.com/user-attachments/files/26013581/monte_carlo_tests_summary.zip)
- Plotted graphs of CSV files: [monte_carlo_tests_plots.zip](https://github.com/user-attachments/files/26013592/monte_carlo_tests_plots.zip)

## Notes
- Earlier revisions of this PR attempted to restrict defense skill gains to hit outcomes only. Further testing showed skill-ups occurring on dodge events in Vanilla clients and on parry/block events in TBC clients. Since the original codebase allows defense gains on dodge/parry/block/miss, and evidence exists for several avoidance outcomes, the restriction was removed and the original qualification behavior was preserved.
- The formula work included here is intended to address the tuning concern directly rather than leaving it for a follow-up.
- Formula reference: [Wow Classic: Defense and Weapon Calculator](https://www.desmos.com/calculator/wdxnypubju)

## Commits
- `a01ce8909` Refactor combat skill progression to single roll path  
- `fda48b1a3` Remove unused parameters and temporary debug code
- `1937676` Retune combat skill progression curve (logarithmic catch-up + quadratic tail)

## DB impact
Core-only change. No database changes.
