### PR TITLE
Creature: Preserve base melee attack power

### DIFF
--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -777,7 +777,7 @@ void ObjectMgr::LoadCreatureClassLvlStats()
         // if any mistake is made, it will be in these formulae that make asumptions about the new calculations
         // AP, RAP, HP, Mana and armor should stay the same pre-change and post-change when using multipliers == 1
         cCLS.BaseMana -= std::min(cCLS.BaseMana, std::max(0u, (uint32)Unit::GetManaBonusFromIntellect(cCLS.Intellect)));
-        cCLS.BaseMeleeAttackPower -= std::min(cCLS.BaseMeleeAttackPower, std::max(0.f, float(cCLS.Strength >= 10 ? (cCLS.Strength - 10) * 2 : 0)));
+        // cCLS.BaseMeleeAttackPower -= std::min(cCLS.BaseMeleeAttackPower, std::max(0.f, float(cCLS.Strength >= 10 ? (cCLS.Strength - 10) * 2 : 0)));
         cCLS.BaseRangedAttackPower -= std::min(cCLS.BaseRangedAttackPower, std::max(0.f, float(cCLS.Agility >= 10 ? (cCLS.Agility - 10) : 0)));
         cCLS.BaseArmor -= std::min(cCLS.BaseArmor, std::max(0u, cCLS.Agility * 2));
         ++storedRow;


### PR DESCRIPTION
Classic was removing base melee AP while loading creature class level stats, so the newer AP calculation ended up with 0 for most mobs. TBC and WotLK already leave this line disabled.

This keeps the DB AP available for Creature::UpdateAttackPowerAndDamage().

Tested with Young Wendigos: hits went from mostly 1-2 to 2-6 against a level 1 priest with 5 armor. Build also passes with AHBot and Playerbot enabled.