### PR TITLE
Remove random chance for empty corpse loot window

### DIFF
--- a/src/game/Loot/LootMgr.cpp
+++ b/src/game/Loot/LootMgr.cpp
@@ -1707,7 +1707,7 @@ Loot::Loot(Player* player, Creature* creature, LootType type) :
                 if (isLootedForAll)
                 {
                     // show sometimes an empty window
-                    if (sWorld.getConfig(CONFIG_BOOL_CORPSE_EMPTY_LOOT_SHOW) && urand(0, 2) == 1)
+                    if (sWorld.getConfig(CONFIG_BOOL_CORPSE_EMPTY_LOOT_SHOW))
                     {
                         m_isFakeLoot = true;
                         isLootedForAll = false;


### PR DESCRIPTION
## 🍰 Pullrequest
Removes the 1-in-3 random chance for the empty loot window on corpses, making it show deterministically whenever `CONFIG_BOOL_CORPSE_EMPTY_LOOT_SHOW` is enabled.

`Loot::CreateLoot`'s `LOOT_CORPSE` case only sets `m_isFakeLoot`/shows the empty loot sparkle via `urand(0, 2) == 1` (roughly 1/3 of the time), even when the config option that's supposed to control this is enabled. Retail WoW Classic Era always opens an empty loot window on an empty corpse, not roughly a third of the time. Tested by killing creatures in starting zone and 7/7 that had no loot showed sparkle and loot window. That's a 0.0457% chance of 1/3 being correct, and thus inversely a 99.9543% chance of 3/3 being correct.

### Proof
<!-- Link resources as proof -->
<img width="1919" height="1199" alt="image" src="https://github.com/user-attachments/assets/c8311d68-8150-4c63-b673-2d7e07f5171a" />
<img width="1919" height="1199" alt="image" src="https://github.com/user-attachments/assets/f7fd729c-a740-4bec-855a-d82aff0d7186" />
Tested repeatedly on retail WoW Classic Era: killing creatures with no actual loot to give still opened an empty loot window every time (7 out of 7 attempts), not close to the ~33% rate the current random gate would produce.


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Set `Corpse.EmptyLootShow = 1` in `mangosd.conf` (the default).
- Kill several creatures configured with a loot table/gold chance but that end up dropping nothing on a given kill.
- Before this change: the empty loot window/sparkle appears roughly 1 in 3 times.
- After this change: the empty loot window/sparkle appears every time, matching retail.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
