### PR TITLE
Fix .gm fly in Classic

### DIFF
--- a/src/game/Anticheat/module/Movement/movement.cpp
+++ b/src/game/Anticheat/module/Movement/movement.cpp
@@ -131,7 +131,9 @@ void Movement::VerifyMovementFlags(uint32 flags, uint32 &removeFlags, bool stric
     if (!_me->movespline->Finalized())
         return;
 
-    if (sAnticheatConfig.IsEnabled(CHEAT_TYPE_FLY_HACK))
+    // A player explicitly placed in GM fly mode is authorized to use the
+    // legacy Vanilla flight flags, matching vMaNGOS PLAYER_CHEAT_FLY.
+    if (sAnticheatConfig.IsEnabled(CHEAT_TYPE_FLY_HACK) && !_me->HasCheatFly())
     {
         static constexpr uint32 flyHackFlags1 = (MOVEFLAG_WALK_MODE | MOVEFLAG_SWIMMING | MOVEFLAG_HOVER | MOVEFLAG_FALLINGFAR | MOVEFLAG_FLYING | MOVEFLAG_ONTRANSPORT);
         static constexpr uint32 flyHackFlags2 = (MOVEFLAG_SWIMMING | MOVEFLAG_FLYING);

--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -5449,7 +5449,7 @@ bool ChatHandler::HandleGMFlyCommand(char* args)
     if (!target)
         target = m_session->GetPlayer();
 
-    target->SetCanFly(value);
+    target->SetCheatFly(value);
     PSendSysMessage(LANG_COMMAND_FLYMODE_STATUS, GetNameLink(target).c_str(), args);
     return true;
 }

--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -5449,11 +5449,6 @@ bool ChatHandler::HandleGMFlyCommand(char* args)
     if (!target)
         target = m_session->GetPlayer();
 
-    // [-ZERO] Need reimplement in another way
-    {
-        SendSysMessage(LANG_USE_BOL);
-        return false;
-    }
     target->SetCanFly(value);
     PSendSysMessage(LANG_COMMAND_FLYMODE_STATUS, GetNameLink(target).c_str(), args);
     return true;

--- a/src/game/Entities/Object.h
+++ b/src/game/Entities/Object.h
@@ -712,13 +712,13 @@ enum MovementFlags
     MOVEFLAG_WALK_MODE          = 0x00000100,               // Walking
 
     MOVEFLAG_LEVITATING         = 0x00000400,
-    MOVEFLAG_FLYING             = 0x00000800,               // Fixed Z in the Vanilla client
+    MOVEFLAG_FLYING             = 0x00000800,               // [-ZERO] is it really need and correct value
     MOVEFLAG_JUMPING            = 0x00002000,
     MOVEFLAG_FALLINGFAR         = 0x00004000,
     MOVEFLAG_SWIMMING           = 0x00200000,               // appears with fly flag also
     MOVEFLAG_SPLINE_ENABLED     = 0x00400000,               // [-ZERO] is it really need and correct value
-    MOVEFLAG_CAN_FLY            = 0x00800000,               // Moved in the Vanilla client
-    MOVEFLAG_FLYING_OLD         = 0x01000000,               // Flying in the Vanilla client
+    MOVEFLAG_CAN_FLY            = 0x00800000,               // [-ZERO] is it really need and correct value
+    MOVEFLAG_FLYING_OLD         = 0x01000000,               // [-ZERO] is it really need and correct value
 
     MOVEFLAG_ONTRANSPORT        = 0x02000000,               // Used for flying on some creatures
     MOVEFLAG_SPLINE_ELEVATION   = 0x04000000,               // used for flight paths

--- a/src/game/Entities/Object.h
+++ b/src/game/Entities/Object.h
@@ -712,13 +712,13 @@ enum MovementFlags
     MOVEFLAG_WALK_MODE          = 0x00000100,               // Walking
 
     MOVEFLAG_LEVITATING         = 0x00000400,
-    MOVEFLAG_FLYING             = 0x00000800,               // [-ZERO] is it really need and correct value
+    MOVEFLAG_FLYING             = 0x00000800,               // Fixed Z in the Vanilla client
     MOVEFLAG_JUMPING            = 0x00002000,
     MOVEFLAG_FALLINGFAR         = 0x00004000,
     MOVEFLAG_SWIMMING           = 0x00200000,               // appears with fly flag also
     MOVEFLAG_SPLINE_ENABLED     = 0x00400000,               // [-ZERO] is it really need and correct value
-    MOVEFLAG_CAN_FLY            = 0x00800000,               // [-ZERO] is it really need and correct value
-    MOVEFLAG_FLYING_OLD         = 0x01000000,               // [-ZERO] is it really need and correct value
+    MOVEFLAG_CAN_FLY            = 0x00800000,               // Moved in the Vanilla client
+    MOVEFLAG_FLYING_OLD         = 0x01000000,               // Flying in the Vanilla client
 
     MOVEFLAG_ONTRANSPORT        = 0x02000000,               // Used for flying on some creatures
     MOVEFLAG_SPLINE_ELEVATION   = 0x04000000,               // used for flight paths
@@ -763,6 +763,17 @@ class MovementInfo
         bool HasMovementFlag(MovementFlags f) const { return (moveFlags & f) != 0; }
         MovementFlags GetMovementFlags() const { return MovementFlags(moveFlags); }
         void SetMovementFlags(MovementFlags f) { moveFlags = f; }
+        void SetAsServerSide()
+        {
+            uint32 const oldTime = stime;
+            stime = WorldTimer::getMSTime();
+
+            // Preserve the order of server-generated movement packets.
+            if (oldTime >= stime)
+                stime = oldTime + 1;
+
+            ctime = 0;
+        }
 
         // Deduce speed type by current movement flags:
         inline UnitMoveType GetSpeedType() const { return GetSpeedType(MovementFlags(moveFlags)); }

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -468,7 +468,7 @@ void TradeData::SetAccepted(bool state, bool crosssend /*= false*/)
 
 //== Player ====================================================
 
-Player::Player(WorldSession* session): Unit(), m_taxiTracker(*this), m_mover(this), m_camera(this), m_reputationMgr(this), m_launched(false)
+Player::Player(WorldSession* session): Unit(), m_taxiTracker(*this), m_mover(this), m_camera(this), m_reputationMgr(this), m_launched(false), m_cheatFly(false)
 {
 #if defined(BUILD_DEPRECATED_PLAYERBOT) || defined(ENABLE_PLAYERBOTS)
     m_playerbotAI = nullptr;
@@ -646,6 +646,12 @@ Player::Player(WorldSession* session): Unit(), m_taxiTracker(*this), m_mover(thi
 
     m_lastDbGuid = 0;
     m_lastGameObject = false;
+}
+
+void Player::SetCheatFly(bool on)
+{
+    m_cheatFly = on;
+    SetCanFly(on);
 }
 
 Player::~Player()

--- a/src/game/Entities/Player.h
+++ b/src/game/Entities/Player.h
@@ -1713,6 +1713,9 @@ class Player : public Unit
         bool IsLaunched() const { return m_launched; }
         void SetLaunched(bool apply) { m_launched = apply; }
 
+        void SetCheatFly(bool on);
+        bool HasCheatFly() const { return m_cheatFly; }
+
         WorldLocation& GetTeleportDest() { return m_teleport_dest; }
         bool IsBeingTeleported() const { return m_semaphoreTeleport_Near || m_semaphoreTeleport_Far; }
         bool IsBeingTeleportedNear() const { return m_semaphoreTeleport_Near; }
@@ -2032,9 +2035,9 @@ class Player : public Unit
         bool isMovingOrTurning() const { return m_movementInfo.HasMovementFlag(movementOrTurningFlagsMask); }
 
         bool CanSwim() const override { return true; }
-        bool CanFly() const override { return m_movementInfo.HasMovementFlag(MOVEFLAG_FLYING); }
+        bool CanFly() const override { return m_movementInfo.HasMovementFlag(MOVEFLAG_FLYING_OLD); }
         bool CanWalk() const override { return true; }
-        bool IsFlying() const override { return false; }
+        bool IsFlying() const override { return CanFly(); }
         bool IsFreeFlying() const { return false; }
         bool IsSwimming() const { return m_movementInfo.HasMovementFlag(MOVEFLAG_SWIMMING); }
 
@@ -2552,6 +2555,7 @@ class Player : public Unit
         int32 m_cannotBeDetectedTimer;
 
         bool m_launched;
+        bool m_cheatFly;
 
         Spell* m_modsSpell;
         std::set<SpellModifierPair>* m_consumedMods;

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -12401,7 +12401,23 @@ void Unit::SetSwim(bool enable)
 
 void Unit::SetCanFly(bool enable)
 {
-    // TBC+
+    if (!IsPlayer())
+        return;
+
+    if (enable)
+    {
+        if (GenericTransport* transport = GetTransport())
+        {
+            transport->RemovePassenger(this);
+            StopMoving(true);
+        }
+
+        m_movementInfo.SetMovementFlags(MovementFlags(MOVEFLAG_LEVITATING | MOVEFLAG_SWIMMING | MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_FLYING));
+    }
+    else
+        m_movementInfo.SetMovementFlags(MOVEFLAG_NONE);
+
+    SendHeartBeat();
 }
 
 void Unit::SetFeatherFall(bool enable)

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -730,6 +730,7 @@ bool Unit::UpdateMeleeAttackingState()
 
 void Unit::SendHeartBeat()
 {
+    m_movementInfo.SetAsServerSide();
     WorldPacket data(MSG_MOVE_HEARTBEAT, 31);
     data << GetPackGUID();
     data << m_movementInfo;
@@ -12412,11 +12413,14 @@ void Unit::SetCanFly(bool enable)
             StopMoving(true);
         }
 
-        m_movementInfo.SetMovementFlags(MovementFlags(MOVEFLAG_LEVITATING | MOVEFLAG_SWIMMING | MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_FLYING));
+        // Vanilla has no enable-flight opcode. Its client-side fly mode uses
+        // the legacy moved/flying bits, named CAN_FLY/FLYING_OLD in this core.
+        m_movementInfo.SetMovementFlags(MovementFlags(MOVEFLAG_LEVITATING | MOVEFLAG_SWIMMING | MOVEFLAG_CAN_FLY | MOVEFLAG_FLYING_OLD));
     }
     else
         m_movementInfo.SetMovementFlags(MOVEFLAG_NONE);
 
+    static_cast<Player*>(this)->GetSession()->RejectMovementPacketsFor(100);
     SendHeartBeat();
 }
 

