### PR TITLE
Spell: Add SpellScript to Fire Blossom spell to target random enemies

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -75,6 +75,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (17536,'spell_awaken_kerlonian'),
 (18153,'spell_kodo_kombobulator'),
 (18969,'spell_taelan_death'),
+(19636,'spell_fireblossom'),
 (19707,'spell_hate_to_half'),
 (19832,'spell_possess_razorgore'),
 (19872,'spell_calm_dragonkin'),

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/molten_core/molten_coreScripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/molten_core/molten_coreScripts.cpp
@@ -64,7 +64,7 @@ struct FireBlossom : public AuraScript
         Creature* caster = static_cast<Creature*>(data.caster);
         if (!caster)
             return;
-        Unit* target = caster->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, data.spellInfo, SELECT_FLAG_IN_LOS);
+        Unit* target = caster->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, data.spellInfo);
         if (!target)
             return;
         data.target = target;

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/molten_core/molten_coreScripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/molten_core/molten_coreScripts.cpp
@@ -56,6 +56,21 @@ bool GOUse_go_molten_core_rune(Player* /*pPlayer*/, GameObject* pGo)
     return true;
 }
 
+// 19636 - Fire Blossom
+struct FireBlossom : public AuraScript
+{
+    void OnPeriodicTrigger(Aura* /*aura*/, PeriodicTriggerData& data) const override
+    {
+        Creature* caster = static_cast<Creature*>(data.caster);
+        if (!caster)
+            return;
+        Unit* target = caster->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, data.spellInfo, SELECT_FLAG_IN_LOS);
+        if (!target)
+            return;
+        data.target = target;
+    }
+};
+
 void AddSC_molten_core()
 {
     Script* pNewScript;
@@ -64,4 +79,6 @@ void AddSC_molten_core()
     pNewScript->Name = "go_molten_core_rune";
     pNewScript->pGOUse = &GOUse_go_molten_core_rune;
     pNewScript->RegisterSelf();
+
+    RegisterSpellScript<FireBlossom>("spell_fireblossom");
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR ensures that Fire Blossom spell from the Firewalker NPC in MC targets a random enemy with each cast.

### Proof
<!-- Link resources as proof -->
- https://www.youtube.com/watch?v=I-qCpWSayAo
- https://vanilla.warcraftlogs.com/reports/P9pTM1qc8VHzYhFt?boss=-3&difficulty=0&hostility=1&source=60&type=damage-done&by=source&ability=19637&view=events

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/4116

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Start combat with a Firewalker with at least 2 players/units

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
