### PR TITLE
Add clarifying comment on WoW Classic Era deviation of sending SMSG_LOOT_MONEY_NOTIFY

### DIFF
--- a/src/game/Loot/LootMgr.cpp
+++ b/src/game/Loot/LootMgr.cpp
@@ -2272,6 +2272,10 @@ void Loot::SendGold(Player* player)
     {
         player->ModifyMoney(m_gold);
 
+        WorldPacket data(SMSG_LOOT_MONEY_NOTIFY, 4);
+        data << uint32(m_gold);
+        player->GetSession()->SendPacket(data);
+
         if (m_guidTarget.IsItem())
         {
             if (Item* item = player->GetItemByGuid(m_guidTarget))

--- a/src/game/Loot/LootMgr.cpp
+++ b/src/game/Loot/LootMgr.cpp
@@ -2272,9 +2272,7 @@ void Loot::SendGold(Player* player)
     {
         player->ModifyMoney(m_gold);
 
-        WorldPacket data(SMSG_LOOT_MONEY_NOTIFY, 4);
-        data << uint32(m_gold);
-        player->GetSession()->SendPacket(data);
+        // Known deviation from WoW Classic Era: do not send SMSG_LOOT_MONEY_NOTIFY for solo money loot
 
         if (m_guidTarget.IsItem())
         {


### PR DESCRIPTION
## 🍰 Pullrequest
Add clarifying comment to that not sending SMSG_LOOT_MONEY_NOTIFY is intentional

### Proof
<!-- Link resources as proof -->
<img width="1919" height="1199" alt="image" src="https://github.com/user-attachments/assets/c58d5c1b-c04c-4425-ae0f-2e183f749c7f" />
On retail WoW Classic Era you see a message when looting money, even when playing solo. When I try this with my local cmangos I don't see such a message. It would be nice if the cmangos code could clarify that this is a known deviation so future people don't need to wonder if this is intentional.


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