--- a/src/game/MotionGenerators/MovementHandler.cpp
+++ b/src/game/MotionGenerators/MovementHandler.cpp
@@ -377,6 +377,16 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recv_data)
     recv_data >> movementInfo;
     /*----------------*/
 
+    // The Vanilla client treats space as a normal jump even while the legacy
+    // flying flags are active. Reject it and resync the client before it can
+    // replace fly mode with a falling movement state.
+    if (opcode == MSG_MOVE_JUMP && plMover && plMover->CanFly())
+    {
+        plMover->m_movementInfo.RemoveMovementFlag(movementOrTurningFlagsMask);
+        plMover->SendHeartBeat();
+        return;
+    }
+
     if (!ProcessMovementInfo(movementInfo, mover, plMover, recv_data))
         return;
 

--- a/src/game/MotionGenerators/MovementHandler.cpp
+++ b/src/game/MotionGenerators/MovementHandler.cpp
@@ -363,6 +363,7 @@ void WorldSession::HandleMoveTeleportAckOpcode(WorldPacket& recv_data)
 void WorldSession::HandleMovementOpcodes(WorldPacket& recv_data)
 {
     Opcodes opcode = recv_data.GetOpcode();
+
     if (!sLog.HasLogFilter(LOG_FILTER_PLAYER_MOVES))
     {
         DEBUG_LOG("WORLD: Received opcode %s (%u, 0x%X)", LookupOpcodeName(opcode), opcode, opcode);
@@ -377,15 +378,10 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recv_data)
     recv_data >> movementInfo;
     /*----------------*/
 
-    // The Vanilla client treats space as a normal jump even while the legacy
-    // flying flags are active. Reject it and resync the client before it can
-    // replace fly mode with a falling movement state.
-    if (opcode == MSG_MOVE_JUMP && plMover && plMover->CanFly())
-    {
-        plMover->m_movementInfo.RemoveMovementFlag(movementOrTurningFlagsMask);
-        plMover->SendHeartBeat();
+    // Do not accept client movement generated before a server-side fly state
+    // change. This mirrors vMaNGOS and protects the newer heartbeat state.
+    if (movementInfo.stime <= m_movementPacketRejectUntil)
         return;
-    }
 
     if (!ProcessMovementInfo(movementInfo, mover, plMover, recv_data))
         return;

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -104,7 +104,7 @@ WorldSession::WorldSession(uint32 id, WorldSocket* sock, AccountTypes sec, time_
     m_clientOS(CLIENT_OS_UNKNOWN), m_clientPlatform(CLIENT_PLATFORM_UNKNOWN), m_orderCounter(0),
     _logoutTime(0), m_afkTime(0), m_playerSave(true), m_inQueue(false), m_playerLoading(false), m_kickSession(false), m_playerLogout(false), m_playerRecentlyLogout(false),
     m_sessionDbcLocale(sWorld.GetAvailableDbcLocale(locale)), m_sessionDbLocaleIndex(sObjectMgr.GetStorageLocaleIndexFor(locale)),
-    m_latency(0), m_clientTimeDelay(0), m_tutorialState(TUTORIALDATA_UNCHANGED)
+    m_latency(0), m_clientTimeDelay(0), m_movementPacketRejectUntil(0), m_tutorialState(TUTORIALDATA_UNCHANGED)
     {}
 
 /// WorldSession destructor
@@ -1235,6 +1235,13 @@ void WorldSession::SynchronizeMovement(MovementInfo& movementInfo)
     if (m_clientTimeDelay == 0)
         m_clientTimeDelay = WorldTimer::getMSTime() - movementInfo.ctime;
     movementInfo.stime = movementInfo.ctime + m_clientTimeDelay + MOVEMENT_PACKET_TIME_DELAY;
+}
+
+void WorldSession::RejectMovementPacketsFor(uint32 milliseconds)
+{
+    uint32 rejectUntil = WorldTimer::getMSTime() + milliseconds;
+    if (m_movementPacketRejectUntil < rejectUntil)
+        m_movementPacketRejectUntil = rejectUntil;
 }
 
 std::deque<uint32> WorldSession::GetOutOpcodeHistory()

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -404,6 +404,7 @@ class WorldSession
         uint32 GetLatency() const { return m_latency; }
         void SetLatency(uint32 latency) { m_latency = latency; }
         void ResetClientTimeDelay() { m_clientTimeDelay = 0; }
+        void RejectMovementPacketsFor(uint32 milliseconds);
         uint32 getDialogStatus(const Player* pPlayer, const Object* questgiver, uint32 defstatus) const;
         ClientOSType GetOS() const { return m_clientOS; }
         void SetOS(ClientOSType os) { m_clientOS = os; }
@@ -857,6 +858,7 @@ class WorldSession
         std::atomic<uint32> m_latency;
         AccountData m_accountData[NUM_ACCOUNT_DATA_TYPES];
         uint32 m_clientTimeDelay;
+        uint32 m_movementPacketRejectUntil;
         uint32 m_Tutorials[8];
         TutorialDataState m_tutorialState;
 


### PR DESCRIPTION
## 🍰 Pullrequest

Restores `.gm fly` for Classic and aligns the movement handling with vMaNGOS.

Classic uses the legacy Vanilla movement flags because the 1.12 client does not have the native flying controls used by TBC and Wrath. The change also keeps GM flight authorized through movement validation and rejects stale movement packets when the mode changes.

Normal jump handling is enabled again. On the Classic client, Space is still a regular jump rather than a flying ascent control, so jumping removes fly mode as it does in vMaNGOS. Altitude is controlled by pitching up or down while moving forward.

### Proof

- Tested in-game on Classic with fly on/off, directional movement, stopping, and jump behavior.
- Built with AHBot and Playerbot enabled.

### Issues

- The Classic client cannot use Space to ascend continuously like TBC or Wrath.

### How2Test

- Enable with `.gm fly on`.
- Check forward, backward, strafe, stopping, and changing altitude by pitching while moving.
- Press Space and confirm the normal Classic jump behavior removes fly mode.
- Enable fly again, then disable it with `.gm fly off`.

### Todo / Checklist

- [x] None